### PR TITLE
Don't allow browser access to the schema directory

### DIFF
--- a/schemas/.htaccess
+++ b/schemas/.htaccess
@@ -1,0 +1,1 @@
+deny from all


### PR DESCRIPTION
Minor point, but giving access to schemas makes it trivial to scan for vulnerable versions