### PR TITLE
We really only want to use a short url for sharing...

### DIFF
--- a/Idno/Pages/Entity/Share.php
+++ b/Idno/Pages/Entity/Share.php
@@ -24,7 +24,7 @@
                 $event = new \Idno\Core\Event();
                 $event->setResponse($url);
                 \Idno\Core\site()->events()->dispatch('url/shorten', $event);
-                $url = $event->response();
+                $short_url = $event->response();
 
                 if (!in_array($type, ['note','reply','rsvp','like'])) {
                     $share_type = 'note';
@@ -54,8 +54,9 @@
                 if (!empty($content_type)) {
                     if ($page = \Idno\Core\site()->getPageHandler('/' . $content_type->camelCase($content_type->getEntityClassName()) . '/edit')) {
                         if ($share_type == 'note' && !substr_count($url, 'twitter.com')) {
-                            $page->setInput('body', $title . ' ' . $url);
+                            $page->setInput('body', $title . ' ' . $short_url);
                         } else {
+                            $page->setInput('short-url', $short_url);
                             $page->setInput('url', $url);
                             if (substr_count($url, 'twitter.com')) {
                                 preg_match("|https?://(www\.)?twitter\.com/(#!/)?@?([^/]*)|", $url, $matches);


### PR DESCRIPTION
Uses shortlink if available for sharing, but replies use the canonical URL.

Shortlink is passed to plugin view as variable.
