### PR TITLE
Autosave: fixes to work with TinyMCE

### DIFF
--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -414,9 +414,6 @@
                 if (!$return) {
                     $this->refreshCurrentSessionuser();
                     $return = $this->currentUser();
-                    if ($return) {
-                        \Idno\Core\Idno::site()->logging()->log("Authed user via session: " . $return->getName(), LOGLEVEL_DEBUG);
-                    }
                 }
 
                 if ($this->isAPIRequest()) {

--- a/IdnoPlugins/Event/Pages/Edit.php
+++ b/IdnoPlugins/Event/Pages/Edit.php
@@ -15,6 +15,12 @@
                     $object = \IdnoPlugins\Event\Event::getByID($this->arguments[0]);
                 } else {
                     $object = new \IdnoPlugins\Event\Event();
+                    $autosave = new \Idno\Core\Autosave();
+                    foreach (array(
+                        'title', 'summary', 'location', 'starttime', 'endtime', 'body'
+                    ) as $field) {
+                        $object->$field = $autosave->getValue('event', $field);
+                    }
                 }
 
                 if ($owner = $object->getOwner()) {

--- a/IdnoPlugins/Event/templates/default/entity/Event/edit.tpl.php
+++ b/IdnoPlugins/Event/templates/default/entity/Event/edit.tpl.php
@@ -1,27 +1,4 @@
 <?=$this->draw('entity/edit/header');?>
-<?php
-
-    $autosave = new \Idno\Core\Autosave();
-    if (!($title = $vars['object']->title)) {
-        $title = $autosave->getValue('event','title');
-    }
-    if (!($summary = $vars['object']->summary)) {
-        $summary = $autosave->getValue('event','summary');
-    }
-    if (!($location = $vars['object']->location)) {
-        $location = $autosave->getValue('event','location');
-    }
-    if (!($starttime = $vars['object']->starttime)) {
-        $starttime = $autosave->getValue('event','starttime');
-    }
-    if (!($endtime = $vars['object']->endtime)) {
-        $endtime = $autosave->getValue('event','endtime');
-    }
-    if (!($body = $vars['object']->body)) {
-        $body = $autosave->getValue('event','body');
-    }
-
-?>
 <form action="<?=$vars['object']->getURL()?>" method="post">
 
     <div class="row">

--- a/IdnoPlugins/Text/Entry.php
+++ b/IdnoPlugins/Text/Entry.php
@@ -56,12 +56,14 @@
              */
             function getIcon()
             {
-                $xpath = new \DOMXPath(@\DOMDocument::loadHTML($this->getDescription()));
-                $src   = $xpath->evaluate("string(//img/@src)");
-                if (!empty($src)) {
-                    return $src;
+                $doc = @\DOMDocument::loadHTML($this->getDescription());
+                if ($doc) {
+                    $xpath = new \DOMXPath($doc);
+                    $src   = $xpath->evaluate("string(//img/@src)");
+                    if (!empty($src)) {
+                        return $src;
+                    }
                 }
-
                 return parent::getIcon();
             }
 

--- a/IdnoPlugins/Text/Pages/Edit.php
+++ b/IdnoPlugins/Text/Pages/Edit.php
@@ -15,6 +15,12 @@
                     $object = \IdnoPlugins\Text\Entry::getByID($this->arguments[0]);
                 } else {
                     $object = new \IdnoPlugins\Text\Entry();
+                    $autosave = new \Idno\Core\Autosave();
+                    foreach (array(
+                        'title', 'body'
+                    ) as $field) {
+                        $object->$field = $autosave->getValue('entry', $field);
+                    }
                 }
 
                 if ($owner = $object->getOwner()) {

--- a/js/default.js
+++ b/js/default.js
@@ -64,17 +64,15 @@ function autoSave(context, elements, selectors) {
     var previousVal = {};
     setInterval(function () {
         var changed = {};
-        for (var element of elements) {
-            var selector, val;
+        for (var i = 0 ; i < elements.length ; i++) {
+            var element = elements[i];
+            var selector = "#" + element;
             if (selectors && element in selectors) {
                 selector = selectors[element];
-            } else {
-                selector = "#" + element;
             }
+            var val = false;
             if ($(selector).val() != previousVal[element]) {
                 val = $(selector).val();
-            } else {
-                val = false;
             }
             if (val !== false) {
                 changed[element] = val;

--- a/js/default.js
+++ b/js/default.js
@@ -51,19 +51,34 @@ function hideContentCreateForm() {
     }
 }
 
-function autoSave(context, elements) {
-    var previousVal = [];
+/**
+ * Periodically send the current values of this form to the server.
+ *
+ * @param string context Usually the type of entity being saved. We keep one autosave
+ *     for each unique context.
+ * @param array elements The elements to save, e.g. ["title", "body"].
+ * @param object selectors (optional) A mapping from element name to its unique
+ *     JQuery-style selector. If no mapping is provided, defaults to "#element";
+ */
+function autoSave(context, elements, selectors) {
+    var previousVal = {};
     setInterval(function () {
         var changed = {};
-        for (element in elements) {
-            if ($("#" + elements[element]).val() != previousVal[elements[element]]) {
-                val = $("#" + elements[element]).val();
+        for (var element of elements) {
+            var selector, val;
+            if (selectors && element in selectors) {
+                selector = selectors[element];
+            } else {
+                selector = "#" + element;
+            }
+            if ($(selector).val() != previousVal[element]) {
+                val = $(selector).val();
             } else {
                 val = false;
             }
             if (val !== false) {
-                changed[elements[element]] = val;
-                previousVal[elements[element]] = val;
+                changed[element] = val;
+                previousVal[element] = val;
             }
         }
         if (Object.keys(changed).length > 0) {

--- a/templates/default/forms/input/richtext.tpl.php
+++ b/templates/default/forms/input/richtext.tpl.php
@@ -139,6 +139,8 @@
     }
 
     // Autosave the title & body
-    autoSave('entry', ['title', '<?=$vars['name']?>']);
+    autoSave('entry', ['title', '<?=$vars['name']?>'], {
+      '<?=$vars['name']?>': '#<?=$unique_id?>',
+    });
 
 </script>


### PR DESCRIPTION
- Use unique ID as selector when saving body
- Restore autosaved fields in getContent instead of the template.
- DOMXPath constructor causes a silent fatal error instead of throwing
  an exception; add null-safety for it