### PR TITLE
Caching getRecords

### DIFF
--- a/Idno/Caching/Cache.php
+++ b/Idno/Caching/Cache.php
@@ -10,7 +10,7 @@ namespace Idno\Caching {
          * Store or replace a value in the cache.
          * 
          * @param $key string Identifier for this value
-         * @param $value string Value to store
+         * @param $value mixed Value to store
          * @return bool
          */
         abstract public function store($key, $value);
@@ -18,7 +18,7 @@ namespace Idno\Caching {
         /**
          * Retrieve a value from the store.
          * @param $key Key to retrieve
-         * @return string|false
+         * @return mixed|false
          */
         abstract public function load($key);
         

--- a/Idno/Caching/Cache.php
+++ b/Idno/Caching/Cache.php
@@ -44,7 +44,7 @@ namespace Idno\Caching {
         /* Array access interface */
         public function offsetGet($key) { return $this->load($key); } 
         public function offsetSet($key, $value) { $this->store($key, $value); } 
-        public function offsetExists($offset) { return (bool)$this->load($key); } 
+        public function offsetExists($key) { return (bool)$this->load($key); } 
         public function offsetUnset($key) { return $this->delete($key); }
     }
     

--- a/Idno/Caching/Cache.php
+++ b/Idno/Caching/Cache.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Idno\Caching {
+    
+    abstract class Cache 
+        implements \ArrayAccess
+    {
+        
+        /**
+         * Store or replace a value in the cache.
+         * 
+         * @param $key string Identifier for this value
+         * @param $value string Value to store
+         * @return bool
+         */
+        abstract public function store($key, $value);
+        
+        /**
+         * Retrieve a value from the store.
+         * @param $key Key to retrieve
+         * @return string|false
+         */
+        abstract public function load($key);
+        
+        /**
+         * Remove a key from the cache.
+         * @param The key
+         * @return bool
+         */
+        abstract public function delete($key);
+        
+        /**
+         * Return the number of keys currently stored.
+         */
+        abstract public function size();
+        
+        
+        /* Object interface */
+        public function __get($key) { return $this->load($key); }
+	public function __set($key, $value) { return $this->store($key, $value); }
+	public function __isset($key) { return (bool)$this->load($key); }
+	public function __unset($key) { return $this->delete($key); }
+        
+        /* Array access interface */
+        public function offsetGet($key) { return $this->load($key); } 
+        public function offsetSet($key, $value) { $this->store($key, $value); } 
+        public function offsetExists($offset) { return (bool)$this->load($key); } 
+        public function offsetUnset($key) { return $this->delete($key); }
+    }
+    
+}

--- a/Idno/Caching/EphemeralCache.php
+++ b/Idno/Caching/EphemeralCache.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Idno\Caching {
+    
+    /**
+     * Caches that last for the lifetime of script execution.
+     */
+    abstract class EphemeralCache 
+        extends Cache 
+    {
+        
+    }
+    
+}

--- a/Idno/Caching/MemoryCache.php
+++ b/Idno/Caching/MemoryCache.php
@@ -19,15 +19,24 @@ namespace Idno\Caching {
 
         public function load($key) {
             
-            if (isset($this->cache[$key]))
+            if (isset($this->cache[$key])) {
+		if (\Idno\Core\site()->config()->debug)
+		    error_log("Loading $key");
                 return $this->cache[$key];
-            
+	    }
+	    
+	    if (\Idno\Core\site()->config()->debug)
+		error_log("$key not cached");
+	    
             return false;
         }
 
         public function size() { return count($this->cache); }
 
         public function store($key, $value) { 
+	    if (\Idno\Core\site()->config()->debug)
+		error_log("Caching $key");
+	    
             $this->cache[$key] = $value;
             
             return true;

--- a/Idno/Caching/MemoryCache.php
+++ b/Idno/Caching/MemoryCache.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Idno\Caching {
+
+    /**
+     * Store values in memory for the lifetime of script execution.
+     */
+    class MemoryCache
+        extends EphemeralCache
+    {
+        /// The cache
+        private $cache = [];
+        
+        public function delete($key) {
+            unset($this->cache[$key]);
+            
+            return true;
+        }
+
+        public function load($key) {
+            
+            if (isset($this->cache[$key]))
+                return $this->cache[$key];
+            
+            return false;
+        }
+
+        public function size() { return count($this->cache); }
+
+        public function store($key, $value) { 
+            $this->cache[$key] = $value;
+            
+            return true;
+        }
+
+    }
+}

--- a/Idno/Caching/PersistentCache.php
+++ b/Idno/Caching/PersistentCache.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Idno\Caching {
+    
+    /**
+     * Caches that last beyond the lifetime of a script.
+     */
+    abstract class PersistentCache 
+        extends Cache 
+    {
+        
+    }
+    
+}

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -14,6 +14,7 @@
 
             private $client = null;
             private $database = null;
+	    private $cache = null;
 
             function init()
             {
@@ -25,6 +26,7 @@
                     }
                     $this->client = new \PDO($connection_string, \Idno\Core\site()->config()->dbuser, \Idno\Core\site()->config()->dbpass);
                     $this->client->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+		    $this->cache = new \Idno\Caching\MemoryCache();
                     //$this->client->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);
                 } catch (\Exception $e) {
                     if (!empty(\Idno\Core\site()->config()->forward_on_empty)) {
@@ -399,13 +401,20 @@
                         $query .= ' where ' . $where . ' ';
                     }
                     $query .= " order by {$collection}.`created` desc limit {$offset},{$limit}";
-
+		    
                     $client = $this->client;
                     /* @var \PDO $client */
 
+		    if (isset($this->cache[md5(serialize($fields).  serialize($parameters) . serialize($limit) . serialize($offset) . serialize($collection))]))
+			return $this->cache[md5(serialize($fields).  serialize($parameters) . serialize($limit) . serialize($offset) . serialize($collection))]; // May be able to do this cleaner
+		    
                     $statement = $client->prepare($query);
                     if ($result = $statement->execute($variables)) {
-                        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+			
+			$objs = $statement->fetchAll(\PDO::FETCH_ASSOC);
+			$this->cache[md5(serialize($fields).  serialize($parameters) . serialize($limit) . serialize($offset) . serialize($collection))] = $objs;
+			
+			return $objs;
                     }
 
                 } catch (\Exception $e) {


### PR DESCRIPTION
All the patches in #371 plus an example usage caching getRecords() 

We may be able to do this cleaner by finding a better way to fingerprint PDO statements.

Adding this closes #371