### PR TITLE
Ios app links

### DIFF
--- a/templates/default/shell.tpl.php
+++ b/templates/default/shell.tpl.php
@@ -264,7 +264,7 @@
                     while (!(stop).test(curnode.nodeName)) {
                         curnode=curnode.parentNode;
                     }
-                    if('href' in curnode && ( curnode.href.indexOf('http') || ~curnode.href.indexOf(location.host) ) ) {
+                    if('href' in curnode && ( curnode.href.indexOf('http') || ~curnode.href.indexOf(location.host) ) && (!curnode.classList.contains('contentTypeButton'))) {
                         e.preventDefault();
                         location.href = curnode.href;
                     }


### PR DESCRIPTION
Better handle links when operating in iOS Standalone (homescreen application) mode...

Local links no longer opened in safari, remote links opened in the normal way.
