### PR TITLE
Email settings test

### DIFF
--- a/Idno/Core/Admin.php
+++ b/Idno/Core/Admin.php
@@ -20,6 +20,7 @@
                 site()->addPageHandler('/admin/dependencies/?', '\Idno\Pages\Admin\Dependencies');
                 site()->addPageHandler('/admin/homepage/?', '\Idno\Pages\Admin\Homepage');
                 site()->addPageHandler('/admin/email/?', '\Idno\Pages\Admin\Email');
+                site()->addPageHandler('/admin/emailtest/?', '\Idno\Pages\Admin\EmailTest');
                 site()->addPageHandler('/admin/about/?', '\Idno\Pages\Admin\About');
                 site()->addPageHandler('/admin/users/?', '\Idno\Pages\Admin\Users');
                 site()->addPageHandler('/admin/export/?', '\Idno\Pages\Admin\Export');

--- a/Idno/Pages/Admin/EmailTest.php
+++ b/Idno/Pages/Admin/EmailTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Administration page: email settings
+ */
+
+namespace Idno\Pages\Admin {
+
+    class EmailTest extends \Idno\Common\Page {
+
+        function postContent() {
+            $this->adminGatekeeper(); // Admins only
+
+            $email = $this->getInput('to_email');
+
+            $message = new \Idno\Core\Email();
+            $message->addTo($email);
+            $message->setSubject("Test email from " . \Idno\Core\site()->config()->title . '!');
+            $message->setHTMLBodyFromTemplate('admin/emailtest');
+
+            if ($message->send())
+                \Idno\Core\site ()->session ()->addMessage ("Test email sent to $email");
+            else
+                \Idno\Core\site ()->session ()->addErrorMessage ("There was a problem sending a test message to $email, check your settings and try again!");
+            
+            $this->forward(\Idno\Core\site()->config()->getURL() . 'admin/email');
+        }
+
+    }
+
+}

--- a/Idno/Pages/Admin/EmailTest.php
+++ b/Idno/Pages/Admin/EmailTest.php
@@ -13,15 +13,20 @@ namespace Idno\Pages\Admin {
 
             $email = $this->getInput('to_email');
 
-            $message = new \Idno\Core\Email();
-            $message->addTo($email);
-            $message->setSubject("Test email from " . \Idno\Core\site()->config()->title . '!');
-            $message->setHTMLBodyFromTemplate('admin/emailtest');
+            try {
+                $message = new \Idno\Core\Email();
+                $message->addTo($email);
+                $message->setSubject("Test email from " . \Idno\Core\site()->config()->title . '!');
+                $message->setHTMLBodyFromTemplate('admin/emailtest');
 
-            if ($message->send())
-                \Idno\Core\site ()->session ()->addMessage ("Test email sent to $email");
-            else
-                \Idno\Core\site ()->session ()->addErrorMessage ("There was a problem sending a test message to $email, check your settings and try again!");
+            
+                if ($message->send())
+                    \Idno\Core\site ()->session ()->addMessage ("Test email sent to $email");
+                else
+                    \Idno\Core\site ()->session ()->addErrorMessage ("There was a problem sending a test message to $email, check your settings and try again!");
+            } catch (\Exception $e) {
+                \Idno\Core\site ()->session ()->addErrorMessage ($e->getMessage());
+            }
             
             $this->forward(\Idno\Core\site()->config()->getURL() . 'admin/email');
         }

--- a/templates/default/admin/email.tpl.php
+++ b/templates/default/admin/email.tpl.php
@@ -134,4 +134,30 @@
             <?= \Idno\Core\site()->actions()->signForm('/admin/email') ?>
         </form>
     </div>
+    <?php if (\Idno\Core\site()->config()->from_email) { ?>
+    <div class="span10 offset1 well">
+        <form action="<?= \Idno\Core\site()->config()->getDisplayURL() ?>admin/emailtest" class="form-horizontal" method="post">
+        
+            <div class="row">
+                <div class="span2">
+                    <p class="control-label" for="name"><strong>To address</strong></p>
+                </div>
+                <div class="span4">
+                    <input type="text" id="from_email" placeholder="To address" class="span4" name="to_email"
+                           value="<?= htmlspecialchars(\Idno\Core\site()->config()->from_email) ?>">
+                </div>
+                <div class="span4">
+                    <p class="config-desc">Email address to send a message to.</p>
+                </div>
+            </div>
+            
+            <div class="control-group">
+                <div class="controls-save">
+                    <button type="submit" class="btn btn-primary">Test settings...</button>
+                </div>
+            </div>
+            <?= \Idno\Core\site()->actions()->signForm('/admin/emailtest') ?>
+        </form>      
+    </div>
+    <?php } ?>
 </div>

--- a/templates/default/admin/email.tpl.php
+++ b/templates/default/admin/email.tpl.php
@@ -143,7 +143,7 @@
                     <p class="control-label" for="name"><strong>To address</strong></p>
                 </div>
                 <div class="span4">
-                    <input type="text" id="from_email" placeholder="To address" class="span4" name="to_email"
+                    <input type="text" id="to_email" placeholder="To address" class="span4" name="to_email"
                            value="<?= htmlspecialchars(\Idno\Core\site()->config()->from_email) ?>">
                 </div>
                 <div class="span4">

--- a/templates/email/admin/emailtest.tpl.php
+++ b/templates/email/admin/emailtest.tpl.php
@@ -1,9 +1,9 @@
 <div style="font-weight: bold; font-size: 30px; line-height: 32px; color: #333" align="center">
-    Test message!
+    Test Email
 </div><br>
 <hr/>
 <br>
-If you can read this, it means that your email settings are working correctly!
+If you can read this, it means that your email settings are configured correctly!
 <br><br>
 <div align="center">
     <a href="<?=\Idno\Core\site()->config()->getDisplayURL()?>" style="background-color:#73B2E3;border:1px solid #73B2E3;border-radius:4px;color:#ffffff;display:inline-block;font-family:sans-serif;font-size:17px;font-weight:normal;line-height:40px;text-align:center;text-decoration:none;width:200px;-webkit-text-size-adjust:none;mso-hide:all;">Visit your site</a>

--- a/templates/email/admin/emailtest.tpl.php
+++ b/templates/email/admin/emailtest.tpl.php
@@ -1,0 +1,13 @@
+<div style="font-weight: bold; font-size: 30px; line-height: 32px; color: #333" align="center">
+    Test message!
+</div><br>
+<hr/>
+<br>
+If you can read this, it means that your email settings are working correctly!
+<br><br>
+<div align="center">
+    <a href="<?=\Idno\Core\site()->config()->getDisplayURL()?>" style="background-color:#73B2E3;border:1px solid #73B2E3;border-radius:4px;color:#ffffff;display:inline-block;font-family:sans-serif;font-size:17px;font-weight:normal;line-height:40px;text-align:center;text-decoration:none;width:200px;-webkit-text-size-adjust:none;mso-hide:all;">Visit your site</a>
+</div>
+<br>
+<br>
+<br>


### PR DESCRIPTION
This patch adds an extra form to the email settings in admin, which let the admin validate their email settings via a one click button.

Note: This isn't a unit test (doesn't really make sense to do this as a unit test atm)