### PR TITLE
Adds SQLite3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ env:
   - DB=mongo
   - DB=sqlite3
 
-#branches:
-#  only:
-#    - master
+branches:
+  only:
+    - master
 
 before_script:
   # Update and install base system
@@ -50,8 +50,6 @@ after_failure:
   - sudo cat $TRAVIS_BUILD_DIR/apache-error.log
 
 notifications:
-   email:
-     - marcus@dushka.co.uk
-#  email:
-#    - hello@withknown.com
-#  irc: "irc.freenode.net#knownchat"
+  email:
+    - hello@withknown.com
+  irc: "irc.freenode.net#knownchat"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ services:
 
 after_failure:
   - sudo cat $TRAVIS_BUILD_DIR/apache-error.log
+  - mysql -utravis -e "use known_unittest; select * from entities where match (search) against ('test sear');"
 
 notifications:
    email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 env:
   - DB=mysql
   - DB=mongo
+  - DB=sqlite3
 
 branches:
   only:
@@ -17,7 +18,7 @@ before_script:
   # Update and install base system
   - sudo apt-get update
   - sudo apt-get install -y --force-yes apache2 libapache2-mod-fastcgi make 
-  - sudo apt-get install -y --force-yes php5-dev php-pear php5-mysql php5-curl php5-gd php5-json 
+  - sudo apt-get install -y --force-yes php5-dev php-pear php5-mysql php5-curl php5-gd php5-json php5-sqlite
   # Enable php-fpm and Mongodb
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - sudo a2enmod rewrite actions fastcgi alias
@@ -35,6 +36,8 @@ before_script:
   - if [[ "$DB" == "mysql" ]]; then mysql -e "USE known_unittest; SOURCE ./schemas/mysql/mysql.sql;" -utravis; fi
   - if [[ "$DB" == "mongo" ]]; then echo "PROVISIONING WITH MongoDB (default)"; fi
   - if [[ "$DB" == "mongo" ]]; then sudo cp -f Tests/build/config_default.ini $TRAVIS_BUILD_DIR/config.ini; fi
+  - if [[ "$DB" == "sqlite3" ]]; then echo "PROVISIONING WITH Sqlite"; fi
+  - if [[ "$DB" == "sqlite3" ]]; then sudo cp -f Tests/build/config_sqlite3.ini $TRAVIS_BUILD_DIR/config.ini; fi
   - sudo cp -f $TRAVIS_BUILD_DIR/htaccess.dist $TRAVIS_BUILD_DIR/.htaccess
   # Restart services
   - sudo service apache2 restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
   - if [[ "$DB" == "mysql" ]]; then mysql --version; fi
   - if [[ "$DB" == "mysql" ]]; then mysql -e "CREATE DATABASE known_unittest;" -uroot; fi
   - if [[ "$DB" == "mysql" ]]; then mysql -e "GRANT ALL ON known_unittest.* TO 'travis'@'127.0.0.1';" -uroot; fi
-  - if [[ "$DB" == "mysql" ]]; then mysql -e "USE known_unittest; SOURCE ./schemas/mysql/mysql.sql; show table status;" -utravis; fi
+  - if [[ "$DB" == "mysql" ]]; then mysql -e "USE known_unittest; SOURCE ./schemas/mysql/mysql.sql; show table status; show index from entities;" -utravis; fi
   - if [[ "$DB" == "mongo" ]]; then echo "PROVISIONING WITH MongoDB (default)"; fi
   - if [[ "$DB" == "mongo" ]]; then sudo cp -f Tests/build/config_default.ini $TRAVIS_BUILD_DIR/config.ini; fi
   - if [[ "$DB" == "sqlite3" ]]; then echo "PROVISIONING WITH Sqlite"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
   # Configure Known
   - if [[ "$DB" == "mysql" ]]; then echo "PROVISIONING WITH MySQL"; fi
   - if [[ "$DB" == "mysql" ]]; then sudo cp -f Tests/build/config_mysql.ini $TRAVIS_BUILD_DIR/config.ini; fi
+  - if [[ "$DB" == "mysql" ]]; then mysql --version; fi
   - if [[ "$DB" == "mysql" ]]; then mysql -e "CREATE DATABASE known_unittest;" -uroot; fi
   - if [[ "$DB" == "mysql" ]]; then mysql -e "GRANT ALL ON known_unittest.* TO 'travis'@'127.0.0.1';" -uroot; fi
   - if [[ "$DB" == "mysql" ]]; then mysql -e "USE known_unittest; SOURCE ./schemas/mysql/mysql.sql;" -utravis; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
   - if [[ "$DB" == "mysql" ]]; then mysql --version; fi
   - if [[ "$DB" == "mysql" ]]; then mysql -e "CREATE DATABASE known_unittest;" -uroot; fi
   - if [[ "$DB" == "mysql" ]]; then mysql -e "GRANT ALL ON known_unittest.* TO 'travis'@'127.0.0.1';" -uroot; fi
-  - if [[ "$DB" == "mysql" ]]; then mysql -e "USE known_unittest; SOURCE ./schemas/mysql/mysql.sql;" -utravis; fi
+  - if [[ "$DB" == "mysql" ]]; then mysql -e "USE known_unittest; SOURCE ./schemas/mysql/mysql.sql; show table status;" -utravis; fi
   - if [[ "$DB" == "mongo" ]]; then echo "PROVISIONING WITH MongoDB (default)"; fi
   - if [[ "$DB" == "mongo" ]]; then sudo cp -f Tests/build/config_default.ini $TRAVIS_BUILD_DIR/config.ini; fi
   - if [[ "$DB" == "sqlite3" ]]; then echo "PROVISIONING WITH Sqlite"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ env:
   - DB=mongo
   - DB=sqlite3
 
-branches:
-  only:
-    - master
+#branches:
+#  only:
+#    - master
 
 before_script:
   # Update and install base system
@@ -49,6 +49,8 @@ after_failure:
   - sudo cat $TRAVIS_BUILD_DIR/apache-error.log
 
 notifications:
-  email:
-    - hello@withknown.com
-  irc: "irc.freenode.net#knownchat"
+   email:
+     - marcus@dushka.co.uk
+#  email:
+#    - hello@withknown.com
+#  irc: "irc.freenode.net#knownchat"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ services:
 
 after_failure:
   - sudo cat $TRAVIS_BUILD_DIR/apache-error.log
-  - mysql -utravis -e "use known_unittest; select * from entities where match (search) against ('test sear');"
 
 notifications:
    email:

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -53,8 +53,10 @@
 
             function init()
             {
-                header('X-Powered-By: https://withknown.com');
-                header('X-Clacks-Overhead: GNU Terry Pratchett');
+                if (!defined('KNOWN_UNIT_TEST')) { // Don't do header stuff in unit tests
+                    header('X-Powered-By: https://withknown.com');
+                    header('X-Clacks-Overhead: GNU Terry Pratchett');
+                }
                 if ($template = $this->getInput('_t')) {
                     if (\Idno\Core\site()->template()->templateTypeExists($template)) {
                         \Idno\Core\site()->template()->setTemplateType($template);

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -435,7 +435,9 @@
 
                     $client = $this->client;
                     /* @var \PDO $client */
-
+if (defined('KNOWN_UNIT_TEST')) {
+    error_log($query);
+}
                     $statement = $client->prepare($query);
 
                     if ($result = $statement->execute($variables)) {
@@ -635,9 +637,6 @@
                     }
                     if (!empty($subwhere)) {
                         $where = '(' . implode(" {$clause} ", $subwhere) . ')';
-                        if (defined('KNOWN_UNIT_TEST')) {
-                            error_log($where);
-                        }
                     }
                 }
 
@@ -712,7 +711,9 @@
                     if (!empty($where)) {
                         $query .= ' where ' . $where . ' ';
                     }
-
+if (defined('KNOWN_UNIT_TEST')) {
+    error_log($query);
+}
                     $client = $this->client;
                     /* @var \PDO $client */
                     $statement = $client->prepare($query);

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -635,6 +635,9 @@
                     }
                     if (!empty($subwhere)) {
                         $where = '(' . implode(" {$clause} ", $subwhere) . ')';
+                        if (defined('KNOWN_UNIT_TEST')) {
+                            error_log($where);
+                        }
                     }
                 }
 

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -715,7 +715,7 @@
                     $statement = $client->prepare($query);
                     if ($result = $statement->execute($variables)) {
                         if ($obj = $statement->fetchObject()) {
-                            return $obj->total;
+                            return (int)$obj->total;
                         }
                     }
 

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -435,9 +435,7 @@
 
                     $client = $this->client;
                     /* @var \PDO $client */
