### PR TITLE
Get and POST call functions

### DIFF
--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -39,6 +39,36 @@ namespace Idno\Core {
 
             return ['content' => $buffer, 'response' => $http_status];
         }
+        
+        static function delete($endpoint, array $params = null) {
+
+            $req = "";
+            if ($params) {
+                foreach ($params as $key => $value)
+                    $req .= "&" . urlencode($key) . "=" . urlencode($value);
+            }
+
+
+            $curl_handle = curl_init();
+            curl_setopt($curl_handle, CURLOPT_URL, $endpoint);
+            curl_setopt($curl_handle, CURLOPT_CONNECTTIMEOUT, 5);
+            curl_setopt($curl_handle, CURLOPT_FOLLOWLOCATION, true);
+            curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($curl_handle, CURLOPT_USERAGENT, "idno webservice client");
+            curl_setopt($curl_handle, CURLOPT_POST, 1);
+            curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, 1);
+            curl_setopt($curl_handle, CURLOPT_POSTFIELDS, $req);
+            curl_setopt($curl_handle, CURLOPT_SSL_VERIFYPEER, 1);
+            curl_setopt($curl_handle, CURLOPT_SSL_VERIFYHOST, 2);
+            curl_setopt($curl_handle, CURLOPT_CUSTOMREQUEST, 'DELETE'); // Override request type
+
+            $buffer = curl_exec($curl_handle);
+            $http_status = curl_getinfo($curl_handle, CURLINFO_HTTP_CODE);
+
+            curl_close($curl_handle);
+
+            return ['content' => $buffer, 'response' => $http_status];
+        }
 
         static function get($endpoint, array $params = null) {
             $req = "";


### PR DESCRIPTION
DRY: Put functions for calling remote endpoints into their own web services file.

Note: The intention is to expand this with, for example, functions for pulling out endpoint urls out of headers and preparing data for transport.
