### PR TITLE
Tidy api result

### DIFF
--- a/templates/default/content/end.tpl.php
+++ b/templates/default/content/end.tpl.php
@@ -115,6 +115,8 @@
                             echo $this->__(array('annotations' => $mentions))->draw('entity/annotations/mentions');
                         }
 
+                        unset($this->vars['annotations']);
+                        unset($this->vars['annotation_permalink']);
                     ?>
 
                 </div>

--- a/templates/default/content/syndication.tpl.php
+++ b/templates/default/content/syndication.tpl.php
@@ -2,14 +2,23 @@
 
     $buttons = '';
     if (!empty($vars['services'])) {
+        
+        // Preserve service details for API
+        $service_details = [];
+        
         foreach($vars['services'] as $service) {
 
             if (\Idno\Core\site()->syndication()->has($service)) {
+                
+                $service_details[$service] = [];
 
                 $button = $this->draw('content/syndication/' . $service);
                 if (empty($button)) {
                     if ($accounts = \Idno\Core\site()->syndication()->getServiceAccounts($service)) {
                         foreach($accounts as $account) {
+                            
+                            $service_details[$service][] = ['username' => $account['username'], 'name' => $account['name']];
+                            
                             $button .= $this->__(array('service' => $service, 'username' => $account['username'], 'name' => $account['name']))->draw('content/syndication/account');
                         }
                     } else {
@@ -25,6 +34,10 @@
         // Since template vars aren't scoped, reset vars to avoid them appearing in API views
         unset($this->vars['service']);
         unset($this->vars['username']);
+        unset($this->vars['name']);
+        
+        // Output service details for API
+        $this->vars['services'] = $service_details;
     }
     $buttons .= $this->draw('content/syndication/buttons');
     if (!empty($buttons)) {

--- a/templates/default/content/syndication.tpl.php
+++ b/templates/default/content/syndication.tpl.php
@@ -21,6 +21,10 @@
             }
 
         }
+        
+        // Since template vars aren't scoped, reset vars to avoid them appearing in API views
+        unset($this->vars['service']);
+        unset($this->vars['username']);
     }
     $buttons .= $this->draw('content/syndication/buttons');
     if (!empty($buttons)) {

--- a/templates/default/entity/annotations/comment/main.tpl.php
+++ b/templates/default/entity/annotations/comment/main.tpl.php
@@ -25,6 +25,8 @@
     </div>
 <?php
 
+    // Prevent scope pollution
+    unset($this->vars['action']);
     }
 
 ?>

--- a/templates/default/forms/link.tpl.php
+++ b/templates/default/forms/link.tpl.php
@@ -27,4 +27,12 @@
     $form = ob_get_clean();
     \Idno\Core\site()->template()->extendTemplateWithContent('shell/footer', $form);
 
+    // Prevent scope pollution
+    unset($this->vars['confirm-text']);
+    unset($this->vars['class']);
+    unset($this->vars['confirm']);
+    unset($this->vars['url']);
+    unset($this->vars['method']);
+    unset($this->vars['data']);
+    unset($this->vars['label']);
 ?>


### PR DESCRIPTION
Some work to prevent the worst cases of scope pollution in api views (#808) and closes #815 by returning more useful service account details in api result.

I think we may need to rethink how views are rendered, especially how data for the api is collected. Rendering $vars as json presents two problems 1) scope violation due to the long standing bug in bonita, 2) it's not possible to override views for an object because you can't just replace an object template and have it rendered.