### PR TITLE
Introducing page assets.

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -47,6 +47,9 @@
 
             // Who owns this page, anyway?
             public $owner = false;
+	    
+	    // Page assets that can be registered and set by plugins (javascript, css, etc)
+	    public $assets = [];
 
             function init()
             {
@@ -564,6 +567,28 @@
 
                 return false;
             }
+	    
+	    /**
+	     * Set or add an asset.
+	     * @param type $name Name of the asset (e.g. 'idno', 'jquery')
+	     * @param type $class Class of asset (e.g. 'javascript', 'css')
+	     * @param type $value A url or other value
+	     */
+	    public function setAsset($name, $value, $class) {
+		if (!is_array($this->assets)) $this->assets = [];
+		if (!is_array($this->assets[$class])) $this->assets[$class] = [];
+		
+		$this->assets[$class][$name] = $value;
+	    }
+	    
+	    /**
+	     * Get assets of a given class.
+	     * @param type $class
+	     * @return array
+	     */
+	    public function getAssets($class) {
+		return $this->assets[$class];
+	    }
 
         }
 

--- a/templates/default/shell.tpl.php
+++ b/templates/default/shell.tpl.php
@@ -48,6 +48,17 @@
 
     <link type="text/plain" rel="author" href="<?= \Idno\Core\site()->config()->url ?>humans.txt" />
 
+<?php
+    // Load style assets
+    if ($style = \Idno\Core\site()->currentPage->getAssets('css')) {
+	foreach ($style as $css) {
+	    ?>
+    <link href="<?= $css; ?>" rel="stylesheet">
+	    <?php
+	}
+    }
+?>
+    
     <?= $this->draw('shell/head', $vars); ?>
 
 </head>
@@ -147,6 +158,17 @@
 <script src="<?= \Idno\Core\site()->config()->url . 'external/bootstrap/' ?>assets/js/bootstrap.min.js"></script>
 <!-- Video shim -->
 <script src="<?= \Idno\Core\site()->config()->url . 'external/fitvids/jquery.fitvids.min.js' ?>"></script>
+
+<?php
+    // Load javascript assets
+    if ($scripts = \Idno\Core\site()->currentPage->getAssets('javascript')) {
+	foreach ($scripts as $script) {
+	    ?>
+<script src="<?= $script ?>"></script>
+	    <?php
+	}
+    }
+?>
 <script>
 
     //$(document).pjax('a:not([href^=\\.],[href^=file])', '#pjax-container');    // In idno, URLs with extensions are probably files.


### PR DESCRIPTION
Page assets provide a more structured way for plugins to add resources to a page (css, javascript etc). Sure, a plugin could in this instance extend shell/head or shell/footer, but imagine this situation:

Plugin A requires a specific javascript library "Awesome.js", and bundles it with it. Plugin B also requires "Awesome.js" and bundles it. If they extended footer, Awesome.js would be loaded twice. Using page assets they'd both have a setAsset call, passing a name of "Awesome.js", so that the asset is only loaded the once.

TODO: Move core assets to this architecture
