### PR TITLE
Flip offset when uploading a vertically oriented avatar

### DIFF
--- a/Idno/Entities/File.php
+++ b/Idno/Entities/File.php
@@ -149,7 +149,7 @@
                                     $original_height = $photo_information[0];
                                     $original_width = $photo_information[0];
                                     $offset_x = 0;
-                                    $offset_y = round(($photo_information[0] - $photo_information[1]) / 2);
+                                    $offset_y = round(($photo_information[1] - $photo_information[0]) / 2);
                                 }
                             } else {
                                 $new_height = $height;


### PR DESCRIPTION
Portrait images were being shifted down instead of up when being
squared off. This change reverses the width and height when
calculating offset-y to be positive rather than negative.

Addresses the sub-issue I mentioned in #457 (probably should have
been its own issue)

Before:
![profile-images-offset](https://cloud.githubusercontent.com/assets/950127/4330035/cec02b5c-3fa5-11e4-84e3-a596eba1b6ea.png)

After:
![avatar-image-offset-fixed](https://cloud.githubusercontent.com/assets/950127/4330041/e0ca4742-3fa5-11e4-8094-969510c27013.png)
