### PR TITLE
Some simple script kiddie spam/login protection

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -811,6 +811,20 @@
             }
 
             /**
+             * Get the referrer information for the current page.
+             */
+            function getReferrer() {
+                
+                $referrer = $_SERVER['HTTP_REFERER'];
+                
+                if (empty($referrer)) {
+                     // TODO: Try other ways - e.g. for nginx
+                }
+                
+                return $referrer;
+            }
+            
+            /**
              * Detects whether the current web browser accepts the given content type.
              * @param string $contentType The MIME content type.
              * @return bool

--- a/Idno/Pages/Session/Login.php
+++ b/Idno/Pages/Session/Login.php
@@ -38,7 +38,8 @@
                     $fwd = \Idno\Core\site()->config()->url;
                 }
 
-                if (empty($this->getReferrer())) {
+                $referrer = $this->getReferrer();
+                if (empty($referrer)) {
                     $this->deniedContent();
                 }
                 

--- a/Idno/Pages/Session/Login.php
+++ b/Idno/Pages/Session/Login.php
@@ -38,6 +38,10 @@
                     $fwd = \Idno\Core\site()->config()->url;
                 }
 
+                if (empty($this->getReferrer())) {
+                    $this->deniedContent();
+                }
+                
                 if ($user = \Idno\Entities\User::getByHandle($this->getInput('email'))) {
                 } else if ($user = \Idno\Entities\User::getByEmail($this->getInput('email'))) {
                 } else {

--- a/IdnoPlugins/Comments/Pages/Post.php
+++ b/IdnoPlugins/Comments/Pages/Post.php
@@ -23,7 +23,8 @@
                     $this->deniedContent();
                 }
                 
-                if (empty($this->getReferrer())) {
+                $referrer = $this->getReferrer();
+                if (empty($referrer)) {
                     $this->deniedContent();
                 }
                 

--- a/IdnoPlugins/Comments/Pages/Post.php
+++ b/IdnoPlugins/Comments/Pages/Post.php
@@ -23,6 +23,10 @@
                     $this->deniedContent();
                 }
                 
+                if (empty($this->getReferrer())) {
+                    $this->deniedContent();
+                }
+                
                 if (!empty($body) && !empty($name) && !empty($validator)) {
                     if ($object = Entity::getByUUID($validator)) {
                         if ($url = Webservice::sanitizeURL($url)) {

--- a/IdnoPlugins/Comments/Pages/Post.php
+++ b/IdnoPlugins/Comments/Pages/Post.php
@@ -16,8 +16,13 @@
                 $body      = strip_tags($this->getInput('body'));
                 $name      = strip_tags($this->getInput('name'));
                 $url       = trim($this->getInput('url'));
+                $url2       = trim($this->getInput('url-2'));
                 $validator = $this->getInput('validator');
 
+                if (!empty($url2)) {
+                    $this->deniedContent();
+                }
+                
                 if (!empty($body) && !empty($name) && !empty($validator)) {
                     if ($object = Entity::getByUUID($validator)) {
                         if ($url = Webservice::sanitizeURL($url)) {

--- a/IdnoPlugins/Comments/templates/default/comments/public/form.tpl.php
+++ b/IdnoPlugins/Comments/templates/default/comments/public/form.tpl.php
@@ -13,6 +13,7 @@
             <div class="col-md-11 idno-comment-container" id="comment-form">
                 <input type="text" name="name" class="form-control" placeholder="Your name" required>
                 <input type="text" name="url" class="form-control" placeholder="Your website address">
+                <input type="text" name="url-2" class="form-control" placeholder="You probably shouldn't fill this in" style="display: none;" >
                 <div id="extrafield" style="display:none"></div>
                 <textarea name="body" placeholder="Add a comment ..." class="form-control mentionable"></textarea>
 


### PR DESCRIPTION
* Sets a booby-trap logged out comment field
* Checks for referrer on login and logged out comment

Both of these do much to stop the basic script kiddie attack scripts.