### PR TITLE
Allow fontello config to be added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ IdnoPlugins/StaticPages/
 error_log
 
 configbackup.ini
+
+# Allow these previously excluded files
+!/external/fontello/config.json


### PR DESCRIPTION
Refs #744 

config.json no longer excluded, but you may need to add it to the repo in a commit 