### PR TITLE
fixed vimeo url regexp

### DIFF
--- a/templates/default/entity/content/embed.tpl.php
+++ b/templates/default/entity/content/embed.tpl.php
@@ -18,7 +18,7 @@
         foreach ($matches[2] as $m)
             $embedded .= '<div><iframe class="youtube-player auto-link figure" width="600" height="420" style="border:0"  src="//www.youtube.com/embed/' . $m . '"></iframe></div>';
     }
-    if (preg_match_all('/vimeo\.com\/([a-z0-9\-\_]+)/i', $body, $matches)) {
+    if (preg_match_all('/vimeo\.com\/([0-9]+)/i', $body, $matches)) {
         foreach ($matches[1] as $m)
             $embedded .= '<iframe src="//player.vimeo.com/video/' . $m . '" width="600" height="450" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>';
     }


### PR DESCRIPTION
vimeo video ids are digits only

Without this fix the template will try to embed vimeo user pages like vimeo.com/sasich/videos which results in a vimeo embed with an error message (since "sasich" would not be a valid video id)