### PR TITLE
Fixes service worker code

### DIFF
--- a/templates/default/shell.tpl.php
+++ b/templates/default/shell.tpl.php
@@ -40,14 +40,16 @@
             ?>
             <script>
                 window.addEventListener('load', function() {
-                    navigator.serviceWorker.register('<?=\Idno\Core\site()->config()->getDisplayURL()?>chrome/service-worker.js', { scope: '/' })
-                        .then(function(r) {
-                            console.log('Registered service worker');
-                        })
-                        .catch(function(whut) {
-                            console.error('Could not register service worker');
-                            console.error(whut);
-                        });
+                    if ('serviceWorker' in navigator) {
+                        navigator.serviceWorker.register('<?=\Idno\Core\site()->config()->getDisplayURL()?>chrome/service-worker.js', { scope: '/' })
+                            .then(function(r) {
+                                console.log('Registered service worker');
+                            })
+                            .catch(function(whut) {
+                                console.error('Could not register service worker');
+                                console.error(whut);
+                            });
+                        }
                 });
             </script>
         <?php

--- a/templates/default/shell.tpl.php
+++ b/templates/default/shell.tpl.php
@@ -35,6 +35,9 @@
 
             ?>
             <link rel="manifest" href="<?=\Idno\Core\site()->config()->getDisplayURL()?>chrome/manifest.json">
+            <?php 
+            if (Idno\Core\site()->isSecure()) {
+            ?>
             <script>
                 window.addEventListener('load', function() {
                     navigator.serviceWorker.register('<?=\Idno\Core\site()->config()->getDisplayURL()?>chrome/service-worker.js', { scope: '/' })
@@ -48,6 +51,7 @@
                 });
             </script>
         <?php
+            }
 
         }
 


### PR DESCRIPTION
* Only attempt loading service worker when available (fatal error can stop other JS from running)
* Only load service worker on TLS connections, as per the developer docs, they MUST ONLY be used when the connection is secure.