### PR TITLE
Split replies and status updates

### DIFF
--- a/Idno/Common/ContentType.php
+++ b/Idno/Common/ContentType.php
@@ -14,6 +14,7 @@
             public $handler_class = 'Idno\\Common\\ContentType';
             public $title = 'Content type';
             public $indieWebContentType = array();
+            public $createable = true;
 
             // Static property containing register of all content types
             static public $registered = array();

--- a/Idno/Pages/Homepage.php
+++ b/Idno/Pages/Homepage.php
@@ -70,6 +70,13 @@
                 $feed  = \Idno\Entities\ActivityStreamPost::getFromX($types, $search, array(), \Idno\Core\site()->config()->items_per_page, $offset);
                 if (\Idno\Core\site()->session()->isLoggedIn()) {
                     $create = \Idno\Common\ContentType::getRegistered();
+                    
+                    // If we can't create an object of this type, hide from the button bar
+                    foreach ($create as $key => $obj) {
+                        if (!$obj->createable) {
+                            unset($create[$key]);
+                        }
+                    }
                 } else {
                     $create = false;
                 }

--- a/IdnoPlugins/Status/ContentType.php
+++ b/IdnoPlugins/Status/ContentType.php
@@ -7,7 +7,7 @@
             public $title = 'Status update';
             public $category_title = 'Status updates';
             public $entity_class = 'IdnoPlugins\\Status\\Status';
-            public $indieWebContentType = array('note','reply');
+            public $indieWebContentType = array('note');
 
         }
 

--- a/IdnoPlugins/Status/Main.php
+++ b/IdnoPlugins/Status/Main.php
@@ -3,10 +3,17 @@
     namespace IdnoPlugins\Status {
 
         class Main extends \Idno\Common\Plugin {
+            
             function registerPages() {
                 \Idno\Core\site()->addPageHandler('/status/edit/?', '\IdnoPlugins\Status\Pages\Edit');
                 \Idno\Core\site()->addPageHandler('/status/edit/([A-Za-z0-9]+)/?', '\IdnoPlugins\Status\Pages\Edit');
                 \Idno\Core\site()->addPageHandler('/status/delete/([A-Za-z0-9]+)/?', '\IdnoPlugins\Status\Pages\Delete');
+            }
+            
+            function registerContentTypes() {
+                parent::registerContentTypes();
+                
+                \Idno\Common\ContentType::register($this->getNamespace() . '\\RepliesContentType');
             }
         }
 

--- a/IdnoPlugins/Status/Main.php
+++ b/IdnoPlugins/Status/Main.php
@@ -7,6 +7,8 @@
             function registerPages() {
                 \Idno\Core\site()->addPageHandler('/status/edit/?', '\IdnoPlugins\Status\Pages\Edit');
                 \Idno\Core\site()->addPageHandler('/status/edit/([A-Za-z0-9]+)/?', '\IdnoPlugins\Status\Pages\Edit');
+                \Idno\Core\site()->addPageHandler('/reply/edit/?', '\IdnoPlugins\Status\Pages\Edit');
+                \Idno\Core\site()->addPageHandler('/reply/edit/([A-Za-z0-9]+)/?', '\IdnoPlugins\Status\Pages\Edit');
                 \Idno\Core\site()->addPageHandler('/status/delete/([A-Za-z0-9]+)/?', '\IdnoPlugins\Status\Pages\Delete');
             }
             

--- a/IdnoPlugins/Status/Pages/Edit.php
+++ b/IdnoPlugins/Status/Pages/Edit.php
@@ -12,7 +12,7 @@
                 if (!empty($this->arguments)) {
                     $object = \IdnoPlugins\Status\Status::getByID($this->arguments[0]);
                 } else {
-                    $object = new \IdnoPlugins\Status\Status();
+                    $object = \IdnoPlugins\Status\Status::factory();
                 }
 
                 $t = \Idno\Core\site()->template();
@@ -44,7 +44,7 @@
                     $object = \IdnoPlugins\Status\Status::getByID($this->arguments[0]);
                 }
                 if (empty($object)) {
-                    $object = new \IdnoPlugins\Status\Status();
+                    $object = \IdnoPlugins\Status\Status::factory();
                 }
 
                 if ($object->saveDataFromInput($this)) {

--- a/IdnoPlugins/Status/RepliesContentType.php
+++ b/IdnoPlugins/Status/RepliesContentType.php
@@ -5,8 +5,8 @@
         class RepliesContentType extends \Idno\Common\ContentType {
 
             public $title = 'Replies';
-            public $category_title = '@replies';
-            public $entity_class = 'IdnoPlugins\\Status\\Status';
+            public $category_title = 'Replies';
+            public $entity_class = 'IdnoPlugins\\Status\\Reply';
             public $indieWebContentType = array('reply');
 
         }

--- a/IdnoPlugins/Status/RepliesContentType.php
+++ b/IdnoPlugins/Status/RepliesContentType.php
@@ -4,10 +4,10 @@
 
         class RepliesContentType extends \Idno\Common\ContentType {
 
-            public $title = '@replies';
-            public $category_title = 'Reply status updates';
+            public $title = 'Replies';
+            public $category_title = '@replies';
             public $entity_class = 'IdnoPlugins\\Status\\Status';
-            public $indieWebContentType = array('note','reply');
+            public $indieWebContentType = array('reply');
 
         }
 

--- a/IdnoPlugins/Status/RepliesContentType.php
+++ b/IdnoPlugins/Status/RepliesContentType.php
@@ -1,0 +1,14 @@
+<?php
+
+    namespace IdnoPlugins\Status {
+
+        class RepliesContentType extends \Idno\Common\ContentType {
+
+            public $title = '@replies';
+            public $category_title = 'Reply status updates';
+            public $entity_class = 'IdnoPlugins\\Status\\Status';
+            public $indieWebContentType = array('note','reply');
+
+        }
+
+    }

--- a/IdnoPlugins/Status/RepliesContentType.php
+++ b/IdnoPlugins/Status/RepliesContentType.php
@@ -8,6 +8,7 @@
             public $category_title = 'Replies';
             public $entity_class = 'IdnoPlugins\\Status\\Reply';
             public $indieWebContentType = array('reply');
+            public $createable = false; // Don't show on new content bar
 
         }
 

