### PR TITLE
Invite entropy

### DIFF
--- a/Idno/Core/TokenProvider.php
+++ b/Idno/Core/TokenProvider.php
@@ -7,6 +7,12 @@
         class TokenProvider extends Component
         {
 
+            /**
+             * Generate a cryptographically secure random token.
+             * @param type $length Length in bytes
+             * @return bytes
+             * @throws \Exception If cryptographic functions are not strong enough.
+             */
             function generateToken($length)
             {
                 $strength = true;
@@ -17,6 +23,15 @@
                 }
 
                 return $bytes;
+            }
+            
+            /**
+             * Generate a cryptographically secure random token, returning it as a HEX encoded string.
+             * Note: Hex is two chars per byte, so $length = 16 would produce a 32 char string (same length as md5(rand()), but more secure)
+             * @param int $length Length in bytes
+             */
+            function generateHexToken($length) {
+                return bin2hex($this->generateToken($length));
             }
 
         }

--- a/Idno/Entities/Invitation.php
+++ b/Idno/Entities/Invitation.php
@@ -26,12 +26,9 @@
              */
             function generateCode()
             {
-                if (\Idno\Core\site()->session()->isLoggedOn()) {
-                    $email = \Idno\Core\site()->session()->currentUser()->email;
-                } else {
-                    $email = base64_encode(time() . rand(0, 99999));
-                }
-                $this->code = md5(time() . rand(0, 9999) . $email);
+                $token = new \Idno\Core\TokenProvider();
+                
+                $this->code = $token->generateHexToken(16);
             }
 
             /**


### PR DESCRIPTION
* Improves / documents TokenProvider
* Removes another instance of artificially reducing entropy where we don't have to. From my code comment: 

> Unless you're planning to do validation on the token based on it's construction (e.g. comparing a password against a hashed and salted password), there is no benefit to artificially reducing entropy by feeding deterministic and computable values into the hash.

> In this instance what you're doing is feeding time() (easily determined by the attacker) + email (supplied by the attacker) + a random value with highly limited scope. Additionally, where email isn't there, you hash a hash, which adds no extra entropy.

> True, an invitation must exist, so it's not actually all that of a problem here, but 1) we have a token, so use it. 2) it's a smaller function, 3) perhaps most importantly, we should get out of the habit of reducing entropy when we don't need to.