### PR TITLE
Bridgy interactions bugfixes

### DIFF
--- a/IdnoPlugins/Bridgy/templates/default/bridgy/account.tpl.php
+++ b/IdnoPlugins/Bridgy/templates/default/bridgy/account.tpl.php
@@ -28,10 +28,10 @@
 
         <div class="col-md-6 col-md-offset-1">
         <?php if ($vars['facebook_enabled']) { ?>
-            <form action="https://www.brid.gy/facebook/start?feature=listen&callback=<?=urlencode(\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/')?>" method="post">
-            <input type="hidden" name="feature" value="listen"></input>
-            <input type="hidden" name="key" value="<?=$vars['facebook_key']?>"></input>
-            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/disabled/?service=facebook'?>">
+            <form action="https://www.brid.gy/delete/start" method="post">
+            <input type="hidden" name="feature" value="listen" />
+            <input type="hidden" name="key" value="<?=$vars['facebook_key']?>" />
+            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/disabled/?service=facebook'?>" />
             <p>
                 <button class="connect fb connected">Facebook + Bridgy connected</button>
             </p>
@@ -41,8 +41,9 @@
         </form>
         <?php } else { ?>
         <form action="https://www.brid.gy/facebook/start" method="post">
-            <input type="hidden" name="feature" value="listen"></input>
-            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/enabled/?service=facebook'?>">
+            <input type="hidden" name="feature" value="listen" />
+            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/enabled/?service=facebook'?>" />
+            <input type="hidden" name="user_url" value="<?=\Idno\Core\site()->config()->getDisplayURL()?>" />
             <p>
                 <button class="connect fb">
                 Activate Facebook + Bridgy</button>
@@ -55,9 +56,9 @@
 
         <?php if ($vars['twitter_enabled']) { ?>
         <form action="https://www.brid.gy/delete/start" method="post">
-            <input type="hidden" name="feature" value="listen"></input>
-            <input type="hidden" name="key" value="<?=$vars['twitter_key']?>"></input>
-            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/disabled/?service=twitter'?>">
+            <input type="hidden" name="feature" value="listen" />
+            <input type="hidden" name="key" value="<?=$vars['twitter_key']?>" />
+            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/disabled/?service=twitter'?>" />
             <p>
                 <button class="connect fb connected">Twitter + Bridgy connected</button>
             </p>
@@ -67,8 +68,9 @@
         </form>
         <?php } else { ?>
         <form action="https://www.brid.gy/twitter/start" method="post">
-            <input type="hidden" name="feature" value="listen"></input>
-            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/enabled/?service=twitter'?>">
+            <input type="hidden" name="feature" value="listen" />
+            <input type="hidden" name="callback" value="<?=\Idno\Core\site()->config()->getDisplayURL() . 'account/bridgy/enabled/?service=twitter'?>" />
+            <input type="hidden" name="user_url" value="<?=\Idno\Core\site()->config()->getDisplayURL()?>" />
             <p>
                 <button class="connect tw">
                 Activate Twitter + Bridgy</button>

--- a/IdnoPlugins/Bridgy/templates/default/bridgy/facebook.tpl.php
+++ b/IdnoPlugins/Bridgy/templates/default/bridgy/facebook.tpl.php
@@ -3,7 +3,7 @@
     <div class="col-md-12" style="margin-top: 2em">
 
         <p>
-            <a href="https://brid.gy/facebook/start?feature=listen&callback=<?=urlencode(\Idno\Core\site()->config()->getDisplayURL() . 'account/facebook/')?>" ><icon class="icon-plus"></icon> Connect Brid.gy</a><br>
+            <a href="https://brid.gy/facebook/start?feature=listen&amp;callback=<?=urlencode(\Idno\Core\site()->config()->getDisplayURL() . 'account/facebook/')?>&amp;user_url=<?=urlencode(\Idno\Core\site()->config()->getDisplayURL())?>" ><icon class="icon-plus"></icon> Connect Brid.gy</a><br>
             <small>
                 Brid.gy imports comments and likes from Facebook and stores them on your Known site.
             </small>

--- a/IdnoPlugins/Bridgy/templates/default/bridgy/twitter.tpl.php
+++ b/IdnoPlugins/Bridgy/templates/default/bridgy/twitter.tpl.php
@@ -3,7 +3,7 @@
     <div class="col-md-10 col-md-offset-1" style="margin-top: 2em">
 
         <p>
-            <a href="https://brid.gy/twitter/start?feature=listen&callback=<?=urlencode(\Idno\Core\site()->config()->getDisplayURL() . 'account/twitter/')?>" class="btn btn-primary">Import replies and retweets</a><br>
+            <a href="https://brid.gy/twitter/start?feature=listen&amp;callback=<?urlencode(\Idno\Core\site()->config()->getDisplayURL() . 'account/twitter/')?>&amp;user_url=<?urlencode(\Idno\Core\site()->getDisplayURL())?>" class="btn btn-primary">Import replies and retweets</a><br>
             <small>
                 Brid.gy imports replies, favorites and retweets from Twitter and stores them on your Known site.
             </small>


### PR DESCRIPTION
- don't require users to put their Known url in their Twitter/Facebook profile.
  Send the user url along with the authorization request (I thought we had
  already done this??)
- fix typo on delete Facebook form action -- should be delete/start instead of
  facebook/start

I don't think twitter.tpl.php and facebook.tpl.php are used anywhere?