### PR TITLE
Retrieve API key via javascript endpoint

### DIFF
--- a/Idno/Pages/Account/Settings/Tools.php
+++ b/Idno/Pages/Account/Settings/Tools.php
@@ -15,10 +15,16 @@
             function getContent()
             {
                 $this->createGatekeeper(); // Logged-in only please
-                $t        = \Idno\Core\site()->template();
-                $t->body  = $t->draw('account/settings/tools');
-                $t->title = 'Tools and Apps';
-                $t->drawPage();
+          
+                if ($this->xhr) {
+                    $user = \Idno\Core\site()->session()->currentUser();
+                    echo json_encode($user->getAPIkey());
+                } else {
+                    $t        = \Idno\Core\site()->template();
+                    $t->body  = $t->draw('account/settings/tools');
+                    $t->title = 'Tools and Apps';
+                    $t->drawPage();
+                }
             }
 
             function postContent()

--- a/templates/default/account/settings/tools.tpl.php
+++ b/templates/default/account/settings/tools.tpl.php
@@ -62,9 +62,23 @@
         <h2>API</h2>
         <p>
             Your API key: <input type="text" id="apikey" class="span4" name="apikey"
-                                 value="<?= htmlspecialchars($user->getAPIkey()) ?>" readonly>
+                                 value="Click to show" readonly>
         </p>
 
     </div>
 
 </div>
+<script>
+    $(document).ready(function() {
+        $('#apikey').click(function() {
+            var ctrl = $(this);
+            
+            $.ajax('<?= \Idno\Core\site()->currentPage()->currentUrl(); ?>', {
+                dataType: 'json',
+                success: function(data) {
+                    ctrl.val(data);
+                }
+            })
+        });
+    });
+</script>


### PR DESCRIPTION
API keys (which are user passwords) are no longer automatically injected into page, and must be explicitly retrieved.

This means passwords are no longer leaked by simply viewing the page over a non-tls connection.