### PR TITLE
Fixed font-awesome class for github icon

### DIFF
--- a/templates/default/entity/User/profile/fields.tpl.php
+++ b/templates/default/entity/User/profile/fields.tpl.php
@@ -22,7 +22,7 @@
                 switch($host) {
 
                     case 'twitter.com':         $icon = 'fa fa-twitter'; break;
-                    case 'github.com':          $icon = 'a fa-github-square'; break;
+                    case 'github.com':          $icon = 'fa fa-github-square'; break;
                     case 'fb.com':
                     case 'facebook.com':        $icon = 'fa fa-facebook'; break;
                     case 'plus.google.com':     $icon = 'fa fa-google-plus'; break;


### PR DESCRIPTION
Github icon needs class `fa` instead of `a` to be a font awesome icon. Was just a typo I guess.