### PR TITLE
Per domain (multisite) configuration

### DIFF
--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -43,6 +43,12 @@
                 if ($config = @parse_ini_file($this->path . '/config.ini')) {
                     $this->config = array_merge($this->config, $config);
                 }
+                
+                // Per domain configuration
+                if ($config = @parse_ini_file($this->path . '/'. $this->host . '.ini')) {
+                    $this->config = array_merge($this->config, $config);
+                }
+                
 
                 date_default_timezone_set($this->timezone);
                 setlocale(LC_ALL, 'en_US.UTF8');


### PR DESCRIPTION
This patch provides basic multisite support for Idno, that:
1. Simplifies deployment (you can have a development configuration and a live configuration in the same repo)
2. Lets you support wild card domains running off a single installation of the codebase, thus providing basic multi-site support.
