### PR TITLE
Better Secret/crypto

### DIFF
--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -106,12 +106,6 @@
                 if (!empty($this->default_plugins)) {
                     $this->plugins = $this->default_plugins;
                 }
-
-                // If we don't have a site secret, create it
-                if (!isset($this->site_secret)) {
-                    $token_generator = new TokenProvider();
-                    $this->site_secret = bin2hex($token_generator->generateToken(64));
-                }
                 
                 date_default_timezone_set($this->timezone);
                 //setlocale(LC_ALL, 'en_US.UTF8');
@@ -163,7 +157,7 @@
                     $this->config         = array_merge($this->config, $this->ini_config);
                     $this->default_config = false;
                 }
-
+                
             }
 
             /**
@@ -318,6 +312,13 @@
                     }
                 }
                 $this->loadIniFiles();
+                
+                // If we don't have a site secret, create it
+                if (!isset($this->site_secret)) {
+                    $token_generator = new TokenProvider(); 
+                    $this->site_secret = bin2hex($token_generator->generateToken(64));
+                    $this->save();
+                }
             }
 
             /**

--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -108,8 +108,10 @@
                 }
 
                 // If we don't have a site secret, create it
-                if (!isset($this->site_secret))
-                    $this->site_secret = hash('sha256', mt_rand() . microtime(true));
+                if (!isset($this->site_secret)) {
+                    $token_generator = new TokenProvider();
+                    $this->site_secret = bin2hex($token_generator->generateToken(64));
+                }
                 
                 date_default_timezone_set($this->timezone);
                 //setlocale(LC_ALL, 'en_US.UTF8');

--- a/Idno/Core/TokenProvider.php
+++ b/Idno/Core/TokenProvider.php
@@ -9,9 +9,14 @@
 
             function generateToken($length)
             {
+                $strength = true;
+                $bytes = openssl_random_pseudo_bytes($length, $strength);
 
-                return openssl_random_pseudo_bytes($length);
-
+                if (!$strength) {
+                    throw new \Exception("Token was generated using an a cryptographically weak algorithm, this probably means your version of OpenSSL is broken or very old.");
+                }
+                
+                return $bytes;
             }
 
         }

--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -33,7 +33,7 @@
                 
                 // Check installed extensions
                 $basics['report']['php-extensions'] = ['status' => 'Ok', 'message' => 'PHP Extension(s): '];
-                foreach (['curl','date','dom','gd','json','libxml','mbstring','mysql','reflection','session','simplexml'] as $extension) {
+                foreach (['curl','date','dom','gd','json','libxml','mbstring','mysql','reflection','session','simplexml', 'openssl'] as $extension) {
                     if (!extension_loaded($extension)) {
                         $basics['report']['php-extensions']['message'] .= "$extension, ";
                         $basics['report']['php-extensions']['status'] = 'Failure';

--- a/Tests/CryptoTest.php
+++ b/Tests/CryptoTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests {
+    
+    /**
+     * Test basic crypto functions.
+     */
+    class CryptoTest extends KnownTestCase {
+        
+        public function testOpenSSLExists() {
+            $this->assertTrue(function_exists('openssl_random_pseudo_bytes'));
+        }
+        
+        public function testStrong() {
+            $bytes = openssl_random_pseudo_bytes(32, $cstrong);
+            
+            $this->assertTrue($cstrong);
+        }
+    }
+}

--- a/Tests/CryptoTest.php
+++ b/Tests/CryptoTest.php
@@ -7,14 +7,27 @@ namespace Tests {
      */
     class CryptoTest extends KnownTestCase {
         
+        /**
+         * SSL Functions exists.
+         */
         public function testOpenSSLExists() {
             $this->assertTrue(function_exists('openssl_random_pseudo_bytes'));
         }
         
+        /**
+         * OpenSSL isn't broken on this system
+         */
         public function testStrong() {
             $bytes = openssl_random_pseudo_bytes(32, $cstrong);
             
             $this->assertTrue($cstrong);
+        }
+        
+        /**
+         * Site secret initialised and reasonably long. (Note, we can't check entropy here)
+         */
+        public function testSiteSecret() {
+            $this->assertTrue((strlen(\Idno\Core\site()->config()->site_secret)>=64));
         }
     }
 }

--- a/Tests/EnvironmentTest.php
+++ b/Tests/EnvironmentTest.php
@@ -15,7 +15,7 @@
              * Assert that required extension modules are present
              */
             function testExtensions() {
-                foreach (['curl','date','dom','gd','json','libxml','mbstring','mysql','reflection','session','simplexml'] as $extension) {
+                foreach (['curl','date','dom','gd','json','libxml','mbstring','mysql','reflection','session','simplexml', 'openssl'] as $extension) {
                     $this->assertTrue(extension_loaded($extension));
                 }
             }

--- a/warmup/requirements.php
+++ b/warmup/requirements.php
@@ -118,7 +118,7 @@
                 <?php
                 }
 
-                $extensions = array('curl','date','dom','gd','json','libxml','mbstring','mysql','reflection','session','simplexml');
+                $extensions = array('curl','date','dom','gd','json','libxml','mbstring','mysql','reflection','session','simplexml', 'openssl');
                 asort($extensions);
                 foreach($extensions as $extension) {
                     if (extension_loaded($extension)) {


### PR DESCRIPTION
* Asserts OpenSSL requirement (is required by core functions, but this is not stated)
* Replaces site secret generation with a cryptographically secure token (double hashing = bad) + generates more entropy.
* Fixes a signup error introduced by #984 