### PR TITLE
add error_log to .gitignore for typical shared hosting setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ IdnoPlugins/Flickr/
 IdnoPlugins/Foursquare/
 IdnoPlugins/SoundCloud/
 IdnoPlugins/Twitter/
+
+error_log


### PR DESCRIPTION
This prevents an error log from being included in the git repo, as some shared hosting tend to add this file it makes sense to block it from the repo.
