### PR TITLE
New requirement: xmlrpc for PHP

### DIFF
--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -48,6 +48,7 @@ Additionally, Known requires the following PHP components:
 * oauth
 * reflection
 * session
+* xmlrpc
 
 Note that you may need to restart the web server after installing these components. Known's installer will tell you
 if a required module isn't available.


### PR DESCRIPTION
Current install process balks at the missing xmlrpc module during the warmup
requirements check.

Signed-off-by: Dan Scott dan@coffeecode.net
