### PR TITLE
Detect "AllowOverride None" during setup

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,6 +6,7 @@
     RewriteBase /
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^js/canary\.js$ js/default.js [L]
     RewriteRule ^(.*)$ index.php?/$1 [L,QSA]
     RewriteRule ^Uploads.* - [F]
 </IfModule>

--- a/warmup/settings.php
+++ b/warmup/settings.php
@@ -39,6 +39,29 @@
         }
     }
 
+    if (function_exists('apache_get_version')) {
+        $host = strtolower($_SERVER['HTTP_HOST']);
+        $schema = $_SERVER['HTTPS'] ? 'https://' : 'http://';
+
+        $curl_handle = curl_init();
+        curl_setopt($curl_handle, CURLOPT_URL, $schema . $host . '/js/canary.js');
+        curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($curl_handle, CURLOPT_HEADER, 1);
+
+        $curl_result = curl_exec($curl_handle);
+        $curl_status = curl_getinfo($curl_handle, CURLINFO_HTTP_CODE);
+
+        if ($curl_status < 200 || $curl_status > 299) {
+            $messages .= '<p>Rewriting appears to be disabled. Usually this means "AllowOverride None" is set in apache2.conf ';
+            $messages .= 'which prevents Known\'s .htaccess from doing its thing. We tried to fetch a URL that should redirect ';
+            $messages .= 'to default.js, but got this response instead:</p>';
+            $messages .= '<code><pre>'.htmlspecialchars($curl_result).'</pre></code>';
+            $ok = false;
+        }
+
+        curl_close($curl_handle);
+    }
+
     if (file_exists('../config.ini') && $ok) {
         header('Location: ../begin/register?set_name=' . urlencode($site_title));
         exit;


### PR DESCRIPTION
Use a silly redirect in .htaccess (/js/canary.js -> /js/default.js),
and use it in warmup/settings.php to detect whether .htaccess is
allowed to rewrite URLs. Hoping this helps fewer self-hosters
get hung up on this common configuration glitch!

This is real dog-sciencey as I fumble through learning php;
please feel free to reject or ask for changes/improvements.

Addresses #858