### PR TITLE
mysql: insert entity and metadata inside of a transaction

### DIFF
--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -103,13 +103,19 @@
                         }
                         break;
                 }
+
+                $this->logging      = new Logging();
                 $this->config->load();
+
+                if (isset($this->config->loglevel)) {
+                    $this->logging->setLogLevel($this->config->loglevel);
+                }
+
                 $this->session      = new Session();
                 $this->actions      = new Actions();
                 $this->template     = new Template();
                 $this->language     = new Language();
                 $this->syndication  = new Syndication();
-                $this->logging      = new Logging($this->config->log_level);
                 $this->reader       = new Reader();
                 $this->helper_robot = new HelperRobot();
 


### PR DESCRIPTION
Makes a pretty significant performance improvement when inserting an entity. On my system it's on the order of 0.3s without and 0.03s with a transaction.

Before:

```
PHP message: Known (known.dev): DEBUG - insert or update took 0.30136895179749 s
PHP message: Known (known.dev): DEBUG - insert or update took 0.3676438331604 s
PHP message: Known (known.dev): DEBUG - insert or update took 0.29871201515198 s
PHP message: Known (known.dev): DEBUG - insert or update took 0.37608504295349 s
```

After: 

```
PHP message: Known (known.dev): DEBUG - insert or update took 0.038892030715942 s
PHP message: Known (known.dev): DEBUG - insert or update took 0.024508953094482 s
PHP message: Known (known.dev): DEBUG - insert or update took 0.030456066131592 s
PHP message: Known (known.dev): DEBUG - insert or update took 0.024585962295532 s
```