### PR TITLE
Out of band headers are hard; use in-band data for api forwarding squish.

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -505,13 +505,13 @@
                     }
                     */
 
-                    if (!\Idno\Core\site()->session()->isAPIRequest() || $this->response == 200) {
-                        header('Location: ' . $location);
-                    }
-                    elseif (\Idno\Core\site()->session()->isAPIRequest()) {
+                    if (\Idno\Core\site()->session()->isAPIRequest()) {
                         echo json_encode([
                             'location' => $location
                         ]); 
+                    }
+                    elseif (!\Idno\Core\site()->session()->isAPIRequest() || $this->response == 200) {
+                        header('Location: ' . $location);
                     }
                     
                     if ($exit) {


### PR DESCRIPTION
Update:

* Avoids #1036 
* Closes #1038 