### PR TITLE
Removing setlocale call from boot

### DIFF
--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -45,7 +45,7 @@
                 }
 
                 date_default_timezone_set($this->timezone);
-                setlocale(LC_ALL, 'en_US.UTF8');
+                //setlocale(LC_ALL, 'en_US.UTF8');
             }
 
             /**


### PR DESCRIPTION
Because cultural imperialism is bad. 
