### PR TITLE
Add u-url classname to post permalink anchor

### DIFF
--- a/templates/default/content/end.tpl.php
+++ b/templates/default/content/end.tpl.php
@@ -1,7 +1,7 @@
 <?php /* @var \Idno\Common\Entity $vars['object'] */ ?>
     <div class="permalink">
         <p>
-            <a href="<?=$vars['object']->getURL()?>" rel="permalink" ><time class="dt-published" datetime="<?=date('c',$vars['object']->created)?>"><?=date('c',$vars['object']->created)?></time></a>
+            <a class="u-url url" href="<?=$vars['object']->getURL()?>" rel="permalink" ><time class="dt-published" datetime="<?=date('c',$vars['object']->created)?>"><?=date('c',$vars['object']->created)?></time></a>
             <a href="<?=$vars['object']->getURL()?>#comments" ><?php if ($replies = $vars['object']->countAnnotations('reply')) { echo '<i class="icon-comments"></i> ' . $replies; } ?></a>
             <a href="<?=$vars['object']->getURL()?>#comments" ><?php if ($likes = $vars['object']->countAnnotations('like')) { echo '<i class="icon-thumbs-up"></i> ' . $likes; } ?></a>
             <a href="<?=$vars['object']->getURL()?>#comments" ><?php if ($shares = $vars['object']->countAnnotations('share')) { echo '<i class="icon-refresh"></i> ' . $shares; } ?></a>


### PR DESCRIPTION
…along with `url` classic fallback for consistency with e-content entry-content.

This change allows me to click through to your posts when reading them in my feed reader http://waterpigs.co.uk/intertubes/feed/

It also clears up one of the indiewebify.me h-entry validator suggestions: http://indiewebify.me/validate-h-entry/?url=http%3A%2F%2Fwerd.io%2F2014%2Fcyclists-of-the-bay-area-heed-my-call
