### PR TITLE
Temporary fix for brid.gy comment clobber (#510).

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1442,6 +1442,9 @@
                             } else {
                                 $permalink = $source;
                             }
+                            // Refs #510: Temporary kludge to work around bridgy
+                            if (strpos($source, 'https://brid-gy.appspot.com/')!==FALSE)
+                                    $permalink = $source;
                             if (!$this->addAnnotation($mention['type'], $mentions['owner']['name'], $mentions['owner']['url'], $mentions['owner']['photo'], $mention['content'], $permalink, $mention['created'])) {
                                 $return = false;
                             }


### PR DESCRIPTION
This allows posts to appear, but the cost is that they all appear to be from brid-gy.appspot.com in the by line...

Closes #510 and #541 
