### PR TITLE
Show nav in share via bookmarklet

### DIFF
--- a/Idno/Pages/Entity/Share.php
+++ b/Idno/Pages/Entity/Share.php
@@ -50,6 +50,10 @@
                 }
 
                 $content_type = \Idno\Common\ContentType::getRegisteredForIndieWebPostType($share_type);
+                
+                $hide_nav = false;
+                if ($this->getInput('via') == 'ff_social')
+                    $hide_nav = true;
 
                 if (!empty($content_type)) {
                     if ($page = \Idno\Core\site()->getPageHandler('/' . $content_type->camelCase($content_type->getEntityClassName()) . '/edit')) {
@@ -64,7 +68,7 @@
                                 }
                             }
                         }
-                        $page->setInput('hidenav', true);
+                        $page->setInput('hidenav', $hide_nav);
                         $page->setInput('sharing',true);
                         $page->setInput('share_type', $share_type);
                         $page->get();
@@ -72,7 +76,7 @@
                 } else {
                     $t    = \Idno\Core\site()->template();
                     $body = $t->__(['share_type' => $share_type, 'content_type' => $content_type, 'sharing' => true])->draw('entity/share');
-                    $t->__(['title' => 'Share', 'body' => $body, 'hidenav' => true])->drawPage();
+                    $t->__(['title' => 'Share', 'body' => $body, 'hidenav' => $hide_nav])->drawPage();
                 }
             }
 

--- a/IdnoPlugins/Firefox/templates/default/account/firefox.tpl.php
+++ b/IdnoPlugins/Firefox/templates/default/account/firefox.tpl.php
@@ -9,7 +9,7 @@
 
         "workerURL": "<?=\Idno\Core\site()->config()->url?>IdnoPlugins/Firefox/worker.js",
         //"sidebarURL": "<?=\Idno\Core\site()->config()->url?>firefox/sidebar",
-        "shareURL": "<?=\Idno\Core\site()->config()->url?>share?share_url=%{url}&share_title=%{title}",
+        "shareURL": "<?=\Idno\Core\site()->config()->url?>share?share_url=%{url}&share_title=%{title}&via=ff_social",
 
         "description": "Powered by Known",
         "author": "Known, Inc",


### PR DESCRIPTION
Closes #380

Hides nav in firefox social, shows in normal bookmarklet share.
