### PR TITLE
Initialise CSRF token

### DIFF
--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -106,6 +106,10 @@
                     $this->plugins = $this->default_plugins;
                 }
 
+                // If we don't have a site secret, create it
+                if (!isset($this->site_secret))
+                    $this->site_secret = hash('sha256', mt_rand() . microtime(true));
+                
                 date_default_timezone_set($this->timezone);
                 //setlocale(LC_ALL, 'en_US.UTF8');
             }
@@ -265,10 +269,6 @@
                 unset($array['disable_ssl_verify']);
                 unset($array['known_hub']);
                 unset($array['directloadplugins']);
-
-                // If we don't have a site secret, create it
-                if (!isset($array['site_secret']))
-                    $array['site_secret'] = hash('sha256', mt_rand() . microtime(true));
 
                 if (\Idno\Core\site()->db()->saveRecord('config', $array)) {
                     $this->init();

--- a/Idno/Core/Template.php
+++ b/Idno/Core/Template.php
@@ -35,6 +35,8 @@
                     $this->detectTemplateType();
                 }
 
+                \Bonita\Main::siteSecret(\Idno\Core\site()->config()->site_secret);
+                
                 return parent::__construct($template);
             }
 

--- a/Idno/Core/Template.php
+++ b/Idno/Core/Template.php
@@ -35,6 +35,7 @@
                     $this->detectTemplateType();
                 }
 
+                assert('\Idno\Core\site()->config()->site_secret /* Site secret not set */');
                 \Bonita\Main::siteSecret(\Idno\Core\site()->config()->site_secret);
                 
                 return parent::__construct($template);


### PR DESCRIPTION
Actually initialise Bonita's CSRF secret, so action tokens can't be trivially guessed.