### PR TITLE
Warmup ssl

### DIFF
--- a/css/simple.css
+++ b/css/simple.css
@@ -907,6 +907,10 @@ a.btn:hover {
     background-color: #FAC9B9;
 }
 
+.warning {
+    background-color: #FAF4B9;
+}
+
 .explainer {
     margin-top: 2em;
 }

--- a/warmup/requirements.php
+++ b/warmup/requirements.php
@@ -74,7 +74,7 @@
                     } else {
                         $class = 'warning';
                     }
-                    $text = 'You appear to be running Known on an unsecured site, we strongly recommend obtaining a certificate to make your site secure.';
+                    $text = 'You appear to be running Known on an unsecured site. We strongly recommend obtaining a certificate to make your site secure, and protect the privacy of your users.';
                 }
             ?>
             <div class="component <?= $class ?>">

--- a/warmup/requirements.php
+++ b/warmup/requirements.php
@@ -5,6 +5,7 @@
     include 'top.php';
 
     $ok = true;
+    $sslrequired = false; // Only warn for now, later we might want to make SSL a requirement
 
 ?>
 
@@ -38,6 +39,49 @@
                     <?=$text?>
                 </p>
 
+            </div>
+            
+            
+            <?php
+                /* 
+                 * Check whether you're installing on a secure connection (and presumably your site is secure).
+                 * This is a warning for now, in future this might be a hard fail. 
+                 */
+            
+                function isTLS() {
+                    if (isset($_SERVER['HTTPS'])) {
+                        if ($_SERVER['HTTPS'] == '1')
+                            return true;
+                        if (strtolower($_SERVER['HTTPS'] == 'on'))
+                            return true;
+                    } else if (isset($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == '443'))
+                        return true;
+
+                    if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+                        return true;
+                    }
+
+                    return false;
+                }
+                
+                if (isTLS()) {
+                    $class = 'success';
+                    $text = 'You are running Known on a secure site.';
+                } else {
+                    if ($sslrequired) {
+                        $class = 'failure';
+                        $ok = false;
+                    } else {
+                        $class = 'warning';
+                    }
+                    $text = 'You appear to be running Known on an unsecured site, we strongly recommend obtaining a certificate to make your site secure.';
+                }
+            ?>
+            <div class="component <?= $class ?>">
+                <h3>Secure site</h3>
+                <p>
+                    <?=$text?>
+                </p>
             </div>
 
             <?php


### PR DESCRIPTION
Place a message during warmup/requirements.php to alert the administrator when they're installing Known on a non-secure site, nudging them to consider installing a certificate.

This is only a warning at the moment, but there's a switch for making it a requirement at some point in the future when port 80 is more widely deprecated.