### PR TITLE
Xcache pages

### DIFF
--- a/Idno/Caching/XCache.php
+++ b/Idno/Caching/XCache.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Idno\Caching {
+
+    /**
+     * Implement a persistent cache using XCache.
+     */
+    class XCache extends PersistentCache {
+        
+        public function delete($key) {
+            xcache_dec('__known_xcache_size', strlen($this->load('__known_xcache_size')));
+            
+            return xcache_unset($key);
+        }
+
+        public function load($key) {
+            return xcache_get($key);
+        }
+
+        public function size() {
+            return (int)$this->load('__known_xcache_size');
+        }
+
+        public function store($key, $value) {
+            
+            if (xcache_set($key, $value)) {
+                xcache_inc('__known_xcache_size', strlen($value));
+            }
+            return false;
+        }
+
+    }
+
+}

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -874,6 +874,21 @@
             {
                 header('Last-Modified: ' . self::timestampToRFC2616($timestamp));
             }
+            
+            /**
+             * Simplify if modified since checks.
+             * Set a 304 not modified if If-Modified-Since header is less than the given timestamp.
+             * @param type $timestamp Timestamp to check
+             */
+            public function lastModifiedGatekeeper($timestamp) {
+                $headers = $this->getallheaders();
+                if (isset($headers['If-Modified-Since'])) {
+                    if (strtotime($headers['If-Modified-Since']) <= $timestamp) { 
+                        header('HTTP/1.1 304 Not Modified');
+                        exit;
+                    }
+                }
+            }
 
             /**
              * Return whether the current page URL matches the given regex string.

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -32,6 +32,7 @@
             public $known_hub;
             public $helper_robot;
             public $reader;
+            public $cache;
 
             function init()
             {
@@ -94,6 +95,12 @@
                 $this->logging      = new Logging($this->config->log_level);
                 $this->reader       = new Reader();
                 $this->helper_robot = new HelperRobot();
+                
+                // Attempt to create a cache object, making use of support present on the system
+                if (extension_loaded('xcache')) {
+                    $this->cache = new \Idno\Caching\XCache();
+                }
+                // TODO: Support other persistent caching methods
 
                 // No URL is a critical error, default base fallback is now a warning (Refs #526)
                 if (!$this->config->url) throw new \Exception('Known was unable to work out your base URL! You might try setting url="http://yourdomain.com/" in your config.ini');
@@ -232,6 +239,15 @@
             function &logging()
             {
                 return $this->logging;
+            }
+            
+            /**
+             * Return a persistent cache object.
+             * @return \Idno\Caching\PersistentCache
+             */
+            function &cache() 
+            {
+                return $this->cache;
             }
 
             /**


### PR DESCRIPTION
* Adds XCache key cache support (with stub for other mechanisms) - useful alternative to database storage for cached data
* Cache 304 data on object and file views, so database is no longer required for 304 test