--- a/IdnoPlugins/Status/Reply.php
+++ b/IdnoPlugins/Status/Reply.php
@@ -1,0 +1,9 @@
+<?php
+
+    namespace IdnoPlugins\Status {
+
+        class Reply extends \IdnoPlugins\Status\Status {
+
+        }
+
+    }

--- a/IdnoPlugins/Status/Status.php
+++ b/IdnoPlugins/Status/Status.php
@@ -3,6 +3,20 @@
     namespace IdnoPlugins\Status {
 
         class Status extends \Idno\Common\Entity {
+            
+            /** 
+             * Create an appropriate status class.
+             * Returns an appropriate new class, either a Status or a Reply, depending on whether it is in reply to something.
+             * @return Status|Reply
+             */
+            public static function factory() {
+                $inreplyto = \Idno\Core\site()->currentPage()->getInput('inreplyto');
+                
+                if (!empty($inreplyto)) 
+                    return new Reply();
+                
+                return new Status();
+            }
 
             function getTitle() {
                 return $this->getShortDescription();

--- a/IdnoPlugins/Status/Status.php
+++ b/IdnoPlugins/Status/Status.php
@@ -11,8 +11,12 @@
              */
             public static function factory() {
                 $inreplyto = \Idno\Core\site()->currentPage()->getInput('inreplyto');
+                $body = \Idno\Core\site()->currentPage()->getInput('body');
                 
                 if (!empty($inreplyto)) 
+                    return new Reply();
+                
+                if ($body[0] == '@')
                     return new Reply();
                 
                 return new Status();

--- a/IdnoPlugins/Status/templates/default/entity/Reply.tpl.php
+++ b/IdnoPlugins/Status/templates/default/entity/Reply.tpl.php
@@ -1,0 +1,1 @@
+<?= $this->draw('entity/Status'); ?>

--- a/IdnoPlugins/Status/templates/default/entity/Reply/icon.tpl.php
+++ b/IdnoPlugins/Status/templates/default/entity/Reply/icon.tpl.php
@@ -1,0 +1,1 @@
+<i class="icon-reply"></i>


### PR DESCRIPTION
Split status messages and replies, allows for filtering on both.

* Detects both inreplyto and @reply as a reply
* Introduces creatable ContentType field (default true), which determines whether a button will appear on the create bar

(closes #55)
