### PR TITLE
Closes #52: Adding triggers for login auditing.

### DIFF
--- a/Idno/Pages/Session/Login.php
+++ b/Idno/Pages/Session/Login.php
@@ -26,15 +26,19 @@ namespace Idno\Pages\Session {
             if ($user = \Idno\Entities\User::getByHandle($this->getInput('email'))) {
             } else if ($user = \Idno\Entities\User::getByEmail($this->getInput('email'))) {
             } else {
+                \Idno\Core\site()->triggerEvent('login:failure:nouser', ['handle_or_email' => $this->getInput('email')]); 
                 $this->setResponse(401);
                 $this->forward('/session/login');
             }
 
             if ($user instanceof \Idno\Entities\User) {
                 if ($user->checkPassword($this->getInput('password'))) {
+                    \Idno\Core\site()->triggerEvent('login:success', ['user' => $user]); // Trigger an event for auditing
                     \Idno\Core\site()->session()->logUserOn($user);
                     \Idno\Core\site()->session()->addMessage("You've signed in as {$user->getTitle()}.");
                     $this->forward();
+                } else {
+                    \Idno\Core\site()->triggerEvent('login:failure:password', ['user' => $user]); 
                 }
             }
         }


### PR DESCRIPTION
Triggers an event on login success and fail, this lets other plugins hook in to provide auditing, IDS and response (especially fail2ban).
