### PR TITLE
Change empty object check

### DIFF
--- a/IdnoPlugins/Text/Pages/Edit.php
+++ b/IdnoPlugins/Text/Pages/Edit.php
@@ -22,7 +22,7 @@
                     'object' => $object
                 ))->draw('entity/Entry/edit');
 
-                if (empty($object)) {
+                if (empty($vars['object']->_id)) {
                     $title = 'Write an entry';
                 } else {
                     $title = 'Edit entry';


### PR DESCRIPTION
entry/edit page title was not reflecting whether it is a new post or not. Changed the empty($object) check to check for empty id.