### PR TITLE
pageTitle incorrectly named title

### DIFF
--- a/IdnoPlugins/Like/templates/default/entity/Like/edit.tpl.php
+++ b/IdnoPlugins/Like/templates/default/entity/Like/edit.tpl.php
@@ -30,7 +30,7 @@
                         Page title<br/>
                         <input required type="text" name="title" id="title" placeholder="Page name"
                                value="<?php
-                                   echo htmlspecialchars($vars['object']->title);
+                                   echo htmlspecialchars($vars['object']->pageTitle);
                                ?>" class="span8"/>
                     </label> -->
                     <label>


### PR DESCRIPTION
The pageTitle was not populating the input field when editing a Like. Code was pulling 'title' instead of pageTitle