-if (defined('KNOWN_UNIT_TEST')) {
-    error_log($query);
-}
+
                     $statement = $client->prepare($query);
 
                     if ($result = $statement->execute($variables)) {
@@ -711,9 +709,7 @@ if (defined('KNOWN_UNIT_TEST')) {
                     if (!empty($where)) {
                         $query .= ' where ' . $where . ' ';
                     }
-if (defined('KNOWN_UNIT_TEST')) {
-    error_log($query);
-}
+
                     $client = $this->client;
                     /* @var \PDO $client */
                     $statement = $client->prepare($query);

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -433,22 +433,6 @@
 
                 return false;
             }
-
-            
-            
-            
-            
-
-            
-            
-            /** TODO **/
-            
-            
-            
-                        
-            
-            
-
             
             /**
              * Recursive function that takes an array of parameters and returns an array of clauses suitable
@@ -642,6 +626,9 @@
                     for ($i = 0; $i <= $metadata_joins; $i++) {
                         $query .= " left join metadata md{$i} on md{$i}.entity = {$collection}.uuid ";
                     }
+                    if (isset($parameters['$search'])) {
+                        $query .= " left join {$collection}_search srch on srch.uuid = {$collection}.uuid ";
+                    }
                     if (!empty($where)) {
                         $query .= ' where ' . $where . ' ';
                     }
@@ -651,7 +638,7 @@
                     $statement = $client->prepare($query);
                     if ($result = $statement->execute($variables)) {
                         if ($obj = $statement->fetchObject()) {
-                            return $obj->total;
+                            return (int)$obj->total;
                         }
                     }
 

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -1,0 +1,866 @@
+<?php
+
+    /**
+     * MySQL back-end for Known data.
+     *
+     * @package idno
+     * @subpackage data
+     */
+
+    namespace Idno\Data {
+
+        class MySQL extends \Idno\Core\DataConcierge
+        {
+
+            private $client = null;
+            private $database = null;
+
+            function init()
+            {
+
+                try {
+                    $connection_string = 'mysql:host=' . \Idno\Core\site()->config()->dbhost . ';dbname=' . \Idno\Core\site()->config()->dbname . ';charset=utf8';
+                    if (!empty(\Idno\Core\site()->config()->dbport)) {
+                        $connection_string .= ';port=' . \Idno\Core\site()->config()->dbport;
+                    }
+                    $this->client = new \PDO($connection_string, \Idno\Core\site()->config()->dbuser, \Idno\Core\site()->config()->dbpass, array(\PDO::MYSQL_ATTR_LOCAL_INFILE => 1));
+                    $this->client->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+                    //$this->client->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);
+                } catch (\Exception $e) {
+                    if (!empty(\Idno\Core\site()->config()->forward_on_empty)) {
+                        header('Location: ' . \Idno\Core\site()->config()->forward_on_empty);
+                        exit;
+                    } else {
+                        //echo '<p>Unfortunately we couldn\'t connect to the database.</p>';
+                        if (\Idno\Core\site()->config()->debug) {
+                            $message = '<p>' . $e->getMessage() . '</p>';
+                            $message .= '<p>' . $connection_string . '</p>';
+                        }
+                        error_log($e->getMessage());
+                        include \Idno\Core\site()->config()->path . '/statics/db.php';
+                        exit;
+                    }
+                }
+
+                $this->database = \Idno\Core\site()->config()->dbname;
+                $this->checkAndUpgradeSchema();
+
+            }
+
+            /**
+             * Handle the session in MySQL
+             */
+            function handleSession()
+            {
+                if (version_compare(phpversion(), '5.3', '>')) {
+                    $sessionHandler = new \Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler(\Idno\Core\site()->db()->getClient(),
+                        array(
+                            'db_table'    => 'session',
+                            'db_id_col'   => 'session_id',
+                            'db_data_col' => 'session_value',
+                            'db_time_col' => 'session_time',
+                        )
+                    );
+
+                    session_set_save_handler($sessionHandler, true);
+                }
+            }
+
+            /**
+             * Returns an instance of the database reference variable
+             * @return string;
+             */
+            function getDatabase()
+            {
+                return $this->database;
+            }
+
+            /**
+             * Returns an instance of the database client reference variable
+             * @return \PDO
+             */
+            function getClient()
+            {
+                return $this->client;
+            }
+
+            /**
+             * MySQL doesn't need the ID to be processed.
+             * @param $id
+             * @return string
+             */
+            function processID($id)
+            {
+                return $id;
+            }
+
+            /**
+             * Saves a Known entity to the database, returning the _id
+             * field on success.
+             *
+             * @param Entity $object
+             */
+
+            function saveObject($object)
+            {
+                if ($object instanceof \Idno\Common\Entity) {
+                    if ($collection = $object->getCollection()) {
+                        $array = $object->saveToArray();
+
+                        return $this->saveRecord($collection, $array);
+                    }
+                }
+
+                return false;
+            }
+
+            /**
+             * Saves a record to the specified database collection
+             *
+             * @param string $collection
+             * @param array $array
+             * @return int | false
+             */
+
+            function saveRecord($collection, $array)
+            {
+                /*
+                $collection_obj = $this->database->selectCollection($collection);
+                if ($result = $collection_obj->save($array, array('w' => 1))) {
+                    if ($result['ok'] == 1) {
+                        return $array['_id'];
+                    }
+                }*/
+
+                if (empty($array['_id'])) {
+                    $array['_id'] = md5(rand(0, 9999) . time());
+                }
+                if (empty($array['uuid'])) {
+                    $array['uuid'] = \Idno\Core\site()->config()->getURL() . 'view/' . $array['_id'];
+                }
+                if (empty($array['owner'])) {
+                    $array['owner'] = '';
+                }
+                try {
+                    $contents = json_encode($array);
+                } catch (\Exception $e) {
+                    $contents = json_encode([]);
+                    \Idno\Core\site()->logging()->log($e->getMessage());
+                    return false;
+                }
+                $search   = '';
+                if (!empty($array['title'])) {
+                    $search .= $array['title'] . ' ';
+                }
+                if (!empty($array['tags'])) {
+                    $search .= $array['tags'] . ' ';
+                }
+                if (!empty($array['description'])) {
+                    $search .= $array['description'] . ' ';
+                }
+                if (!empty($array['body'])) {
+                    $search .= strip_tags($array['body']);
+                }
+                if (empty($array['entity_subtype'])) {
+                    $array['entity_subtype'] = 'Idno\\Common\\Entity';
+                }
+                if (empty($array['created'])) {
+                    $array['created'] = date("Y-m-d H:i:s", time());
+                } else {
+                    $array['created'] = date("Y-m-d H:i:s", $array['created']);
+                }
+
+                $search = str_replace("\n", " \n ", $search);
+                $search = str_replace("\r", "", $search);
+                $search = str_replace("#", " #", $search);
+                $search = strtolower($search);
+
+                $client = $this->client;
+                /* @var \PDO $client */
+
+                try {
+
+                    $statement = $client->prepare("insert into {$collection}
+                                                    (`uuid`, `_id`, `entity_subtype`,`owner`, `contents`, `search`, `created`)
+                                                    values
+                                                    (:uuid, :id, :subtype, :owner, :contents, :search, :created)
+                                                    on duplicate key update `uuid` = :uuid, `entity_subtype` = :subtype, `owner` = :owner, `contents` = :contents, `search` = :search, `created` = :created");
+                    if ($statement->execute(array(':uuid' => $array['uuid'], ':id' => $array['_id'], ':owner' => $array['owner'], ':subtype' => $array['entity_subtype'], ':contents' => $contents, ':search' => $search, ':created' => $array['created']))) {
+                        if ($statement = $client->prepare("delete from metadata where _id = :id")) {
+                            $statement->execute(array(':id' => $array['_id']));
+                        }
+                        foreach ($array as $key => $val) {
+                            if (!is_array($val)) {
+                                $val = array($val);
+                            }
+                            foreach ($val as $value) {
+                                if (is_array($value) || is_object($value)) {
+                                    try {
+                                        $value = json_encode($value);
+                                    } catch (\Exception $e) {
+                                        $value = json_encode([]);
+                                        \Idno\Core\site()->logging()->log($e->getMessage());
+                                    }
+                                }
+                                if (empty($value)) {
+                                    $value = 0;
+                                }
+                                if ($statement = $client->prepare("insert into metadata set `collection` = :collection, `entity` = :uuid, `_id` = :id, `name` = :name, `value` = :value")) {
+                                    $statement->execute(array('collection' => $collection, ':uuid' => $array['uuid'], ':id' => $array['_id'], ':name' => $key, ':value' => $value));
+                                }
+                            }
+                        }
+
+                        return $array['_id'];
+                    }
+                } catch (\Exception $e) {
+                    \Idno\Core\site()->logging()->log($e->getMessage());
+                }
+
+                return false;
+            }
+
+            /**
+             * Retrieves a Known entity object by its UUID, casting it to the
+             * correct class
+             *
+             * @param string $id
+             * @return \Idno\Common\Entity | false
+             */
+
+            function getObject($uuid)
+            {
+                if ($result = $this->getRecordByUUID($uuid)) {
+                    if ($object = $this->rowToEntity($result)) {
+                        if ($object->canRead()) {
+                            return $object;
+                        }
+                    }
+                }
+
+                return false;
+            }
+
+            /**
+             * Retrieves a record from the database by its UUID
+             *
+             * @param string $id
+             * @param string $collection The collection to retrieve from (default: entities)
+             * @return array
+             */
+
+            function getRecordByUUID($uuid, $collection = 'entities')
+            {
+                try {
+                    $statement = $this->client->prepare("select distinct {$collection}.* from " . $collection . " where uuid = :uuid");
+                    if ($statement->execute(array(':uuid' => $uuid))) {
+                        return $statement->fetch(\PDO::FETCH_ASSOC);
+                    }
+                } catch (\Exception $e) {
+                    \Idno\Core\site()->logging()->log($e->getMessage());
+                }
+
+                return false;
+            }
+
+            /**
+             * Converts a database row into a Known entity
+             *
+             * @param array $row
+             * @return \Idno\Common\Entity
+             */
+            function rowToEntity($row)
+            {
+                if (!empty($row['entity_subtype']) && !empty($row['contents'])) {
+                    if (class_exists($row['entity_subtype'])) {
+
+                        $contents = (array)json_decode($row['contents'], true);
+
+                        $object = new $row['entity_subtype']();
+                        $object->loadFromArray($contents);
+
+                        return $object;
+                    }
+                }
+
+                return false;
+            }
+
+            /**
+             * Retrieves a record from the database by ID
+             *
+             * @param string $id
+             * @param string $entities The collection name to retrieve from (default: 'entities')
+             * @return array
+             */
+
+            function getRecord($id, $collection = 'entities')
+            {
+                $statement = $this->client->prepare("select {$collection}.* from " . $collection . " where _id = :id");
+                if ($statement->execute(array(':id' => $id))) {
+                    return $statement->fetch(\PDO::FETCH_ASSOC);
+                }
+
+                return false;
+            }
+
+            /**
+             * Retrieves ANY record from a collection
+             *
+             * @param string $collection
+             * @return mixed
+             */
+            function getAnyRecord($collection = 'entities')
+            {
+                try {
+                    $statement = $this->client->prepare("select {$collection}.* from " . $collection . " limit 1");
+                    if ($statement->execute()) {
+                        if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+                            if ($obj = $this->rowToEntity($row)) {
+                                return $obj;
+                            }
+
+                            return $row;
+                        }
+                    }
+                } catch (\Exception $e) {
+                    if (\Idno\Core\site()->session() == null)
+                        die($e->getMessage());
+                }
+
+                return false;
+            }
+
+            /**
+             * Retrieve objects of a certain kind that we're allowed to see,
+             * (or excluding kinds that we don't want to see),
+             * in reverse chronological order
+             *
+             * @param string|array $subtypes String or array of subtypes we're allowed to see
+             * @param array $search Any extra search terms in array format (eg array('foo' => 'bar')) (default: empty)
+             * @param array $fields An array of fieldnames to return (leave empty for all; default: all)
+             * @param int $limit Maximum number of records to return (default: 10)
+             * @param int $offset Number of records to skip (default: 0)
+             * @param string $collection Collection to query; default: entities
+             * @return array|false Array of elements or false, depending on success
+             */
+
+            function getObjects($subtypes = '', $search = array(), $fields = array(), $limit = 10, $offset = 0, $collection = 'entities')
+            {
+
+                // Initialize query parameters to be an empty array
+                $query_parameters = array();
+
+                // Ensure subtypes are recorded properly
+                // and remove subtypes that have an exclamation mark before them
+                // from consideration
+                if (!empty($subtypes)) {
+                    $not = array();
+                    if (!is_array($subtypes)) {
+                        $subtypes = array($subtypes);
+                    }
+                    foreach ($subtypes as $key => $subtype) {
+                        if (substr($subtype, 0, 1) == '!') {
+                            unset($subtypes[$key]);
+                            $not[] = substr($subtype, 1);
+                        }
+                    }
+                    if (!empty($subtypes)) {
+                        $query_parameters['entity_subtype']['$in'] = $subtypes;
+                    }
+                    if (!empty($not)) {
+                        $query_parameters['entity_subtype']['$not'] = $not;
+                    }
+                }
+
+                // Make sure we're only getting objects that we're allowed to see
+                $readGroups                 = \Idno\Core\site()->session()->getReadAccessGroupIDs();
+                $query_parameters['access'] = array('$in' => $readGroups);
+
+                // Join the rest of the search query elements to this search
+                $query_parameters = array_merge($query_parameters, $search);
+
+                // Prepare the fields array for searching, if required
+                if (!empty($fields) && is_array($fields)) {
+                    $fields = array_flip($fields);
+                    $fields = array_fill_keys($fields, true);
+                } else {
+                    $fields = array();
+                }
+
+                // Run the query
+                if ($results = $this->getRecords($fields, $query_parameters, $limit, $offset, $collection)) {
+                    $return = array();
+                    foreach ($results as $row) {
+                        $return[] = $this->rowToEntity($row);
+                    }
+
+                    return $return;
+                }
+
+                return array();
+
+            }
+
+            /**
+             * Retrieves a set of records from the database with given parameters, in
+             * reverse chronological order
+             *
+             * @param array $parameters Query parameters in MongoDB format
+             * @param int $limit Maximum number of records to return
+             * @param int $offset Number of records to skip
+             * @param string $collection The collection to interrogate (default: 'entities')
+             * @return iterator|false Iterator or false, depending on success
+             */
+
+            function getRecords($fields, $parameters, $limit, $offset, $collection = 'entities')
+            {
+                try {
+
+                    // Build query
+                    $query            = "select distinct {$collection}.* from {$collection} ";
+                    $variables        = array();
+                    $metadata_joins   = 0;
+                    $non_md_variables = array();
+                    $limit            = (int)$limit;
+                    $offset           = (int)$offset;
+                    $where            = $this->build_where_from_array($parameters, $variables, $metadata_joins, $non_md_variables, 'and', $collection);
+                    for ($i = 1; $i <= $metadata_joins; $i++) {
+                        $query .= " left join metadata md{$i} on md{$i}.entity = {$collection}.uuid ";
+                    }
+                    if (!empty($where)) {
+                        $query .= ' where ' . $where . ' ';
+                    }
+                    $query .= " order by {$collection}.`created` desc limit {$offset},{$limit}";
+
+                    $client = $this->client;
+                    /* @var \PDO $client */
+
+                    $statement = $client->prepare($query);
+
+                    if ($result = $statement->execute($variables)) {
+                        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+                    }
+
+                } catch (\Exception $e) {
+                    \Idno\Core\site()->logging()->log($e->getMessage());
+                    return false;
+                }
+
+                return false;
+            }
+
+            /**
+             * Export a collection as SQL.
+             * @param string $collection
+             * @return bool|string
+             */
+            function exportRecords($collection = 'entities')
+            {
+                try {
+                    $file   = tempnam(\Idno\Core\site()->config()->getTempDir(), 'sqldump');
+                    $client = $this->client;
+                    /* @var \PDO $client */
+                    $statement = $client->prepare("select * from {$collection}");
+                    $output    = '';
+                    if ($response = $statement->execute()) {
+                        while ($object = $statement->fetch(\PDO::FETCH_ASSOC)) {
+                            $uuid   = $object['uuid'];
+                            $fields = array_keys($object);
+                            $fields = array_map(function ($v) {
+                                return '`' . $v . '`';
+                            }, $fields);
+                            $object = array_map(function ($v) {
+                                return \Idno\Core\site()->db()->getClient()->quote($v);
+                            }, $object);
+                            $line   = 'insert into ' . $collection . ' ';
+                            $line .= '(' . implode(',', $fields) . ')';
+                            $line .= ' values ';
+                            $line .= '(' . implode(',', $object) . ');';
+                            $output .= $line . "\n";
+                            $metadata_statement = $client->prepare("select * from metadata where `entity` = :uuid");
+                            if ($metadata_response = $metadata_statement->execute([':uuid' => $uuid])) {
+                                while ($object = $metadata_statement->fetch(\PDO::FETCH_ASSOC)) {
+                                    $fields = array_keys($object);
+                                    $fields = array_map(function ($v) {
+                                        return '`' . $v . '`';
+                                    }, $fields);
+                                    $object = array_map(function ($v) {
+                                        return \Idno\Core\site()->db()->getClient()->quote($v);
+                                    }, $object);
+                                    $line   = 'insert into metadata ';
+                                    $line .= '(' . implode(',', $fields) . ')';
+                                    $line .= ' values ';
+                                    $line .= '(' . implode(',', $object) . ');';
+                                    $output .= $line . "\n";
+                                }
+                                unset($metadata_statement);
+                                gc_collect_cycles();    // Clean memory
+                            }
+                            $output .= "\n";
+                            unset($object);
+                            unset($fields);
+                            gc_collect_cycles();    // Clean memory
+                        }
+                    }
+
+                    return $output;
+                } catch (\Exception $e) {
+                    \Idno\Core\site()->logging()->log($e->getMessage());
+
+                    return false;
+                }
+
+                return false;
+            }
+
+            /**
+             * Recursive function that takes an array of parameters and returns an array of clauses suitable
+             * for compiling into an SQL query
+             * @param $params
+             * @param $where
+             * @param $variables
+             * @param $metadata_joins
+             * @param $non_md_variables
+             * @param string $clause Defaults to 'and'
+             */
+            function build_where_from_array($params, &$variables, &$metadata_joins, &$non_md_variables, $clause = 'and', $collection = 'entities')
+            {
+
+                $where = '';
+                if (empty($variables)) {
+                    $variables = array();
+                }
+                if (empty($metadata_joins)) {
+                    $metadata_joins = 0;
+                }
+                if (empty($non_md_variables)) {
+                    $non_md_variables = 0;
+                }
+                if (is_array($params) && !empty($params)) {
+                    $subwhere = array();
+                    foreach ($params as $key => $value) {
+                        if (!is_array($value)) {
+                            if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner', 'created'))) {
+                                $subwhere[] = "(`{$collection}`.`{$key}` = :nonmdvalue{$non_md_variables})";
+                                if ($key == 'created') {
+                                    if (!is_int($value)) {
+                                        $value = strtotime($value);
+                                    }
+                                }
+                                $variables[":nonmdvalue{$non_md_variables}"] = $value;
+                                $non_md_variables++;
+                            } else {
+                                $metadata_joins++;
+                                $subwhere[]                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`value` = :value{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}')";
+                                $variables[":name{$metadata_joins}"]  = $key;
+                                $variables[":value{$metadata_joins}"] = $value;
+                            }
+                        } else {
+                            if (!empty($value['$or'])) {
+                                $subwhere[] = "(" . $this->build_where_from_array($value['$or'], $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
+                            }
+                            if (!empty($value['$not'])) {
+                                if (!empty($value['$not']['$in'])) {
+                                    $value['$not'] = array_merge($value['$not'], $value['$not']['$in']);
+                                    unset($value['$not']['$in']);
+                                }
+                                if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner'))) {
+                                    $notstring = "`{$collection}`.`$key` not in(";
+                                    $i         = 0;
+                                    foreach ($value['$not'] as $val) {
+                                        if ($i > 0) $notstring .= ', ';
+                                        $notstring .= ":nonmdvalue{$non_md_variables}";
+                                        $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                        $non_md_variables++;
+                                        $i++;
+                                    }
+                                    $notstring .= ")";
+                                } else {
+                                    $metadata_joins++;
+                                    $notstring                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}' and md{$metadata_joins}.`value` not in (";
+                                    $variables[":name{$metadata_joins}"] = $key;
+                                    $i                                   = 0;
+                                    foreach ($value['$not'] as $val) {
+                                        if ($i > 0) $notstring .= ', ';
+                                        $notstring .= ":nonmdvalue{$non_md_variables}";
+                                        $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                        $non_md_variables++;
+                                        $i++;
+                                    }
+                                    $notstring .= "))";
+                                }
+                                $subwhere[] = $notstring;
+                            }
+                            if (!empty($value['$in'])) {
+                                if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner'))) {
+                                    $instring = "`{$collection}`.`$key` in (";
+                                    $i        = 0;
+                                    foreach ($value['$in'] as $val) {
+                                        if ($i > 0) $instring .= ', ';
+                                        $instring .= ":nonmdvalue{$non_md_variables}";
+                                        $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                        $non_md_variables++;
+                                        $i++;
+                                    }
+                                    $instring .= ")";
+                                } else {
+                                    $metadata_joins++;
+                                    $instring                            = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}' and md{$metadata_joins}.`value` in (";
+                                    $variables[":name{$metadata_joins}"] = $key;
+                                    $i                                   = 0;
+                                    foreach ($value['$in'] as $val) {
+                                        if ($i > 0) $instring .= ', ';
+                                        $instring .= ":nonmdvalue{$non_md_variables}";
+                                        $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                        $non_md_variables++;
+                                        $i++;
+                                    }
+                                    $instring .= "))";
+                                }
+                                $subwhere[] = $instring;
+                            }
+                            if ($key == '$search') {
+                                $val = $value[0]; // The search query is always in $value position [0] for now
+                                if (strlen($val) > 5) {
+                                    $subwhere[]                                  = "match (`search`) against (:nonmdvalue{$non_md_variables})";
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                } else {
+                                    $subwhere[]                                  = "`search` like :nonmdvalue{$non_md_variables}";
+                                    $variables[":nonmdvalue{$non_md_variables}"] = '%' . $val . '%';
+                                }
+                                $non_md_variables++;
+                            }
+                        }
+                    }
+                    if (!empty($subwhere)) {
+                        $where = '(' . implode(" {$clause} ", $subwhere) . ')';
+                    }
+                }
+
+                return $where;
+            }
+
+            /**
+             * Count objects of a certain kind that we're allowed to see
+             *
+             * @param string|array $subtypes String or array of subtypes we're allowed to see
+             * @param array $search Any extra search terms in array format (eg array('foo' => 'bar')) (default: empty)
+             * @param string $collection Collection to query; default: entities
+             */
+            function countObjects($subtypes = '', $search = array(), $collection = 'entities')
+            {
+
+                // Initialize query parameters to be an empty array
+                $query_parameters = array();
+
+                // Ensure subtypes are recorded properly
+                // and remove subtypes that have an exclamation mark before them
+                // from consideration
+                if (!empty($subtypes)) {
+                    $not = array();
+                    if (!is_array($subtypes)) {
+                        $subtypes = array($subtypes);
+                    }
+                    foreach ($subtypes as $key => $subtype) {
+                        if (substr($subtype, 0, 1) == '!') {
+                            unset($subtypes[$key]);
+                            $not[] = substr($subtype, 1);
+                        }
+                    }
+                    if (!empty($subtypes)) {
+                        $query_parameters['entity_subtype']['$in'] = $subtypes;
+                    }
+                    if (!empty($not)) {
+                        $query_parameters['entity_subtype']['$not'] = $not;
+                    }
+                }
+
+                // Make sure we're only getting objects that we're allowed to see
+                $readGroups                 = \Idno\Core\site()->session()->getReadAccessGroupIDs();
+                $query_parameters['access'] = array('$in' => $readGroups);
+
+                // Join the rest of the search query elements to this search
+                $query_parameters = array_merge($query_parameters, $search);
+
+                return $this->countRecords($query_parameters, $collection);
+
+            }
+
+            /**
+             * Count the number of records that match the given parameters
+             * @param array $parameters
+             * @param string $collection The collection to interrogate (default: 'entities')
+             * @return int
+             */
+            function countRecords($parameters, $collection = 'entities')
+            {
+                try {
+
+                    // Build query
+                    $query            = "select count(distinct {$collection}.uuid) as total from {$collection} ";
+                    $variables        = array();
+                    $metadata_joins   = 0;
+                    $non_md_variables = array();
+                    $where            = $this->build_where_from_array($parameters, $variables, $metadata_joins, $non_md_variables, 'and', $collection);
+                    for ($i = 0; $i <= $metadata_joins; $i++) {
+                        $query .= " left join metadata md{$i} on md{$i}.entity = {$collection}.uuid ";
+                    }
+                    if (!empty($where)) {
+                        $query .= ' where ' . $where . ' ';
+                    }
+
+                    $client = $this->client;
+                    /* @var \PDO $client */
+                    $statement = $client->prepare($query);
+                    if ($result = $statement->execute($variables)) {
+                        if ($obj = $statement->fetchObject()) {
+                            return $obj->total;
+                        }
+                    }
+
+                } catch (Exception $e) {
+                    \Idno\Core\site()->logging()->log($e->getMessage());
+                    return false;
+                }
+
+                return 0;
+            }
+
+            /**
+             * Get database errors
+             * @return mixed
+             */
+            function getErrors()
+            {
+                if (!empty($this->client)) {
+                    return $this->client->errorInfo();
+                }
+
+                return false;
+            }
+
+            /**
+             * Remove an entity from the database
+             * @param string $id
+             * @return true|false
+             */
+            function deleteRecord($id, $collection = 'entities')
+            {
+                try {
+
+                    $client = $this->client;
+                    /* @var \PDO $client */
+                    $statement = $client->prepare("delete from {$collection} where _id = :id");
+                    if ($statement->execute(array(':id' => $id))) {
+                        if ($statement = $client->prepare("delete from metadata where _id = :id")) {
+                            return $statement->execute(array(':id' => $id));
+                        }
+                    }
+
+                } catch (\Exception $e) {
+
+                    \Idno\Core\site()->logging()->log($e->getMessage());
+                    return false;
+
+                }
+
+                return false;
+            }
+
+            /**
+             * Retrieve the filesystem associated with the current db, suitable for saving
+             * and retrieving files
+             * @return bool
+             */
+            function getFilesystem()
+            {
+                // We're not returning a filesystem for MySQL
+                return false;
+            }
+
+            /**
+             * Given a text query, return an array suitable for adding into getFromX calls
+             * @param $query
+             * @return array
+             */
+            function createSearchArray($query)
+            {
+                return array('$search' => array($query));
+            }
+
+            /**
+             * Retrieve version information from the schema
+             * @return array|bool
+             */
+            function getVersions()
+            {
+                try {
+                    $client = $this->client;
+                    /* @var \PDO $client */
+                    $statement = $client->prepare("select * from `versions`");
+                    if ($statement->execute()) {
+                        return $statement->fetchAll(\PDO::FETCH_OBJ);
+                    }
+                } catch (\Exception $e) {
+                    //\Idno\Core\site()->logging()->log($e->getMessage());
+                    error_log($e->getMessage());
+                }
+
+                return false;
+            }
+
+            /**
+             * Checks the current schema version and upgrades if necessary
+             */
+            function checkAndUpgradeSchema()
+            {
+                if ($versions = $this->getVersions()) {
+                    foreach ($versions as $version) {
+                        if ($version->label == 'schema') {
+                            $basedate          = $newdate = (int)$version->value;
+                            $upgrade_sql_files = array();
+                            $schema_dir        = dirname(dirname(dirname(__FILE__))) . '/schemas/mysql/';
+                            $client            = $this->client;
+                            /* @var \PDO $client */
+                            if ($basedate < 2014100801) {
+                                if ($sql = @file_get_contents($schema_dir . '2014100801.sql')) {
+                                    try {
+                                        $statement = $client->prepare($sql);
+                                        $statement->execute();
+                                    } catch (\Exception $e) {
+                                        //\Idno\Core\site()->logging()->log($e->getMessage());
+                                        error_log($e->getMessage());
+                                    }
+                                }
+                                $newdate = 2014100801;
+                            }
+                            if ($basedate < 2015061501) {
+                                if ($sql = @file_get_contents($schema_dir . '2015061501.sql')) {
+                                    try {
+                                        $statement = $client->prepare($sql);
+                                        $statement->execute();
+                                    } catch (\Exception $e) {
+                                        //\Idno\Core\site()->logging()->log($e->getMessage());
+                                        error_log($e->getMessage());
+                                    }
+                                }
+                                $newdate = 2015061501;
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+
+        /**
+         * Helper function that returns the current database object
+         * @return \Idno\Core\DataConcierge
+         */
+        function db()
+        {
+            return \Idno\Core\site()->db();
+        }
+
+    }

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -311,20 +311,6 @@
                 return false;
             }
             
-            
-            
-            
-
-            
-            
-            /** TODO **/
-            
-            
-            
-                        
-            
-            
-
             /**
              * Retrieve objects of a certain kind that we're allowed to see,
              * (or excluding kinds that we don't want to see),
@@ -444,6 +430,22 @@
                 return false;
             }
 
+            
+            
+            
+            
+
+            
+            
+            /** TODO **/
+            
+            
+            
+                        
+            
+            
+
+            
             /**
              * Recursive function that takes an array of parameters and returns an array of clauses suitable
              * for compiling into an SQL query

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -220,14 +220,6 @@
                 return false;
             }
 
-            
-            
-            /** TODO **/
-            
-            
-            
-            
-
             /**
              * Retrieves a record from the database by its UUID
              *
@@ -263,7 +255,7 @@
 
                         $contents = (array)json_decode($row['contents'], true);
 
-                        $object = new $row['entity_subtype']();
+                        $object = new $row['entity_subtype'](); 
                         $object->loadFromArray($contents);
 
                         return $object;
@@ -290,6 +282,7 @@
 
                 return false;
             }
+            
 
             /**
              * Retrieves ANY record from a collection
@@ -317,6 +310,20 @@
 
                 return false;
             }
+            
+            
+            
+            
+
+            
+            
+            /** TODO **/
+            
+            
+            
+                        
+            
+            
 
             /**
              * Retrieve objects of a certain kind that we're allowed to see,
@@ -431,70 +438,6 @@
 
                 } catch (\Exception $e) {
                     \Idno\Core\site()->logging()->log($e->getMessage());
-                    return false;
-                }
-
-                return false;
-            }
-
-            /**
-             * Export a collection as SQL.
-             * @param string $collection
-             * @return bool|string
-             */
-            function exportRecords($collection = 'entities')
-            {
-                try {
-                    $file   = tempnam(\Idno\Core\site()->config()->getTempDir(), 'sqldump');
-                    $client = $this->client;
-                    /* @var \PDO $client */
-                    $statement = $client->prepare("select * from {$collection}");
-                    $output    = '';
-                    if ($response = $statement->execute()) {
-                        while ($object = $statement->fetch(\PDO::FETCH_ASSOC)) {
-                            $uuid   = $object['uuid'];
-                            $fields = array_keys($object);
-                            $fields = array_map(function ($v) {
-                                return '`' . $v . '`';
-                            }, $fields);
-                            $object = array_map(function ($v) {
-                                return \Idno\Core\site()->db()->getClient()->quote($v);
-                            }, $object);
-                            $line   = 'insert into ' . $collection . ' ';
-                            $line .= '(' . implode(',', $fields) . ')';
-                            $line .= ' values ';
-                            $line .= '(' . implode(',', $object) . ');';
-                            $output .= $line . "\n";
-                            $metadata_statement = $client->prepare("select * from metadata where `entity` = :uuid");
-                            if ($metadata_response = $metadata_statement->execute([':uuid' => $uuid])) {
-                                while ($object = $metadata_statement->fetch(\PDO::FETCH_ASSOC)) {
-                                    $fields = array_keys($object);
-                                    $fields = array_map(function ($v) {
-                                        return '`' . $v . '`';
-                                    }, $fields);
-                                    $object = array_map(function ($v) {
-                                        return \Idno\Core\site()->db()->getClient()->quote($v);
-                                    }, $object);
-                                    $line   = 'insert into metadata ';
-                                    $line .= '(' . implode(',', $fields) . ')';
-                                    $line .= ' values ';
-                                    $line .= '(' . implode(',', $object) . ');';
-                                    $output .= $line . "\n";
-                                }
-                                unset($metadata_statement);
-                                gc_collect_cycles();    // Clean memory
-                            }
-                            $output .= "\n";
-                            unset($object);
-                            unset($fields);
-                            gc_collect_cycles();    // Clean memory
-                        }
-                    }
-
-                    return $output;
-                } catch (\Exception $e) {
-                    \Idno\Core\site()->logging()->log($e->getMessage());
-
                     return false;
                 }
 
@@ -814,14 +757,13 @@
                 }
             }
             
-            /**
-             * Install a schema.
-             * @param type $dbname
-             */
-            function installSchema($dbname) {
+            
+        
+            public function exportRecords($collection = 'entities') {
                 
+                
+                return false; // TODO
             }
-
         }
 
         /**

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -146,7 +146,7 @@ namespace Tests\Data {
 
             $search = \Idno\Core\site()->db()->createSearchArray("test search obj");
 
-            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); var_export($search); die(var_export(\Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search))); var_export($count); die('blerg');
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); var_export($search);  var_export($count); die('blerg');
             $this->assertTrue(is_int($count));
             $this->assertTrue($count > 0);
             

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -149,10 +149,10 @@ namespace Tests\Data {
 //            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); 
 //            $this->assertTrue(is_int($count));
 //            $this->assertTrue($count > 0);
-//            
-            $feed  = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_array($feed));
-            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));
+////            
+//            $feed  = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
+//            $this->assertTrue(is_array($feed)); 
+//            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));
         }
         
         public function testCountObjects() {

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -146,7 +146,7 @@ namespace Tests\Data {
 
             $search = \Idno\Core\site()->db()->createSearchArray("test search obj");
 
-            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); die(var_export($count,true));
             $this->assertTrue(is_int($count));
             $this->assertTrue($count > 0);
             

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -5,11 +5,92 @@ namespace Tests\Data {
     /**
      * Test the currently configured DataConcierge.
      */
-    class DataConciergeTest extends Tests\KnownTestCase {
+    class DataConciergeTest extends \Tests\KnownTestCase {
         
         public static $object;
+        public static $uuid;
+        public static $id;
+        public static $url;
         
+        /**
+         * Versions test (if applicable)
+         */
+        public function testVersions() {
+            if (is_callable([\Idno\Core\site()->db(), 'getVersions'])) {
+                $versions = \Idno\Core\site()->db()->getVersions();
+                
+                $this->assertTrue(is_array($versions));
+            }
+        }
         
+        /**
+         * Create an object.
+         */
+        public function testCreateObject() {
+            
+            $obj = new \Idno\Entities\GenericDataItem();
+            $obj->setDatatype('UnitTestObject');
+            $obj->variable1 = 'test';
+            $obj->variable2 = 'test again';
+            $id = $obj->save();
+            
+            // Make sure we've created something
+            $this->assertTrue(is_string($id));
+            
+            // Save for later retrieval
+            self::$id = $id;
+            self::$uuid = $obj->getUUID();
+            self::$url = $obj->getUrl();
+            self::$object = $obj;
+            
+            // Verify
+            $this->assertTrue(is_string(self::$id));
+            $this->assertTrue(is_string(self::$uuid));
+            $this->assertTrue(is_string(self::$url));
+        }
+        
+        /**
+         * Attempt to retrieve record by UUID.
+         */
+        public function testGetByUUID() {
+            $this->validateObject(
+                    \Idno\Core\site()->db()->rowToEntity(
+                            \Idno\Core\site()->db()->getRecordByUUID(self::$uuid)
+                    )
+            );
+        }
+        
+        /**
+         * Attempt to retrieve record by ID.
+         */
+        public function testGetRecord() {
+            $this->validateObject(
+                    \Idno\Core\site()->db()->rowToEntity(
+                            \Idno\Core\site()->db()->getRecord(self::$id)
+                    )
+            );
+        }
+        
+        /**
+         * Attempt to get any object
+         */
+        public function testGetAnyRecord() {
+            $obj = \Idno\Core\site()->db()->getAnyRecord();
+           
+            $this->assertTrue(is_object($obj));
+        }
+        
+        /**
+         * Helper function to validate object.
+         */
+        protected function validateObject($obj) {
+            
+            $this->assertTrue($obj instanceof \Idno\Entities\GenericDataItem);
+            $this->assertEquals(self::$object->getID(), $obj->getID());
+            $this->assertEquals(self::$id, $obj->getID());
+            $this->assertEquals(self::$uuid, $obj->getUUID());
+            $this->assertEquals(self::$url, $obj->getUrl());
+        }
         
         public static function tearDownAfterClass() {
             if (static::$object) static::$object->delete();
@@ -17,3 +98,4 @@ namespace Tests\Data {
     }
 }
 
+// get id, get uuid, get url, get by metadata, search

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -12,7 +12,7 @@ namespace Tests\Data {
         public static $id;
         public static $url;
         
-        public static $fts_object;
+        public static $fts_objects;
         
         public static function setUpBeforeClass()
         {
@@ -145,7 +145,7 @@ namespace Tests\Data {
         
         public function testSearchLong() {
             
-            /** Create a FTS object, since MySQL FTS tables operate in natural language mode */
+            /** Create couple of FTS objects, since MySQL FTS tables operate in natural language mode */
             $obj = new \Idno\Entities\GenericDataItem();
             $obj->setDatatype('UnitTestObject');
             $obj->setTitle("This is a test obj to get around MySQL natural language mode");
@@ -153,7 +153,14 @@ namespace Tests\Data {
             $obj->variable2 = 'test again';
             $id = $obj->save();
             
-            self::$fts_object = $obj;
+            $obj2 = new \Idno\Entities\GenericDataItem();
+            $obj2->setDatatype('UnitTestObject');
+            $obj2->setTitle("This is some other text because mysql is a pain.");
+            $obj2->variable1 = 'test';
+            $obj2->variable2 = 'test again';
+            $id = $obj2->save();
+            
+            self::$fts_objects = [$obj, $obj2];
             
             
             $search = array();
@@ -168,7 +175,12 @@ namespace Tests\Data {
             $this->assertTrue(is_array($feed)); 
             $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));
             
-            $obj->delete();
+            // Clean up
+            if (static::$fts_objects) {
+                foreach (static::$fts_objects as $obj) {
+                    $obj->delete();
+                }
+            }
         }
         
         public function testCountObjects() {
@@ -192,7 +204,11 @@ namespace Tests\Data {
         
         public static function tearDownAfterClass() {
             if (static::$object) static::$object->delete();
-            if (static::$fts_object) static::$fts_object->delete();
+            if (static::$fts_objects) {
+                foreach (static::$fts_objects as $obj) {
+                    $obj->delete();
+                }
+            }
         }
     }
 }

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -30,6 +30,7 @@ namespace Tests\Data {
             
             $obj = new \Idno\Entities\GenericDataItem();
             $obj->setDatatype('UnitTestObject');
+            $obj->setTitle("Unit Test Search Object");
             $obj->variable1 = 'test';
             $obj->variable2 = 'test again';
             $id = $obj->save();

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -143,7 +143,7 @@ namespace Tests\Data {
         public function testSearchLong() {
             $search = array();
 
-            $search = \Idno\Core\site()->db()->createSearchArray("search obj");
+            $search = \Idno\Core\site()->db()->createSearchArray("test search obj");
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
             $this->assertTrue(is_int($count));

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -133,6 +133,7 @@ namespace Tests\Data {
             $search = \Idno\Core\site()->db()->createSearchArray("sear");
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
+            $this->assertTrue(is_int($count));
             $this->assertTrue($count > 0);
             
             $feed  = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -12,6 +12,22 @@ namespace Tests\Data {
         public static $id;
         public static $url;
         
+        public static function setUpBeforeClass()
+        {
+            $obj = new \Idno\Entities\GenericDataItem();
+            $obj->setDatatype('UnitTestObject');
+            $obj->setTitle("Unit Test Search Object");
+            $obj->variable1 = 'test';
+            $obj->variable2 = 'test again';
+            $id = $obj->save();
+            
+            // Save for later retrieval
+            self::$id = $id;
+            self::$uuid = $obj->getUUID();
+            self::$url = $obj->getUrl();
+            self::$object = $obj;
+        }
+        
         /**
          * Versions test (if applicable)
          */
@@ -27,27 +43,12 @@ namespace Tests\Data {
          * Create an object.
          */
         public function testCreateObject() {
-            
-            $obj = new \Idno\Entities\GenericDataItem();
-            $obj->setDatatype('UnitTestObject');
-            $obj->setTitle("Unit Test Search Object");
-            $obj->variable1 = 'test';
-            $obj->variable2 = 'test again';
-            $id = $obj->save();
-            
-            // Make sure we've created something
-            $this->assertTrue(is_string($id));
-            
-            // Save for later retrieval
-            self::$id = $id;
-            self::$uuid = $obj->getUUID();
-            self::$url = $obj->getUrl();
-            self::$object = $obj;
-            
             // Verify
-            $this->assertTrue(is_string(self::$id));
+            $this->assertFalse(empty(self::$id));
             $this->assertTrue(is_string(self::$uuid));
             $this->assertTrue(is_string(self::$url));
+            
+            $this->validateObject(self::$object);
         }
         
         /**
@@ -78,6 +79,13 @@ namespace Tests\Data {
         public function testGetAnyRecord() {
             $obj = \Idno\Core\site()->db()->getAnyRecord();
            
+            $this->assertFalse(empty($obj));
+            if (is_array($obj))
+            {
+                print "WARNING: getAnyRecord for this DataConcierge returned an Array. This is inconsistent, but we're converting.";
+                $obj = \Idno\Core\site()->db()->rowToEntity($obj);
+            }
+            
             $this->assertTrue(is_object($obj));
         }
         
@@ -155,11 +163,11 @@ namespace Tests\Data {
         /**
          * Helper function to validate object.
          */
-        protected function validateObject($obj) {
+        protected function validateObject(&$obj) {
             
             $this->assertTrue($obj instanceof \Idno\Entities\GenericDataItem);
-            $this->assertEquals(self::$object->getID(), $obj->getID());
-            $this->assertEquals(self::$id, $obj->getID());
+            $this->assertEquals("".self::$object->getID(), "".$obj->getID());
+            $this->assertEquals("".self::$id, "".$obj->getID());
             $this->assertEquals(self::$uuid, $obj->getUUID());
             $this->assertEquals(self::$url, $obj->getUrl());
         }

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -98,6 +98,26 @@ namespace Tests\Data {
             $this->validateObject($obj);
         }
         
+        public function testGetByMetadata() {
+            
+            $null = \Idno\Entities\GenericDataItem::get(['variable1' => 'not']);
+            $this->assertTrue(empty($null));
+            
+            $objs = \Idno\Entities\GenericDataItem::get(['variable1' => 'test']);
+            $this->assertTrue(is_array($objs));
+            $this->validateObject($objs[0]);
+        }
+        
+        public function testGetByMetadataMulti() {
+            
+            $null = \Idno\Entities\GenericDataItem::get(['variable1' => 'test', 'variable2' => 'not']);
+            $this->assertTrue(empty($null));
+            
+            $objs = \Idno\Entities\GenericDataItem::get(['variable1' => 'test', 'variable2' => 'test again']);
+            $this->assertTrue(is_array($objs));
+            $this->validateObject($objs[0]);
+        }
+        
         /**
          * Helper function to validate object.
          */

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -146,6 +146,7 @@ namespace Tests\Data {
             $search = \Idno\Core\site()->db()->createSearchArray("search obj");
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
+            $this->assertTrue(is_int($count));
             $this->assertTrue($count > 0);
             
             $feed  = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -146,10 +146,10 @@ namespace Tests\Data {
 
             $search = \Idno\Core\site()->db()->createSearchArray("test search obj");
 
-            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); var_export($search);  var_export($count); die('blerg');
-            $this->assertTrue(is_int($count));
-            $this->assertTrue($count > 0);
-            
+//            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); 
+//            $this->assertTrue(is_int($count));
+//            $this->assertTrue($count > 0);
+//            
             $feed  = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
             $this->assertTrue(is_array($feed));
             $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -146,7 +146,7 @@ namespace Tests\Data {
 
             $search = \Idno\Core\site()->db()->createSearchArray("test search obj");
 
-            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); var_export($search); var_export(\Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search)); die(var_export($count,true));
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); var_export($search); die(var_export(\Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search))); die(var_export($count,true));
             $this->assertTrue(is_int($count));
             $this->assertTrue($count > 0);
             

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -52,7 +52,7 @@ namespace Tests\Data {
         /**
          * Attempt to retrieve record by UUID.
          */
-        public function testGetByUUID() {
+        public function testGetRecordByUUID() {
             $this->validateObject(
                     \Idno\Core\site()->db()->rowToEntity(
                             \Idno\Core\site()->db()->getRecordByUUID(self::$uuid)
@@ -81,6 +81,24 @@ namespace Tests\Data {
         }
         
         /**
+         * Test getByID
+         */
+        public function testGetById() {
+            $obj = \Idno\Entities\GenericDataItem::getByID(self::$id);
+            
+            $this->validateObject($obj);
+        }
+        
+        /**
+         * Test getByID
+         */
+        public function testGetByUUID() {
+            $obj = \Idno\Entities\GenericDataItem::getByUUID(self::$uuid);
+            
+            $this->validateObject($obj);
+        }
+        
+        /**
          * Helper function to validate object.
          */
         protected function validateObject($obj) {
@@ -98,4 +116,4 @@ namespace Tests\Data {
     }
 }
 
-// get id, get uuid, get url, get by metadata, search
+//  get by metadata, search

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -163,7 +163,7 @@ namespace Tests\Data {
         /**
          * Helper function to validate object.
          */
-        protected function validateObject(&$obj) {
+        protected function validateObject($obj) {
             
             $this->assertTrue($obj instanceof \Idno\Entities\GenericDataItem);
             $this->assertEquals("".self::$object->getID(), "".$obj->getID());

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -119,6 +119,39 @@ namespace Tests\Data {
             $this->validateObject($objs[0]);
         }
         
+        public function testSearchShort() {
+            $search = array();
+
+            $search = \Idno\Core\site()->db()->createSearchArray("sear");
+
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
+            $this->assertTrue($count > 0);
+            
+            $feed  = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
+            $this->assertTrue(is_array($feed));
+            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));
+        }
+        
+        public function testSearchLong() {
+            $search = array();
+
+            $search = \Idno\Core\site()->db()->createSearchArray("search obj");
+
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
+            $this->assertTrue($count > 0);
+            
+            $feed  = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
+            $this->assertTrue(is_array($feed));
+            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));
+        }
+        
+        public function testCountObjects() {
+            $cnt = \Idno\Entities\GenericDataItem::count(['variable1' => 'test']);
+            
+            $this->assertTrue(is_int($cnt));
+            $this->assertTrue($cnt > 0);
+        }
+        
         /**
          * Helper function to validate object.
          */

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Data {
+    
+    /**
+     * Test the currently configured DataConcierge.
+     */
+    class DataConciergeTest extends Tests\KnownTestCase {
+        
+        public static $object;
+        
+        
+        
+        public static function tearDownAfterClass() {
+            if (static::$object) static::$object->delete();
+        }
+    }
+}
+

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -146,7 +146,7 @@ namespace Tests\Data {
 
             $search = \Idno\Core\site()->db()->createSearchArray("test search obj");
 
-            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); die(var_export($count,true));
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); var_export($search); var_export(\Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search)); die(var_export($count,true));
             $this->assertTrue(is_int($count));
             $this->assertTrue($count > 0);
             

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -146,7 +146,7 @@ namespace Tests\Data {
 
             $search = \Idno\Core\site()->db()->createSearchArray("test search obj");
 
-            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); var_export($search); die(var_export(\Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search))); die(var_export($count,true));
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); var_export($search); die(var_export(\Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search))); var_export($count); die('blerg');
             $this->assertTrue(is_int($count));
             $this->assertTrue($count > 0);
             

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -12,6 +12,8 @@ namespace Tests\Data {
         public static $id;
         public static $url;
         
+        public static $fts_object;
+        
         public static function setUpBeforeClass()
         {
             $obj = new \Idno\Entities\GenericDataItem();
@@ -142,17 +144,31 @@ namespace Tests\Data {
         }
         
         public function testSearchLong() {
+            
+            /** Create a FTS object, since MySQL FTS tables operate in natural language mode */
+            $obj = new \Idno\Entities\GenericDataItem();
+            $obj->setDatatype('UnitTestObject');
+            $obj->setTitle("This is a test obj to get around MySQL natural language mode");
+            $obj->variable1 = 'test';
+            $obj->variable2 = 'test again';
+            $id = $obj->save();
+            
+            self::$fts_object = $obj;
+            
+            
             $search = array();
 
-            $search = \Idno\Core\site()->db()->createSearchArray("test search obj");
+            $search = \Idno\Core\site()->db()->createSearchArray("language");
 
-//            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search); 
-//            $this->assertTrue(is_int($count));
-//            $this->assertTrue($count > 0);
-////            
-//            $feed  = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
-//            $this->assertTrue(is_array($feed)); 
-//            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
+            $this->assertTrue(is_int($count));
+            $this->assertTrue($count > 0);
+           
+            $feed  = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
+            $this->assertTrue(is_array($feed)); 
+            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));
+            
+            $obj->delete();
         }
         
         public function testCountObjects() {
@@ -176,6 +192,7 @@ namespace Tests\Data {
         
         public static function tearDownAfterClass() {
             if (static::$object) static::$object->delete();
+            if (static::$fts_object) static::$fts_object->delete();
         }
     }
 }

--- a/Tests/build/config_sqlite3.ini
+++ b/Tests/build/config_sqlite3.ini
@@ -1,0 +1,7 @@
+database = 'Sqlite3'
+dbname = '/tmp/known_unittest.db';
+
+sessionname = 'known_unittest'
+
+filesystem = 'local'
+uploadpath = '/tmp/'

--- a/schemas/sqlite3/sqlite3.sql
+++ b/schemas/sqlite3/sqlite3.sql
@@ -1,0 +1,120 @@
+
+--
+-- Base Known schema
+--
+
+--
+-- Table structure for table `config`
+--
+
+CREATE TABLE IF NOT EXISTS config (
+  uuid varchar(255) NOT NULL PRIMARY KEY,
+  _id varchar(32) NOT NULL,
+  owner varchar(255) NOT NULL,
+  entity_subtype varchar(64) NOT NULL,
+  created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  contents longblob NOT NULL,
+  search text NOT NULL
+);
+CREATE INDEX IF NOT EXISTS _id ON config (_id);
+CREATE INDEX IF NOT EXISTS owner ON config (owner);
+CREATE INDEX IF NOT EXISTS entity_subtype ON config (entity_subtype);
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `entities`
+--
+
+CREATE TABLE IF NOT EXISTS entities (
+  uuid varchar(255) NOT NULL PRIMARY KEY,
+  _id varchar(32) NOT NULL UNIQUE,
+  owner varchar(255) NOT NULL,
+  entity_subtype varchar(64) NOT NULL,
+  created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  contents longblob NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS owner ON entities (owner, created);
+CREATE INDEX IF NOT EXISTS entity_subtype ON entities (entity_subtype);
+
+CREATE VIRTUAL TABLE entities_search USING fts4 (
+  uuid varchar(255) NOT NULL PRIMARY KEY,
+  _id varchar(32) NOT NULL UNIQUE,
+  owner varchar(255) NOT NULL,
+  entity_subtype varchar(64) NOT NULL,
+  created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  search text NOT NULL
+);
+
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `reader`
+--
+
+CREATE TABLE IF NOT EXISTS reader (
+  uuid varchar(255) NOT NULL PRIMARY KEY,
+  _id varchar(32) NOT NULL UNIQUE,
+  owner varchar(255) NOT NULL,
+  entity_subtype varchar(64) NOT NULL,
+  created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  contents blob NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS owner ON reader (owner, created);
+CREATE INDEX IF NOT EXISTS entity_subtype ON reader (entity_subtype);
+
+CREATE VIRTUAL TABLE reader_search USING fts4 (
+  uuid varchar(255) NOT NULL PRIMARY KEY,
+  _id varchar(32) NOT NULL UNIQUE,
+  owner varchar(255) NOT NULL,
+  entity_subtype varchar(64) NOT NULL,
+  created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  search text NOT NULL
+);
+
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `metadata`
+--
+
+CREATE TABLE IF NOT EXISTS metadata (
+  entity varchar(255) NOT NULL,
+  _id varchar(32) NOT NULL,
+  collection varchar(64) NOT NULL,
+  name varchar(32) NOT NULL,
+  value text NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS entity ON metadata (entity,name);
+CREATE INDEX IF NOT EXISTS value ON metadata (value);
+CREATE INDEX IF NOT EXISTS name ON metadata (name);
+CREATE INDEX IF NOT EXISTS collection ON metadata (collection);
+CREATE INDEX IF NOT EXISTS _id ON metadata (_id);
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `versions`
+--
+
+CREATE TABLE IF NOT EXISTS versions (
+  label varchar(32) NOT NULL PRIMARY KEY,
+  value varchar(10) NOT NULL
+);
+
+--
+-- Session handling table
+--
+
+CREATE TABLE IF NOT EXISTS session (
+    session_id varchar(255) NOT NULL PRIMARY KEY,
+    session_value text NOT NULL,
+    session_time int(11) NOT NULL
+);
+
+REPLACE INTO `versions` VALUES('schema', '2015051602');

--- a/schemas/sqlite3/sqlite3.sql
+++ b/schemas/sqlite3/sqlite3.sql
@@ -40,10 +40,6 @@ CREATE INDEX IF NOT EXISTS entity_subtype ON entities (entity_subtype);
 
 CREATE VIRTUAL TABLE entities_search USING fts4 (
   uuid varchar(255) NOT NULL PRIMARY KEY,
-  _id varchar(32) NOT NULL UNIQUE,
-  owner varchar(255) NOT NULL,
-  entity_subtype varchar(64) NOT NULL,
-  created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   search text NOT NULL
 );
 
@@ -68,10 +64,6 @@ CREATE INDEX IF NOT EXISTS entity_subtype ON reader (entity_subtype);
 
 CREATE VIRTUAL TABLE reader_search USING fts4 (
   uuid varchar(255) NOT NULL PRIMARY KEY,
-  _id varchar(32) NOT NULL UNIQUE,
-  owner varchar(255) NOT NULL,
-  entity_subtype varchar(64) NOT NULL,
-  created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   search text NOT NULL
 );
 


### PR DESCRIPTION
This patch does a bunch (below) but primarily it introduces support for SQLite file based sql storage.

I did this because SQL/Mongo has quite a lot of overhead in terms of both complexity and resources compared to straight files, and often seemed overkill for folk running Known on low powered devices (embedded / single use sites / simple hosting etc).

It provides a nice fallback, a useful tool for quickly building test builds, as well as reduces some of the admin overhead for folk.

I've got plans for this for some IoT type stuff, and was meaning to do it for a while, but it was prompted by some guy on IRC who's SD card bought the farm, and I figured a SQLite db might be more appropriate.

Anyway, this patch does:

* Introduces SQLite dataconcierge 
* Adds SQLite to travis builds
* Introduces a dataconciege test to build which tests mysql, sqlite and mongo builds
* Fixes a few bugs exposed by these unit tests
* Exposes some inconsistencies between mongo and mysql (#978)

Anyway, it seems to be fairly stable, but should probably be considered "experimental" until the path gets trodden a little more.