### PR TITLE
sort out order of plugin registration and user auth

### DIFF
--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -35,6 +35,13 @@
             public $reader;
             public $cache;
 
+            function __construct()
+            {
+                parent::__construct();
+                // auth the user after all the plugins and pages have registered so they can respond to events
+                $this->session()->tryAuthUser();
+            }
+
             function init()
             {
                 self::$site       = $this;
@@ -105,7 +112,7 @@
                 $this->logging      = new Logging($this->config->log_level);
                 $this->reader       = new Reader();
                 $this->helper_robot = new HelperRobot();
-                
+
                 // Attempt to create a cache object, making use of support present on the system
                 if (extension_loaded('xcache')) {
                     $this->cache = new \Idno\Caching\XCache();
@@ -133,9 +140,7 @@
                     \Idno\Core\Idno::site()->known_hub->connect();
                 }
 
-                site()->session()->APIlogin();
                 User::registerEvents();
-                site()->session()->refreshCurrentSessionuser();
             }
 
             /**
@@ -254,12 +259,12 @@
             {
                 return $this->logging;
             }
-            
+
             /**
              * Return a persistent cache object.
              * @return \Idno\Caching\PersistentCache
              */
-            function &cache() 
+            function &cache()
             {
                 return $this->cache;
             }

--- a/IdnoPlugins/IndiePub/Main.php
+++ b/IdnoPlugins/IndiePub/Main.php
@@ -1,10 +1,22 @@
 <?php
 
     namespace IdnoPlugins\IndiePub {
+        use IdnoPlugins\IndiePub\Pages\IndieAuth\Token;
 
         class Main extends \Idno\Common\Plugin {
-            function registerPages() {
 
+
+            function registerEventHooks()
+            {
+                \Idno\Core\site()->addEventHook('user/auth/request', function(\Idno\Core\Event $event) {
+                    if ($user = \IdnoPlugins\IndiePub\Main::authenticate()) {
+                        $event->setResponse($user);
+                    }
+                });
+            }
+
+            function registerPages()
+            {
                 \Idno\Core\Idno::site()->addPageHandler('/indieauth/auth/?', '\IdnoPlugins\IndiePub\Pages\IndieAuth\Auth',true);
                 \Idno\Core\Idno::site()->addPageHandler('/indieauth/approve/?', '\IdnoPlugins\IndiePub\Pages\IndieAuth\Approve',true);
                 \Idno\Core\Idno::site()->addPageHandler('/indieauth/token/?', '\IdnoPlugins\IndiePub\Pages\IndieAuth\Token',true);
@@ -15,6 +27,44 @@
                 header('Link: <'.\Idno\Core\Idno::site()->config()->getURL().'indieauth/token>; rel="token_endpoint"');
                 header('Link: <'.\Idno\Core\Idno::site()->config()->getURL().'micropub/endpoint>; rel="micropub"');
             }
+
+            /**
+             * Check that this token is either a user token or the
+             * site's API token, and auth the current request for that user if so.
+             *
+             * @return \Idno\Entities\User user on success
+             */
+            private static function authenticate()
+            {
+                $access_token = \Idno\Core\Idno::site()->currentPage()->getInput('access_token');
+                $headers = \Idno\Core\Idno::site()->currentPage()->getallheaders();
+                if (!empty($headers['Authorization'])) {
+                    $token = $headers['Authorization'];
+                    $token = trim(str_replace('Bearer', '', $token));
+                } else if ($token = \Idno\Core\Idno::site()->currentPage()->getInput('access_token')) {
+                    $token = trim($token);
+                }
+
+                if (!empty($token)) {
+                    \Idno\Core\Idno::site()->session()->setIsAPIRequest(true);
+                    $found = Token::findUserForToken($token);
+                    if (!empty($found)) {
+                        $user = $found['user'];
+                        \Idno\Core\Idno::site()->session()->refreshSessionUser($user);
+                        return $user;
+                    }
+                    $user = \Idno\Entities\User::getOne(array('admin' => true));
+                    if ($token == $user->getAPIkey()) {
+                        \Idno\Core\Idno::site()->session()->refreshSessionUser($user);
+                        return $user;
+                    }
+                }
+
+                return false;
+            }
+
+
+
         }
 
     }

--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -11,152 +11,115 @@
 
             function get($params = array())
             {
-
-                $headers = $this->getallheaders();
-                if (!empty($headers['Authorization'])) {
-                    $token = $headers['Authorization'];
-                    $token = trim(str_replace('Bearer', '', $token));
-                } else if ($token = $this->getInput('access_token')) {
-                    $token = trim($token);
-                }
-
-                if ($this->validateToken($token)) {
-                    if ($query = trim($this->getInput('q'))) {
-                        switch ($query) {
-                            case 'syndicate-to':
-                                echo json_encode([
-                                    'syndicate-to'          => \Idno\Core\Idno::site()->syndication()->getServiceAccountStrings(),
-                                    'syndicate-to-expanded' => \Idno\Core\Idno::site()->syndication()->getServiceAccountData()
-                                ], JSON_PRETTY_PRINT);
-                                break;
+                $this->gatekeeper();
+                if ($query = trim($this->getInput('q'))) {
+                    switch ($query) {
+                    case 'syndicate-to':
+                        if ($this->isAcceptedContentType('application/json')) {
+                            header('Content-Type: application/json');
+                            echo json_encode([
+                                'syndicate-to'          => \Idno\Core\Idno::site()->syndication()->getServiceAccountStrings(),
+                                'syndicate-to-expanded' => \Idno\Core\Idno::site()->syndication()->getServiceAccountData(),
+                            ], JSON_PRETTY_PRINT);
+                        } else {
+                            echo http_build_query([
+                                "syndicate-to" => \Idno\Core\Idno::site()->syndication()->getServiceAccountStrings(),
+                            ]);
                         }
+                        break;
                     }
-                }
-                else {
-                    $this->setResponse(403);
-                    echo '?';
                 }
             }
 
             function post()
             {
+                $this->gatekeeper();
+                // If we're here, we're authorized
 
-                $headers = $this->getallheaders();
-                if (!empty($headers['Authorization'])) {
-                    $token = $headers['Authorization'];
-                    $token = trim(str_replace('Bearer', '', $token));
-                } else if ($token = $this->getInput('access_token')) {
-                    $token = trim($token);
-                }
+                // Get details
+                $type        = $this->getInput('h');
+                $content     = $this->getInput('content');
+                $name        = $this->getInput('name');
+                $in_reply_to = $this->getInput('in-reply-to');
+                $syndicate   = $this->getInput('mp-syndicate-to', $this->getInput('syndicate-to'));
+                $like_of     = $this->getInput('like-of');
+                $repost_of   = $this->getInput('repost-of');
 
-                if ($this->validateToken($token)) {
-                    // If we're here, we're authorized
-
-                    // Get details
-                    $type        = $this->getInput('h');
-                    $content     = $this->getInput('content');
-                    $name        = $this->getInput('name');
-                    $in_reply_to = $this->getInput('in-reply-to');
-                    $syndicate   = $this->getInput('mp-syndicate-to');
-                    $like_of     = $this->getInput('like-of');
-                    $repost_of   = $this->getInput('repost-of');
-
-                    if ($type == 'entry') {
-                        $type = 'article';
-                        if (!empty($_FILES['photo'])) {
-                            $type = 'photo';
-                            if (empty($name) && !empty($content)) {
-                                $name    = $content;
-                                $content = '';
-                            }
-                        }
-                        if (empty($name)) {
-                            $type = 'note';
-                        }
-                        if (!empty($like_of)) {
-                            $type = 'like';
-                        }
-                        if (!empty($repost_of)) {
-                            $type = 'repost';
+                if ($type == 'entry') {
+                    $type = 'article';
+                    if (!empty($_FILES['photo'])) {
+                        $type = 'photo';
+                        if (empty($name) && !empty($content)) {
+                            $name    = $content;
+                            $content = '';
                         }
                     }
+                    if (empty($name)) {
+                        $type = 'note';
+                    }
+                    if (!empty($like_of)) {
+                        $type = 'like';
+                    }
+                    if (!empty($repost_of)) {
+                        $type = 'repost';
+                    }
+                }
 
-                    // Get an appropriate plugin, given the content type
-                    if ($contentType = ContentType::getRegisteredForIndieWebPostType($type)) {
+                // Get an appropriate plugin, given the content type
+                if ($contentType = ContentType::getRegisteredForIndieWebPostType($type)) {
 
-                        if ($entity = $contentType->createEntity()) {
+                    if ($entity = $contentType->createEntity()) {
 
-                            error_log(var_export($entity, true));
+                        error_log(var_export($entity, true));
 
-                            if (is_array($content)) {
-                                $content_value = '';
-                                if (!empty($content['html'])) {
-                                    $content_value = $content['html'];
-                                } else if (!empty($content['value'])) {
-                                    $content_value = $content['value'];
-                                }
+                        if (is_array($content)) {
+                            $content_value = '';
+                            if (!empty($content['html'])) {
+                                $content_value = $content['html'];
+                            } else if (!empty($content['value'])) {
+                                $content_value = $content['value'];
+                            }
+                        } else {
+                            $content_value = $content;
+                        }
+
+                        $this->setInput('title', $name);
+                        $this->setInput('body', $content_value);
+                        $this->setInput('inreplyto', $in_reply_to);
+                        $this->setInput('like-of', $like_of);
+                        $this->setInput('repost-of', $repost_of);
+                        $this->setInput('access', 'PUBLIC');
+                        if ($created = $this->getInput('published')) {
+                            $this->setInput('created', $created);
+                        }
+                        if (!empty($syndicate)) {
+                            if (is_array($syndicate)) {
+                                $syndication = $syndicate;
                             } else {
-                                $content_value = $content;
-                            }
-
-                            $this->setInput('title', $name);
-                            $this->setInput('body', $content_value);
-                            $this->setInput('inreplyto', $in_reply_to);
-                            $this->setInput('like-of', $like_of);
-                            $this->setInput('repost-of', $repost_of);
-                            $this->setInput('access', 'PUBLIC');
-                            if ($created = $this->getInput('published')) {
-                                $this->setInput('created', $created);
-                            }
-                            if (!empty($syndicate)) {
                                 $syndication = array(trim(str_replace('.com', '', $syndicate)));
-                                $this->setInput('syndication', $syndication);
                             }
-                            if ($entity->saveDataFromInput()) {
-                                $this->setResponse(201);
-                                header('Location: ' . $entity->getURL());
-                                exit;
-                            } else {
-                                $this->setResponse(500);
-                                echo "Couldn't create {$type}";
-                                exit;
-                            }
-
+                            \Idno\Core\Idno::site()->logging()->log("Setting syndication: $syndication");
+                            $this->setInput('syndication', $syndication);
+                        }
+                        if ($entity->saveDataFromInput()) {
+                            $this->setResponse(201);
+                            header('Location: ' . $entity->getURL());
+                            exit;
+                        } else {
+                            $this->setResponse(500);
+                            echo "Couldn't create {$type}";
+                            exit;
                         }
 
-                    } else {
-
-                        $this->setResponse(500);
-                        echo "Couldn't find content type {$type}";
-                        exit;
-
                     }
+
+                } else {
+
+                    $this->setResponse(500);
+                    echo "Couldn't find content type {$type}";
+                    exit;
 
                 }
-
-                $this->setResponse(403);
-                echo 'Bad token';
-
-            }
-
-            // Check that this token is either a user token or the
-            // site's API token, and log that user in if so.
-            private function validateToken($token)
-            {
-                if (!empty($token)) {
-                    $found = Token::findUserForToken($token);
-                    if (!empty($found)) {
-                        $user = $found['user'];
-                        \Idno\Core\Idno::site()->session()->refreshSessionUser($user);
-                        return true;
-                    }
-                    $user = \Idno\Entities\User::getOne(array('admin' => true));
-                    if ($token == $user->getAPIkey()) {
-                        \Idno\Core\Idno::site()->session()->refreshSessionUser($user);
-                        return true;
-                    }
-                }
-                return false;
             }
 
         }


### PR DESCRIPTION
- clarify that "login" happens once when the user enters their
  username/password, whereas "auth" happens per-request
- plugins should expect to register hooks before user auth happens --
  cannot depend on the user being set during init.
- plugins should handle event "user/auth/request" to provide own
  authentication mechanism
- plugins should handle event "user/auth/success" to react to the user
  being authed
- updated IndiePub plugin to use the pluggable auth mechanism

Intends to address #519 and #918, and supersedes @mapkyca's PR #1123