### PR TITLE
Refs #127: Introducing new "saved" event, so that plugins can listen to ...

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -114,11 +114,12 @@
                         \Idno\Core\site()->db()->saveObject($this);
                         
                         $event = new \Idno\Core\Event(array('object' => $this));
-                        \Idno\Core\site()->events()->dispatch('saved', $event);
                         
                         if ($this->getActivityStreamsObjectType()) {
                             \Idno\Core\site()->events()->dispatch('post/' . $this->getActivityStreamsObjectType(), $event);
                         }
+                        
+                        \Idno\Core\site()->events()->dispatch('saved', $event);
                     }
 
                     return $this->_id;


### PR DESCRIPTION
...all object creation events _after_ that object has been saved and has a UUID.
