### PR TITLE
Follow redirections on file_get_contents()

### DIFF
--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -283,6 +283,19 @@
             {
                 $result = self::get($url);
 
+                // Checking for redirects (HTTP codes 301 and 302)
+                $redirect_count = 0;
+				while (($result['response'] == 302) || ($result['response'] == 301)) {
+				    $redirect_count += 1;
+				    if ($redirect_count >= 3) {
+				        // We have followed 3 redirections already…
+				        // This may be a redirect loop so we'd better drop it already.
+				        return false;
+				    }
+				    // The redirection URL is the "location" field of the header
+				    $result = self::get(http_parse_headers($result['header'])["location"]);
+				}
+
                 if ($result['error'] == "")
                     return $result['content'];
 


### PR DESCRIPTION
Quickfix for #753.

Adds a block to Webservice.php:file_get_contents() to check for redirections. Stops after 3 redirections to prevent redirect loops.