### PR TITLE
Cleaner status imports from WP

### DIFF
--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -413,13 +413,20 @@
                                 }
 
                                 self::importImagesFromBodyHTML($body, parse_url($item['link'], PHP_URL_HOST));
+                                if (empty($item['title']) && strlen($body) < 600) {
+	                                $object = new \IdnoPlugins\Status\Status();
+	                                $object->created = $published;
+	                                $object->body    = ($body);
+	                                $object->save(true);
 
-                                $object = new \IdnoPlugins\Text\Entry();
-                                $object->setTitle(html_entity_decode($title));
-                                $object->created = $published;
-                                $object->body    = ($body);
-                                $object->save(true);
+                                } else {
 
+	                                $object = new \IdnoPlugins\Text\Entry();
+	                                $object->setTitle(html_entity_decode($title));
+	                                $object->created = $published;
+	                                $object->body    = ($body);
+	                                $object->save(true);
+                                }
                             }
 
                         }


### PR DESCRIPTION
When a post coming from wordpress is less than 500 characters and has no title, treat it as a status update, rather than a full-on post.