### PR TITLE
fixes #472 - wraps values in single quotes

### DIFF
--- a/Themes/Black/theme.ini
+++ b/Themes/Black/theme.ini
@@ -1,11 +1,11 @@
 [Theme description]
-name =                  Tabula rasa
-version =               0.1
-author =                Known
-author_email =          hello@withknown.com
-author_url =            http://withknown.com
-description =           A simple, modern, blank-slate theme for Known.  Specially designed for single-author accounts.
+name =                  'Tabula rasa'
+version =               '0.1'
+author =                'Known'
+author_email =          'hello@withknown.com'
+author_url =            'http://withknown.com'
+description =           'A simple, modern, blank-slate theme for Known.  Specially designed for single-author accounts.'
 
 [Extensions]
-pages/home/blurb =      black/home/blurb
-shell/head       =      black/shell/head
+pages/home/blurb =      'black/home/blurb'
+shell/head       =      'black/shell/head'

--- a/Themes/Cherwell/theme.ini
+++ b/Themes/Cherwell/theme.ini
@@ -1,14 +1,14 @@
 [Theme description]
-name =                  Cherwell
-version =               0.1
-author =                Known
-author_email =          hello@withknown.com
-author_url =            http://withknown.com
-description =           A single-user theme with a customizable background image.
+name =                  'Cherwell'
+version =               '0.1'
+author =                'Known'
+author_email =          'hello@withknown.com'
+author_url =            'http://withknown.com'
+description =           'A single-user theme with a customizable background image.'
 
 [Extensions]
-pages/home/blurb =      cherwell/home/blurb
-shell/head       =      cherwell/shell/head
+pages/home/blurb =      'cherwell/home/blurb'
+shell/head       =      'cherwell/shell/head'
 
 [Prepend Extensions]
-admin/menu/items =      cherwell/admin/menu
+admin/menu/items =      'cherwell/admin/menu'

--- a/Themes/Fauvists/theme.ini
+++ b/Themes/Fauvists/theme.ini
@@ -1,11 +1,11 @@
 [Theme description]
-name =                  The Fauvists
-version =               0.1
-author =                Known
-author_email =          hello@withknown.com
-author_url =            http://withknown.com
-description =           A colorful theme for Known.  Specially designed for multi-user accounts.
+name =                  'The Fauvists'
+version =               '0.1'
+author =                'Known'
+author_email =          'hello@withknown.com'
+author_url =            'http://withknown.com'
+description =           'A colorful theme for Known.  Specially designed for multi-user accounts.'
 
 [Extensions]
-pages/home/blurb =     fauvists/home/blurb
-shell/head       =      fauvists/shell/head
+pages/home/blurb =      'fauvists/home/blurb'
+shell/head       =      'fauvists/shell/head'

--- a/Themes/Green/theme.ini
+++ b/Themes/Green/theme.ini
@@ -1,11 +1,11 @@
 [Theme description]
-name =                  O’Keeffe
-version =               0.1
-author =                Known
-author_email =          hello@withknown.com
-author_url =            http://withknown.com
-description =           A modern, cool theme for Known. Specially designed for single-author accounts.
+name =                  'O’Keeffe'
+version =               '0.1'
+author =                'Known'
+author_email =          'hello@withknown.com'
+author_url =            'http://withknown.com'
+description =           'A modern, cool theme for Known. Specially designed for single-author accounts.'
 
 [Extensions]
-pages/home/blurb =      green/home/blurb
-shell/head       =      green/shell/head
+pages/home/blurb =      'green/home/blurb'
+shell/head       =      'green/shell/head'

--- a/Themes/Kandinsky/theme.ini
+++ b/Themes/Kandinsky/theme.ini
@@ -1,11 +1,11 @@
 [Theme description]
-name =                  Kandinsky
-version =               0.1
-author =                Known
-author_email =          hello@withknown.com
-author_url =            http://withknown.com
-description =           A modern, warm theme for Known. Specially designed for single-author accounts.
+name =                  'Kandinsky'
+version =               '0.1'
+author =                'Known'
+author_email =          'hello@withknown.com'
+author_url =            'http://withknown.com'
+description =           'A modern, warm theme for Known. Specially designed for single-author accounts.'
 
 [Extensions]
-pages/home/blurb =      kandinsky/home/blurb
-shell/head       =      kandinsky/shell/head
+pages/home/blurb =      'kandinsky/home/blurb'
+shell/head       =      'kandinsky/shell/head'

--- a/Themes/Solo/theme.ini
+++ b/Themes/Solo/theme.ini
@@ -1,11 +1,11 @@
 [Theme description]
-name =                  Solo
-version =               0.1
-author =                Known
-author_email =          hello@withknown.com
-author_url =            http://withknown.com
-description =           A simple single-user theme for Known.
+name =                  'Solo'
+version =               '0.1'
+author =                'Known'
+author_email =          'hello@withknown.com'
+author_url =            'http://withknown.com'
+description =           'A simple single-user theme for Known.'
 
 [Extensions]
-pages/home/blurb =      solo/home/blurb
-shell/head       =      solo/shell/head
+pages/home/blurb =      'solo/home/blurb'
+shell/head       =      'solo/shell/head'


### PR DESCRIPTION
I explain the reasoning for this change in issue 472; but basically, using single quotes makes the values safer when using parse_ini_file to read these files.  Otherwise, some words such as on/off will throw an error about an invalid boolean value.
