### PR TITLE
Generate API key with some actual random bytes.

### DIFF
--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -302,8 +302,9 @@
              */
             function generateAPIkey()
             {
-                $apikey       = md5(time() . \Idno\Core\site()->config()->host . \Idno\Core\site()->config()->email . rand(0, 999999) . rand(0, 999999) . microtime());
-                $apikey       = strtolower(substr(base64_encode($apikey), 12, 16));
+                $token = new \Idno\Core\TokenProvider();
+                
+                $apikey       = strtolower(substr(base64_encode($token->generateToken(32)), 12, 16));
                 $this->apikey = $apikey;
                 $this->save();
 


### PR DESCRIPTION
Generate the API key from an actual entropic source.  

Things still to consider:

* [ ] Why are we artificially reducing the entropy of the key to 16 bytes base 64 encoded
* [ ] API keys are passwords, so I think we need to move to Oauth2, but at the very least we need to increase the entropy of the key and the hash it's fed into.