### PR TITLE
fixes a couple of found XSS flaws

### DIFF
--- a/templates/default/entity/ActivityStreamPost.tpl.php
+++ b/templates/default/entity/ActivityStreamPost.tpl.php
@@ -84,7 +84,7 @@
 
                     ?>
                     <div class="e-content entry-content">
-                        <?php if (!empty($subObject)) echo $subObject->draw(); ?>
+                        <?php if (!empty($subObject)) echo htmlspecialchars($subObject->draw(), ENT_QUOTES); ?>
                     </div>
                     <div class="footer">
                         <?= $this->draw('content/end') ?>

--- a/templates/default/entity/annotations/replies.tpl.php
+++ b/templates/default/entity/annotations/replies.tpl.php
@@ -12,7 +12,7 @@
                 </p>
             </div>
             <div class="idno-annotation-content span6">
-                <?=$this->autop($this->parseURLs($annotation['content']));?>
+                <?= htmlspecialchars($this->autop($this->parseURLs($annotation['content'])), ENT_QUOTES);?>
                 <p><small><a href="<?=htmlspecialchars($annotation['owner_url'])?>"><?=$annotation['owner_name']?></a>,
                     <a href="<?=$permalink?>"><?=date('M d Y', $annotation['time']);?></a>
                     on <a href="<?=$permalink?>"><?=parse_url($permalink, PHP_URL_HOST)?></a></small></p></small></p>


### PR DESCRIPTION
I've not had chance to really get my head around the structure of the code so this is just a quick hack to get around the problem. There are a number of places where user generated content is outputted unescaped, which leads to an XSS vulnerability. 

I'd probably suggest creating a global wrapper function for all user outputs so its escaped by default, these were just two places I could easily perform the attack. 

See how I can call the console log here - http://markharding.withknown.com/2014/consolelogok#comments. 
