### PR TITLE
htaccess: move canary RewriteRule above the RewriteConds

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,9 +4,9 @@
 <IfModule mod_rewrite.c>
     RewriteEngine on
     RewriteBase /
+    RewriteRule ^js/canary\.js$ js/default.js [L]
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule ^js/canary\.js$ js/default.js [L]
     RewriteRule ^(.*)$ index.php?/$1 [L,QSA]
     RewriteRule ^Uploads.* - [F]
 </IfModule>


### PR DESCRIPTION
Oops, need to fix an earlier mistake -- this way the -f -d RewriteConds apply
to the index.php RewriteRule, not to the canary rule.