### PR TITLE
re-check bridgy connection status

### DIFF
--- a/IdnoPlugins/Bridgy/Main.php
+++ b/IdnoPlugins/Bridgy/Main.php
@@ -13,6 +13,7 @@
                 \Idno\Core\site()->addPageHandler('account/bridgy/?','IdnoPlugins\Bridgy\Pages\Account');
                 \Idno\Core\site()->addPageHandler('account/bridgy/enabled/?','IdnoPlugins\Bridgy\Pages\Enabled');
                 \Idno\Core\site()->addPageHandler('account/bridgy/disabled/?','IdnoPlugins\Bridgy\Pages\Disabled');
+                \Idno\Core\site()->addPageHandler('account/bridgy/check/?','IdnoPlugins\Bridgy\Pages\Check');
 
             }
 

--- a/IdnoPlugins/Bridgy/Pages/Account.php
+++ b/IdnoPlugins/Bridgy/Pages/Account.php
@@ -6,12 +6,13 @@
 
         class Account extends Page
         {
+            public static $SERVICES = array('twitter', 'facebook');
 
             function getContent()
             {
                 $user = \Idno\Core\site()->session()->currentUser();
                 $vars = array();
-                foreach (array('twitter', 'facebook') as $service) {
+                foreach (self::$SERVICES as $service) {
                     if ($user && isset($user->bridgy[$service])) {
                         $bdata = $user->bridgy[$service];
                         $vars[$service.'_enabled'] = isset($bdata['status'])
@@ -31,7 +32,6 @@
                 $t->body = $t->__($vars)->draw('bridgy/account');
                 $t->title = 'Interactions';
                 $t->drawPage();
-
             }
 
         }

--- a/IdnoPlugins/Bridgy/Pages/Check.php
+++ b/IdnoPlugins/Bridgy/Pages/Check.php
@@ -1,0 +1,67 @@
+<?php
+
+    namespace IdnoPlugins\Bridgy\Pages {
+
+        use Idno\Common\Page;
+
+        /**
+         * Checks asynchronously whether the account status has been
+         * enabled/disabled since the last time we checked.
+         *
+         * If it has changed, re-renders the account page and sends
+         * it back as part of the JSON response.
+         */
+        class Check extends Page
+        {
+            function getContent()
+            {
+                $user = \Idno\Core\site()->session()->currentUser();
+                $t = \Idno\Core\site()->template();
+                $t->setTemplateType('json');
+
+                $t->changed = false;
+                foreach (Account::$SERVICES as $service) {
+                    if (self::checkService($user, $service)) {
+                        $t->changed = true;
+                    }
+                }
+
+                $t->drawPage();
+            }
+
+            /**
+             * Fetch and parse the Bridgy user page for this service,
+             * update its status and return true if it has changed.
+             */
+            function checkService($user, $service)
+            {
+                if (!isset($user->bridgy) || !isset($user->bridgy[$service])) {
+                    return false;
+                }
+
+                $bridgy_url = $user->bridgy[$service]['user'];
+                if (!empty($bridgy_url) and $resp = \Idno\Core\Webservice::get($bridgy_url)) {
+                    $parsed = (new \Mf2\Parser($resp['content'], $bridgy_url))->parse();
+                    $status = 'disabled';
+                    if (!empty($parsed['items'])) {
+                        $hcard = $parsed['items'][0];
+                        if (!empty($hcard['properties']['bridgy-account-status'])
+                                && $hcard['properties']['bridgy-account-status'][0] == 'enabled'
+                                && !empty($hcard['properties']['bridgy-listen-status'])
+                                && $hcard['properties']['bridgy-listen-status'][0] == 'enabled') {
+                            $status = 'enabled';
+                        }
+                    }
+
+                    if ($user->bridgy[$service]['status'] != $status) {
+                        $user->bridgy[$service]['status'] = $status;
+                        $user->save();
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+        }
+
+    }

--- a/IdnoPlugins/Bridgy/templates/default/bridgy/account.tpl.php
+++ b/IdnoPlugins/Bridgy/templates/default/bridgy/account.tpl.php
@@ -24,10 +24,9 @@
     </div>
 
 </div>
-<div class="row">
+<div class="row" id="account-area">
 
     <div class="span6 offset1">
-
         <?php if ($vars['facebook_enabled']) { ?>
         <form action="https://www.brid.gy/delete/start" method="post">
             <input type="hidden" name="feature" value="listen"></input>
@@ -80,3 +79,27 @@
     </div>
 
 </div>
+
+
+<script>
+$(function(){
+    function refreshAccountArea() {
+        $.get(
+            "<?=\Idno\Core\site()->config()->getDisplayURL().'account/bridgy/'?>",
+            function(page) {
+                // swap out the account area with the re-rendered area
+                $('#account-area').replaceWith(
+                    $('#account-area', $(page)));
+            });
+    }
+
+    // check whether the account statuses have changed
+    $.get(
+        "<?=\Idno\Core\site()->config()->getDisplayURL().'account/bridgy/check/'?>",
+        function(data) {
+            if (data.changed) {
+                refreshAccountArea();
+            }
+        });
+});
+</script>


### PR DESCRIPTION
- First call checks whether account enabledness has changed
- Re-render the account page and have JS swap out the relevant section

This is the last thing I was planning to do for #843

Of possible minor interest, I wanted to re-render the Account page as part of the Check handler (so that there would only need to be one request). So I would update $user, and then draw the Account page, but it never seemed to pick up the changes to user... guessing it has something to do with the way the session is persisted. Rendering in a second JS request proved much more reliable.