### PR TITLE
Call db->optimize at most once a day

### DIFF
--- a/Idno/Pages/Admin/Home.php
+++ b/Idno/Pages/Admin/Home.php
@@ -15,7 +15,13 @@
             function getContent()
             {
                 $this->adminGatekeeper(); // Admins only
-                \Idno\Core\Idno::site()->db()->optimize();
+                $lastOptTime = empty(\Idno\Core\Idno::site()->config()->dboptimized) ? 0 : \Idno\Core\Idno::site()->config()->dboptimized;
+                if (($time = time()) - $lastOptTime > 24 * 60 * 60) {
+                    \Idno\Core\Idno::site()->logging()->log("Optimizing database tables. Last run " . date('Y-m-d H:i:s', $lastOptTime));
+                    \Idno\Core\Idno::site()->db()->optimize();
+                    \Idno\Core\Idno::site()->config()->dboptimized = $time;
+                    \Idno\Core\Idno::site()->config()->save();
+                }
                 if ($messages = \Idno\Core\Idno::site()->getVendorMessages()) {
                     \Idno\Core\Idno::site()->session()->addMessage($messages);
                 }
@@ -23,7 +29,6 @@
                 $t->body  = $t->__(array('vendor_messages' => $messages))->draw('admin/home');
                 $t->title = 'Administration';
                 $t->drawPage();
-
             }
 
             function postContent()


### PR DESCRIPTION
Loading /admin/ takes a while because of a call to db->optimize().
This PR throttles it so that it will only call optimize if it's been
more than 24 hours since the last call. I'm open to other ideas too
(including leaving it alone)