### PR TITLE
use "u-uid u-url" to find wm permalink

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1682,7 +1682,12 @@
                                 $mention['created'] = time();
                             }
                             if (!empty($item['properties']['url'])) {
-                                $mention['url'] = $item['properties']['url'];
+                                if (!empty($item['properties']['uid'])) {
+                                    $mention['url'] = array_intersect($item['properties']['uid'], $item['properties']['url']);
+                                }
+                                if (empty($mention['url'])) {
+                                    $urls = $item['properties']['url'];
+                                }
                             }
                             if (!empty($item['properties']['in-reply-to']) && is_array($item['properties']['in-reply-to'])) {
                                 if (in_array($target, static::getStringURLs($item['properties']['in-reply-to']))) {


### PR DESCRIPTION
If it's specified "u-uid u-url" gives the post permalink,
as opposed to "u-url" by itself which can include things
like shortlinks.

Known currently concatenates multiple u-urls together
which btw, is probably a bad idea in general
bc you should always be getting full absolute URLs as
the value of u- properties. (so concatenating them
would always give an incorrect URL)