### PR TITLE
Backport for older phpUnit

### DIFF
--- a/Tests/Data/ConfigTest.php
+++ b/Tests/Data/ConfigTest.php
@@ -12,7 +12,7 @@ namespace Tests\Data {
          * Ensure that config collection has been correctly configured.
          */
         public function testSave() {
-            $this->assertNotFalse(\Idno\Core\site()->config()->save());
+            $this->assertTrue(\Idno\Core\site()->config()->save()!==false);
         }
         
         


### PR DESCRIPTION
Ubuntu for some reason comes bundled with a really old version of PHP Unit.