### PR TITLE
bugfix: Post Privacy was reset to public when editing some post types

### DIFF
--- a/IdnoPlugins/Checkin/templates/default/entity/Checkin/edit.tpl.php
+++ b/IdnoPlugins/Checkin/templates/default/entity/Checkin/edit.tpl.php
@@ -144,7 +144,6 @@
             <?= $this->__([
                 'name' => 'body',
                 'value' => $vars['object']->body,
-                'object' => $object,
                 'wordcount' => false,
                 'class' => 'wysiwyg-short',
                 'height' => 100,

--- a/IdnoPlugins/Like/templates/default/entity/Like/edit.tpl.php
+++ b/IdnoPlugins/Like/templates/default/entity/Like/edit.tpl.php
@@ -59,7 +59,6 @@
                 <?= $this->__([
                     'name'        => 'description',
                     'value'       => $vars['object']->description,
-                    'object'      => $object,
                     'wordcount'   => false,
                     'class'       => 'wysiwyg-short',
                     'height'      => 250,

--- a/IdnoPlugins/Media/templates/default/entity/Media/edit.tpl.php
+++ b/IdnoPlugins/Media/templates/default/entity/Media/edit.tpl.php
@@ -45,7 +45,6 @@
             <?= $this->__([
                 'name' => 'body',
                 'value' => $vars['object']->body,
-                'object' => $vars['object'],
                 'wordcount' => false,
                 'height' => 250,
                 'class' => 'wysiwyg-short',

--- a/IdnoPlugins/Photo/templates/default/entity/Photo/edit.tpl.php
+++ b/IdnoPlugins/Photo/templates/default/entity/Photo/edit.tpl.php
@@ -60,7 +60,6 @@
                     <?= $this->__([
                         'name' => 'body',
                         'value' => $vars['object']->body,
-                        'object' => $object,
                         'wordcount' => false,
                         'class' => 'wysiwyg-short',
                         'height' => 100,

--- a/IdnoPlugins/StaticPages/templates/default/entity/StaticPage/edit.tpl.php
+++ b/IdnoPlugins/StaticPages/templates/default/entity/StaticPage/edit.tpl.php
@@ -51,7 +51,6 @@
                 <?= $this->__([
                     'name' => 'body',
                     'value' => $vars['object']->body,
-                    'object' => $object,
                     'wordcount' => false,
                     'class' => 'wysiwyg',
                     'height' => 100,


### PR DESCRIPTION
The call to `$t->__(array('object' => $object))` was overwriting the
actual 'object' value in `$vars` with the undefined variable `$object`.
We could call `$t->__(array('object' => $vars['object']))` instead but I
believe that would be redundant.

Fixes #1026