### PR TITLE
Secure cookies

### DIFF
--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -22,7 +22,7 @@
                 ini_set('session.gc_maxlifetime', 60 * 60 * 24 * 7); // Garbage collection to match
                 ini_set('session.cookie_httponly', true); // Restrict cookies to HTTP only (help reduce XSS attack profile)
                 if (site()->isSecure()) {
-                    ini_set('session.cookie_secure', true); 
+                    ini_set('session.cookie_secure', true); // Set secure cookies when site is secure
                 }
 
                 site()->db()->handleSession();

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -21,6 +21,7 @@
                 ini_set('session.cookie_lifetime', 60 * 60 * 24 * 7); // Persistent cookies
                 ini_set('session.gc_maxlifetime', 60 * 60 * 24 * 7); // Garbage collection to match
                 ini_set('session.cookie_httponly', true); // Restrict cookies to HTTP only (help reduce XSS attack profile)
+                ini_set('session.use_strict_mode', true); // Help mitigate session fixation
                 if (site()->isSecure()) {
                     ini_set('session.cookie_secure', true); // Set secure cookies when site is secure
                 }

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -22,6 +22,7 @@
                 ini_set('session.gc_maxlifetime', 60 * 60 * 24 * 7); // Garbage collection to match
                 ini_set('session.cookie_httponly', true); // Restrict cookies to HTTP only (help reduce XSS attack profile)
                 ini_set('session.use_strict_mode', true); // Help mitigate session fixation
+                ini_set('session.hash_function', 'sha256'); // Using a more secure hashing algorithm for session IDs
                 if (site()->isSecure()) {
                     ini_set('session.cookie_secure', true); // Set secure cookies when site is secure
                 }

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -32,7 +32,7 @@
                 session_name(site()->config->sessionname);
                 session_start();
                 session_cache_limiter('public');
-                session_regenerate_id();
+                session_regenerate_id(true);
 
                 // Session login / logout
                 site()->addPageHandler('/session/login', '\Idno\Pages\Session\Login', true);

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -21,6 +21,9 @@
                 ini_set('session.cookie_lifetime', 60 * 60 * 24 * 7); // Persistent cookies
                 ini_set('session.gc_maxlifetime', 60 * 60 * 24 * 7); // Garbage collection to match
                 ini_set('session.cookie_httponly', true); // Restrict cookies to HTTP only (help reduce XSS attack profile)
+                if (site()->isSecure()) {
+                    ini_set('session.cookie_secure', true); 
+                }
 
                 site()->db()->handleSession();
 


### PR DESCRIPTION
Applying some of the recommendations from https://php.net/manual/en/session.security.php

Mainly, setting cookies_secure during secure sessions, but also, enabling strict mode sessions and switching the session ID algorithm from MD5 to sha256