### PR TITLE
Checks content type before MF2 mining on share

### DIFF
--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -56,7 +56,7 @@
                         curl_setopt($curl_handle, CURLOPT_POSTFIELDS, $params);
                         break;
                     case 'head':
-                        curl_setopt($curl_handle, CURLOPT_NOBODY);
+                        curl_setopt($curl_handle, CURLOPT_NOBODY, true);
                     case 'get':
                     default:
                         $req = "";

--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -55,6 +55,8 @@
                         curl_setopt($curl_handle, CURLOPT_CUSTOMREQUEST, 'PUT'); // Override request type
                         curl_setopt($curl_handle, CURLOPT_POSTFIELDS, $params);
                         break;
+                    case 'head':
+                        curl_setopt($curl_handle, CURLOPT_NOBODY);
                     case 'get':
                     default:
                         $req = "";
@@ -298,6 +300,19 @@
             static function get($endpoint, array $params = null, array $headers = null)
             {
                 return self::send('get', $endpoint, $params, $headers);
+            }
+            
+            
+            /**
+             * Send a web services HEAD request to a specified URI endpoint
+             * @param string $endpoint The URI to send the HEAD request to
+             * @param array $params Optionally, an array of parameters to send (keys are the parameter names)
+             * @param array $headers Optionally, an array of headers to send with the request (keys are the header names)
+             * @return array
+             */
+            static function head($endpoint, array $params = null, array $headers = null)
+            {
+                return self::send('head', $endpoint, $params, $headers);
             }
 
             /**

--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -67,7 +67,6 @@
                             $req = $params;
                         }
 
-                        curl_setopt($curl_handle, CURLOPT_HTTPGET, true);
                         if (strpos($endpoint, '?') !== false) {
                             $endpoint .= '&' . $req;
                         } else {

--- a/Idno/Pages/Entity/Share.php
+++ b/Idno/Pages/Entity/Share.php
@@ -28,16 +28,26 @@
                 if (!in_array($type, array('note', 'reply', 'rsvp', 'like', 'bookmark'))) {
                     $share_type = 'note';
 
-                    if ($content = \Idno\Core\Webservice::get($url)) {
-                        if ($mf2 = \Idno\Core\Webmention::parseContent($content['content'])) {
-                            if (!empty($mf2['items'])) {
-                                foreach ($mf2['items'] as $item) {
-                                    if (!empty($item['type'])) {
-                                        if (in_array('h-entry', $item['type'])) {
-                                            $share_type = 'reply';
-                                        }
-                                        if (in_array('h-event', $item['type'])) {
-                                            $share_type = 'rsvp';
+                    // Probe to see if this is something we can MF2 parse, before we do
+                    $headers = [];
+                    if ($head = \Idno\Core\Webservice::head($url)) {
+                        $headers = http_parse_headers($head['header']);
+                    }
+                    
+                    // Only MF2 Parse supported types
+                    if (preg_match('/text\/(html|plain)+/', $headers['Content-Type'])) {
+                        
+                        if ($content = \Idno\Core\Webservice::get($url)) {
+                            if ($mf2 = \Idno\Core\Webmention::parseContent($content['content'])) {
+                                if (!empty($mf2['items'])) {
+                                    foreach ($mf2['items'] as $item) {
+                                        if (!empty($item['type'])) {
+                                            if (in_array('h-entry', $item['type'])) {
+                                                $share_type = 'reply';
+                                            }
+                                            if (in_array('h-event', $item['type'])) {
+                                                $share_type = 'rsvp';
+                                            }
                                         }
                                     }
                                 }

--- a/Idno/shims.php
+++ b/Idno/shims.php
@@ -25,3 +25,43 @@
         }
 
     }
+
+    // Shim for missing pecl function from https://php.net/manual/en/function.http-parse-headers.php#112986
+    if (!function_exists('http_parse_headers'))
+    {
+        function http_parse_headers($raw_headers)
+        {
+            $headers = array();
+            $key = ''; 
+
+            foreach(explode("\n", $raw_headers) as $i => $h)
+            {
+                $h = explode(':', $h, 2);
+
+                if (isset($h[1]))
+                {
+                    if (!isset($headers[$h[0]]))
+                        $headers[$h[0]] = trim($h[1]);
+                    elseif (is_array($headers[$h[0]]))
+                    {
+                        $headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1]))); 
+                    }
+                    else
+                    {
+                        $headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1])));
+                    }
+
+                    $key = $h[0]; 
+                }
+                else 
+                { 
+                    if (substr($h[0], 0, 1) == "\t") 
+                        $headers[$key] .= "\r\n\t".trim($h[0]); 
+                    elseif (!$key) 
+                        $headers[0] = trim($h[0]);trim($h[0]); 
+                } 
+            }
+
+            return $headers;
+        }
+    }


### PR DESCRIPTION
MF2 only called for supported file types, which avoids out of memory error when processing a non-supported type (like MP3 or video)