### PR TITLE
always use $this->getallheaders() workaround for nginx

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -86,7 +86,7 @@
 
                 \Idno\Core\site()->triggerEvent('page/head', array('page_class' => get_called_class(), 'arguments' => $arguments));
 
-                // Triggering GET content to call all the appropriate headers (web server should truncate the head request from body). 
+                // Triggering GET content to call all the appropriate headers (web server should truncate the head request from body).
                 // This is the only way we can generate accurate expires and content length etc, but could be done more efficiently
                 $this->getContent();
 
@@ -147,7 +147,7 @@
                 if (\Idno\Core\site()->session()->isAPIRequest()) {
 
                     // If postContent hasn't forwarded itself, and returns null, then balance of probabilities is something went wrong.
-                    // Either way, it's not safe to forward to the site root since this spits back json encoded front page and a 200 response. 
+                    // Either way, it's not safe to forward to the site root since this spits back json encoded front page and a 200 response.
                     // API currently doesn't explicitly handle this situation (bad), but we don't want to forward (worse). Some plugins will still
                     // forward to / in some situations, these will need rewriting.
                     if ($return === null)
@@ -571,7 +571,7 @@
                     } else {
                         $this->deniedContent();
                     }
-                    
+
                 }
             }
 
@@ -670,7 +670,7 @@
                         return true;
                 } else if (isset($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == '443'))
                     return true;
-                
+
                 if(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'){
                     return true;
                 }
@@ -781,7 +781,17 @@
                 }
             }
 
-            function getallheaders() {
+            /**
+             * Shim for running on nginx, which doesn't provide the
+             * getallheaders function
+             * @return array
+             */
+            function getallheaders()
+            {
+                if (function_exists('getallheaders')) {
+                    return getallheaders();
+                }
+
                 $headers = '';
                 foreach ($_SERVER as $name => $value) {
                     if (substr($name, 0, 5) == 'HTTP_') {
@@ -953,4 +963,3 @@
         }
 
     }
-

--- a/Idno/Pages/Entity/View.php
+++ b/Idno/Pages/Entity/View.php
@@ -47,15 +47,15 @@
                 //header("Cache-Control: private");
                 //header('Expires: ' . date(\DateTime::RFC1123, time() + (86400 * 30))); // Cache for 30 days!
                 $this->setLastModifiedHeader($object->updated); // Say when this was last modified
-                
-                $headers = getallheaders(); 
+
+                $headers = $this->getallheaders();
                 if (isset($headers['If-Modified-Since'])) {
-                    if (strtotime($headers['If-Modified-Since']) <= $object->updated) { 
+                    if (strtotime($headers['If-Modified-Since']) <= $object->updated) {
                         header('HTTP/1.1 304 Not Modified');
                         exit;
                     }
                 }
-                
+
                 $t = \Idno\Core\site()->template();
                 $t->__(array(
 

--- a/Idno/Pages/File/View.php
+++ b/Idno/Pages/File/View.php
@@ -22,24 +22,11 @@
 
                 if (empty($object)) $this->forward(); // TODO: 404
 
-                if (!function_exists('getallheaders')) {
-                    function getallheaders()
-                    {
-                        $headers = '';
-                        foreach ($_SERVER as $name => $value) {
-                            if (substr($name, 0, 5) == 'HTTP_') {
-                                $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
-                            }
-                        }
-
-                        return $headers;
-                    }
-                }
 
                 session_write_close();  // Close the session early
 
                 //header("Pragma: public");
-                
+
                 // Determine uploaded timestamp
                 if ($object instanceof \MongoGridFSFile) {
                     $upload_ts = $object->file['uploadDate']->sec;
@@ -50,7 +37,7 @@
                 } else {
                     $upload_ts = time();
                 }
-                
+
                 header("Pragma: public");
                 header("Cache-Control: public");
                 header('Expires: ' . date(\DateTime::RFC1123, time() + (86400 * 30))); // Cache files for 30 days!
@@ -63,7 +50,7 @@
                 //header('Accept-Ranges: bytes');
                 //header('Content-Length: ' . filesize($object->getSize()));
 
-                $headers = getallheaders(); 
+                $headers = $this->getallheaders();
                 if (isset($headers['If-Modified-Since'])) {
                     if (strtotime($headers['If-Modified-Since']) <= $upload_ts) { //> time() - (86400 * 30)) {
                         header('HTTP/1.1 304 Not Modified');


### PR DESCRIPTION
- Removed duplicate getallheaders shim in \Pages\File\View
- $this->getallheaders() will defer to getallheaders() if it's defined.

Background: had an error referencing getallheaders in Idno/Pages/Entity/View.php on nginx. I changed it to $this-> to fix the error, and thought it would be nice to deduplicate the two shims.