### PR TITLE
store Bridgy connected/disconnected status

### DIFF
--- a/IdnoPlugins/Bridgy/Main.php
+++ b/IdnoPlugins/Bridgy/Main.php
@@ -11,6 +11,8 @@
                 \Idno\Core\site()->template()->extendTemplate('account/menu/items', 'bridgy/menu');
 
                 \Idno\Core\site()->addPageHandler('account/bridgy/?','IdnoPlugins\Bridgy\Pages\Account');
+                \Idno\Core\site()->addPageHandler('account/bridgy/enabled/?','IdnoPlugins\Bridgy\Pages\Enabled');
+                \Idno\Core\site()->addPageHandler('account/bridgy/disabled/?','IdnoPlugins\Bridgy\Pages\Disabled');
 
             }
 

--- a/IdnoPlugins/Bridgy/Pages/Account.php
+++ b/IdnoPlugins/Bridgy/Pages/Account.php
@@ -9,14 +9,26 @@
 
             function getContent()
             {
-
-                if (!empty($_SERVER['HTTP_REFERER']))
-                if (substr_count($_SERVER['HTTP_REFERER'], 'brid.gy')) {
-                    \Idno\Core\site()->session()->addMessage("Your account has been connected with brid.gy!");
+                $user = \Idno\Core\site()->session()->currentUser();
+                $vars = array();
+                foreach (array('twitter', 'facebook') as $service) {
+                    if ($user && isset($user->bridgy[$service])) {
+                        $bdata = $user->bridgy[$service];
+                        $vars[$service.'_enabled'] = isset($bdata['status'])
+                            && $bdata['status'] == 'enabled';
+                        if (isset($bdata['user'])) {
+                            $vars[$service.'_user'] = $bdata['user'];
+                        }
+                        if (isset($bdata['key'])) {
+                            $vars[$service.'_key'] = $bdata['key'];
+                        }
+                    } else {
+                        $vars[$service.'_enabled'] = false;
+                    }
                 }
 
                 $t = \Idno\Core\site()->template();
-                $t->body = $t->__([])->draw('bridgy/account');
+                $t->body = $t->__($vars)->draw('bridgy/account');
                 $t->title = 'Interactions';
                 $t->drawPage();
 

--- a/IdnoPlugins/Bridgy/Pages/Disabled.php
+++ b/IdnoPlugins/Bridgy/Pages/Disabled.php
@@ -1,0 +1,31 @@
+<?php
+
+    namespace IdnoPlugins\Bridgy\Pages {
+
+        use Idno\Common\Page;
+
+        class Disabled extends Page
+        {
+
+            function getContent()
+            {
+                $user = \Idno\Core\site()->session()->currentUser();
+                // these will be set if this is a callback from bridgy
+                $service = $this->getInput('service');
+                $bresult = $this->getInput('result');
+
+                if ($user && $service && $bresult == 'success') {
+                    // update the user's bridgy-connection status for this service
+                    $user->bridgy[$service] = array(
+                        'status' =>  'disabled',
+                        'user' => $this->getInput('user'),
+                        'key' => $this->getInput('key'));
+                    $user->save();
+                }
+
+                $this->forward(\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/');
+            }
+
+        }
+
+    }

--- a/IdnoPlugins/Bridgy/Pages/Enabled.php
+++ b/IdnoPlugins/Bridgy/Pages/Enabled.php
@@ -1,0 +1,30 @@
+<?php
+
+    namespace IdnoPlugins\Bridgy\Pages {
+
+        use Idno\Common\Page;
+
+        class Enabled extends Page
+        {
+
+            function getContent()
+            {
+                $user = \Idno\Core\site()->session()->currentUser();
+                // these will be set if this is a callback from bridgy
+                $service = $this->getInput('service');
+
+                if ($user && $service) {
+                    // update the user's bridgy-connection status for this service
+                    $user->bridgy[$service] = array(
+                        'status' => $this->getInput('result') == 'success' ? 'enabled' : 'disabled',
+                        'user' => $this->getInput('user'),
+                        'key' => $this->getInput('key'));
+                    $user->save();
+                }
+
+                $this->forward(\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/');
+            }
+
+        }
+
+    }

--- a/IdnoPlugins/Bridgy/templates/default/bridgy/account.tpl.php
+++ b/IdnoPlugins/Bridgy/templates/default/bridgy/account.tpl.php
@@ -28,7 +28,22 @@
 
     <div class="span6 offset1">
 
-        <form action="https://www.brid.gy/facebook/start?feature=listen&callback=<?=urlencode(\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/')?>" method="post">
+        <?php if ($vars['facebook_enabled']) { ?>
+        <form action="https://www.brid.gy/delete/start" method="post">
+            <input type="hidden" name="feature" value="listen"></input>
+            <input type="hidden" name="key" value="<?=$vars['facebook_key']?>"></input>
+            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/disabled/?service=facebook'?>">
+            <p>
+                <button class="connect fb connected">Facebook + Bridgy connected</button>
+            </p>
+            <p>
+                Bridgy is pulling in comments and likes from Facebook. Click to disable.
+            </p>
+        </form>
+        <?php } else { ?>
+        <form action="https://www.brid.gy/facebook/start" method="post">
+            <input type="hidden" name="feature" value="listen"></input>
+            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/enabled/?service=facebook'?>">
             <p>
                 <button class="connect fb">Activate Facebook + Bridgy</button>
             </p>
@@ -36,7 +51,24 @@
                 Bridgy pulls in comments and likes from Facebook.
             </p>
         </form>
-        <form action="https://www.brid.gy/twitter/start?feature=listen&callback=<?=urlencode(\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/')?>" method="post">
+        <?php } ?>
+
+        <?php if ($vars['twitter_enabled']) { ?>
+        <form action="https://www.brid.gy/delete/start" method="post">
+            <input type="hidden" name="feature" value="listen"></input>
+            <input type="hidden" name="key" value="<?=$vars['twitter_key']?>"></input>
+            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/disabled/?service=twitter'?>">
+            <p>
+                <button class="connect fb connected">Twitter + Bridgy connected</button>
+            </p>
+            <p>
+                Bridgy is pulling in replies, favorites, and retweets from Twitter. Click to disable.
+            </p>
+        </form>
+        <?php } else { ?>
+        <form action="https://www.brid.gy/twitter/start" method="post">
+            <input type="hidden" name="feature" value="listen"></input>
+            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/enabled/?service=twitter'?>">
             <p>
                 <button class="connect tw">Activate Twitter + Bridgy</button>
             </p>
@@ -44,7 +76,7 @@
                 Bridgy pulls in replies, favorites, and retweets from Twitter.
             </p>
         </form>
-
+        <?php } ?>
     </div>
 
 </div>


### PR DESCRIPTION
- better visual feedback when connected
- allow users to disconnect via the same interface

this addresses issue #843 

still TODO:

- Refetch and parse the Bridgy user page to update connected status
  in the future.