### PR TITLE
Apache 2.4 configuration has changed keywords

### DIFF
--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -9,6 +9,29 @@ Known *requires* the following server components:
 
 Known must be installed at the root of a domain, and does not currently support subdirectory installations.
 
+If you use Apache 2.4, you either must install and activate:
+* mod_access_compat (see http://httpd.apache.org/docs/2.4/mod/mod_access_compat.html)
+or manually edit Known's stock .htaccess file by replacing:
+```
+<Files ~ "\.ini$">
+Order allow,deny
+Deny from all
+</Files>
+<Files ~ "\.xml$">
+Order allow,deny
+Deny from all
+</Files>
+```
+with
+```
+<Files ~ "\.ini$">
+Require all denied
+</Files>
+<Files ~ "\.xml$">
+Require all denied
+</Files>
+```
+
 Additionally, Known requires the following PHP components:
 
 * curl


### PR DESCRIPTION
Just failed my Indie Box test because of that. Indie Box runs Apache 2.4
