### PR TITLE
Options for SMTP connections

### DIFF
--- a/Idno/Core/Email.php
+++ b/Idno/Core/Email.php
@@ -147,8 +147,11 @@
                     if (!empty(site()->config()->smtp_port)) {
                         $transport->setPort(site()->config()->smtp_port);
                     }
-                    if (!empty(site()->config()->smtp_tls)) {
-                        $transport->setEncryption('tls');
+                    if (!empty(site()->config()->smtp_secure)) {
+                        switch (site()->config()->smtp_secure) {   
+                            case 'tls': $transport->setEncryption('tls'); break;
+                            case 'ssl': $transport->setEncryption('ssl'); break;
+                        }
                     }
                     $mailer = \Swift_Mailer::newInstance($transport);
 

--- a/Idno/Pages/Admin/Email.php
+++ b/Idno/Pages/Admin/Email.php
@@ -28,7 +28,7 @@
                 \Idno\Core\site()->config->config['smtp_username'] = $this->getInput('smtp_username');
                 \Idno\Core\site()->config->config['smtp_password'] = $this->getInput('smtp_password');
                 \Idno\Core\site()->config->config['smtp_port']     = (int)$this->getInput('smtp_port');
-                \Idno\Core\site()->config->config['smtp_tls']      = (bool)$this->getInput('smtp_tls');
+                \Idno\Core\site()->config->config['smtp_tls']      = $this->getInput('smtp_tls');
 
                 if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
                     \Idno\Core\site()->config->config['from_email'] = $this->getInput('from_email');

--- a/Idno/Pages/Admin/Email.php
+++ b/Idno/Pages/Admin/Email.php
@@ -28,7 +28,7 @@
                 \Idno\Core\site()->config->config['smtp_username'] = $this->getInput('smtp_username');
                 \Idno\Core\site()->config->config['smtp_password'] = $this->getInput('smtp_password');
                 \Idno\Core\site()->config->config['smtp_port']     = (int)$this->getInput('smtp_port');
-                \Idno\Core\site()->config->config['smtp_tls']      = $this->getInput('smtp_tls');
+                \Idno\Core\site()->config->config['smtp_secure']      = $this->getInput('smtp_secure');
 
                 if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
                     \Idno\Core\site()->config->config['from_email'] = $this->getInput('from_email');

--- a/templates/default/admin/email.tpl.php
+++ b/templates/default/admin/email.tpl.php
@@ -112,12 +112,22 @@
 
             <div class="row">
                 <div class="span2">
-                    <p class="control-label" for="name"><strong>Use TLS?</strong></p>
+                    <p class="control-label" for="name"><strong>Use Secure connection?</strong></p>
                 </div>
                 <div class="config-toggle span4">
-                    <input type="checkbox" data-toggle="toggle" data-onstyle="info" data-on="Yes" data-off="No"
-                           name="smtp_tls"
-                           value="true" <?php if (\Idno\Core\site()->config()->smtp_tls == true) echo 'checked'; ?>>
+                    <select name="smtp_tls">
+                        <?php
+                            foreach ([
+                                'No' => false,
+                                'Yes (tls)' => 'tls',
+                                'Yes (ssl/starttls)' => 'ssl'
+                            ] as $field => $value) {
+                                ?>
+                        <option value="<?= $value; ?>" <?php if (\Idno\Core\site()->config()->smtp_tls === $value) { echo "selected"; } ?>><?= $field; ?></option>
+                        <?php
+                            }
+                        ?>
+                    </select>
                 </div>
                 <div class="span4">
                     <p class="config-desc">Select yes if you use secure logins to your mail server.</p>

--- a/templates/default/admin/email.tpl.php
+++ b/templates/default/admin/email.tpl.php
@@ -120,7 +120,7 @@
                             foreach ([
                                 'No' => false,
                                 'Yes (tls)' => 'tls',
-                                'Yes (ssl/starttls)' => 'ssl'
+                                'Yes (ssl)' => 'ssl'
                             ] as $field => $value) {
                                 ?>
                         <option value="<?= $value; ?>" <?php if (\Idno\Core\site()->config()->smtp_tls === $value) { echo "selected"; } ?>><?= $field; ?></option>

--- a/templates/default/admin/email.tpl.php
+++ b/templates/default/admin/email.tpl.php
@@ -115,7 +115,7 @@
                     <p class="control-label" for="name"><strong>Use Secure connection?</strong></p>
                 </div>
                 <div class="config-toggle span4">
-                    <select name="smtp_tls">
+                    <select name="smtp_secure">
                         <?php
                             foreach ([
                                 'No' => false,
@@ -123,7 +123,7 @@
                                 'Yes (ssl)' => 'ssl'
                             ] as $field => $value) {
                                 ?>
-                        <option value="<?= $value; ?>" <?php if (\Idno\Core\site()->config()->smtp_tls === $value) { echo "selected"; } ?>><?= $field; ?></option>
+                        <option value="<?= $value; ?>" <?php if (\Idno\Core\site()->config()->smtp_secure === $value) { echo "selected"; } ?>><?= $field; ?></option>
                         <?php
                             }
                         ?>


### PR DESCRIPTION
This patch *should* go some way to fixing #775.

There are three methods for secure connections for sending email - SSL, TLS and STARTTLS. Unfortunately swift seems to conflate the last two.

However, this patch now provides a way of connecting over SSL, which might address the problem. If @neilr8133 tries the patch, it'd be good to get feedback.