### PR TITLE
Autosave bugfixes

### DIFF
--- a/Idno/Core/Autosave.php
+++ b/Idno/Core/Autosave.php
@@ -51,7 +51,7 @@
                     if ($user = site()->session()->currentUser()) {
                         if (is_array($elements) && !empty($elements) && !empty($context)) {
                             $autosave           = $user->autosave;
-                            $autosave[$context] = $elements;
+                            $autosave[$context] = empty($autosave[$context]) ? $elements : array_merge($autosave[$context], $elements);
                             $user->autosave     = $autosave;
                             if ($user->save()) {
                                 \Idno\Core\Idno::site()->session()->refreshSessionUser($user);

--- a/IdnoPlugins/Text/templates/default/entity/Entry/edit.tpl.php
+++ b/IdnoPlugins/Text/templates/default/entity/Entry/edit.tpl.php
@@ -1,22 +1,18 @@
 <?= $this->draw('entity/edit/header'); ?>
 <?php
-
     $autosave = new \Idno\Core\Autosave();
     if (!empty($vars['object']->body)) {
         $body = $vars['object']->body;
-    } else {
-        $body = $autosave->getValue('entry', 'bodyautosave');
     }
     if (!empty($vars['object']->title)) {
         $title = $vars['object']->title;
-    } else {
-        $title = $autosave->getValue('entry', 'title');
     }
     if (!empty($vars['object'])) {
         $object = $vars['object'];
     } else {
         $object = false;
     }
+    $unique_id = 'body'.rand(0, 9999);
 
     /* @var \Idno\Core\Template $this */
 
@@ -45,14 +41,15 @@
                     }
 
                 ?>
-                
+
                 <div class="content-form">
                     <label for="title">Title</label>
-                    <input type="text" name="title" id="title" placeholder="Give it a title" value="<?= htmlspecialchars($title) ?>" class="form-control"/>                    
+                    <input type="text" name="title" id="title" placeholder="Give it a title" value="<?= htmlspecialchars($title) ?>" class="form-control"/>
                 </div>
 
                 <?= $this->__([
                     'name' => 'body',
+                    'unique_id' => $unique_id,
                     'value' => $body,
                     'object' => $object,
                     'wordcount' => true
@@ -61,11 +58,11 @@
 
                 <?php if (empty($vars['object']->_id)) echo $this->drawSyndication('article'); ?>
                 <?php if (empty($vars['object']->_id)) { ?><input type="hidden" name="forward-to" value="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'; ?>" /><?php } ?>
-                
+
                 <?= $this->draw('content/access'); ?>
 
                 <p class="button-bar ">
-	                
+
                     <?= \Idno\Core\Idno::site()->actions()->signForm('/entry/edit') ?>
                     <input type="button" class="btn btn-cancel" value="Cancel" onclick="tinymce.EditorManager.execCommand('mceRemoveEditor',true, 'body'); hideContentCreateForm();"/>
                     <input type="submit" class="btn btn-primary" value="Publish"/>
@@ -76,5 +73,12 @@
 
         </div>
     </form>
-    <div id="bodyautosave" style="display:none"></div>
 <?= $this->draw('entity/edit/footer'); ?>
+<script>
+
+    // Autosave the title & body
+    autoSave('entry', ['title', 'body'], {
+      'body': '#<?=$unique_id?>',
+    });
+
+</script>

--- a/templates/default/forms/input/richtext.tpl.php
+++ b/templates/default/forms/input/richtext.tpl.php
@@ -1,6 +1,10 @@
 <?php
 
-    $unique_id = 'body' . rand(0,9999);
+    if (!empty($vars['unique_id'])) {
+	    $unique_id = $vars['unique_id'];
+    } else {
+	    $unique_id = 'body' . rand(0,9999);
+    }
     if (!empty($vars['class'])) {
         $class = $vars['class'];
     } else {
@@ -137,10 +141,4 @@
             }
         });
     }
-
-    // Autosave the title & body
-    autoSave('entry', ['title', '<?=$vars['name']?>'], {
-      '<?=$vars['name']?>': '#<?=$unique_id?>',
-    });
-
 </script>


### PR DESCRIPTION
- Don't save for any use of richtext editor -- move autoSave call to
  Text's edit template itself.
- Since javascript only sends values that have changed, merge them
  with the existing autosave values on the server side.