### PR TITLE
Change to have pageTitle persist if entered

### DIFF
--- a/IdnoPlugins/Like/Like.php
+++ b/IdnoPlugins/Like/Like.php
@@ -91,6 +91,8 @@
                             } else {
                                 $this->pageTitle = '';
                             }
+                        } else {
+                        	$this->pageTitle = $title;
                         }
                         if (empty($title)) {
                             \Idno\Core\site()->session()->addErrorMessage('You need to specify a title.');


### PR DESCRIPTION
The pageTitle was not being saved when entering or updating a Like. The code was checking if $title was empty, but not doing anything if it wasn't. I added an else statement to save it if it isn't empty.