### PR TITLE
You can't return null by reference, just let the function fail with null...

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -299,8 +299,6 @@
             function &__get($name)
             {
                 if (isset($this->attributes[$name])) return $this->attributes[$name];
-
-                return null;
             }
 
             /**


### PR DESCRIPTION
... naturally
