### PR TITLE
force time limit to be min 120

### DIFF
--- a/Idno/start.php
+++ b/Idno/start.php
@@ -30,8 +30,8 @@
         }
     });
 
-// Set time limit if we're using the default
-    if (ini_get('max_execution_time') == 30) {
+// Set time limit if we're using less
+    if (ini_get('max_execution_time') < 120 ) {
         set_time_limit(120);
     }
 


### PR DESCRIPTION
lets say a user has set a time limit of 40 which is greater than default time limit 30 but still it will cause a lot of problem . So we should force the execution limit to be at least 120 . Any problem on this ?