### PR TITLE
Basic support for custom permalink structures

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1492,18 +1492,16 @@
                 return $object;
             }
 
-            static function getPermalinkStructure()
-            {
-                if ($permalinks = \Idno\Core\Idno::site()->config()->permalinks) {
-                    return $permalinks;
-                }
-                // default
-                return '/:year/:slug';
-            }
-            
+            /**
+             * Get the routing regular expression for entities based
+             * on the configured permalink structure. By convention
+             * the route must contain one matching group that matches
+             * either the post ID or the post slug.
+             * @return string
+             */
             static function getPermalinkRoute()
             {
-                $parts = explode('/', static::getPermalinkStructure());
+                $parts = explode('/', \Idno\Core\Idno::site()->config()->getPermalinkStructure());
                 $result = implode('/', array_map(function ($part)
                 {
                     switch ($part) {
@@ -1539,7 +1537,7 @@
                 }
 
                 // build the permalink based on the configured structure
-                $parts = explode('/', static::getPermalinkStructure());
+                $parts = explode('/', \Idno\Core\Idno::site()->config()->getPermalinkStructure());
 
                 if (
                     (!in_array(':slug', $parts) || $this->getSlug()) &&

--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -57,6 +57,7 @@
                 'form_token_expiry'      => 21600,
                 'show_privacy'           => true,
                 'bypass_fulltext_search' => false,
+                'permalink_structure'    => '/:year/:slug',
             );
 
             public $ini_config = array();
@@ -712,6 +713,19 @@
                 $temp = '/tmp/';
 
                 return $temp;
+            }
+
+            /**
+             * Get the configured permalink structure for posts in the
+             * format /:tag1/:tag2
+             * @return string
+             */
+            function getPermalinkStructure()
+            {
+                if  (empty($this->permalink_structure)) {
+                    return '/:year/:slug';
+                }
+                return $this->permalink_structure;
             }
 
             /**

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -156,6 +156,7 @@
              */
             function registerPages()
             {
+                $permalink_route = \Idno\Common\Entity::getPermalinkRoute();
 
                 /** Homepage */
                 $this->addPageHandler('', '\Idno\Pages\Homepage');
@@ -168,15 +169,15 @@
                 /** Individual entities / posting / deletion */
                 $this->addPageHandler('/view/([\%A-Za-z0-9]+)/?', '\Idno\Pages\Entity\View');
                 $this->addPageHandler('/s/([\%A-Za-z0-9]+)/?', '\Idno\Pages\Entity\Shortlink');
-                $this->addPageHandler('/[0-9]+/([\%A-Za-z0-9\-\_]+)/?', '\Idno\Pages\Entity\View');
+                $this->addPageHandler($permalink_route.'/?', '\Idno\Pages\Entity\View');
                 $this->addPageHandler('/edit/([A-Za-z0-9]+)/?', '\Idno\Pages\Entity\Edit');
                 $this->addPageHandler('/delete/([A-Za-z0-9]+)/?', '\Idno\Pages\Entity\Delete');
                 $this->addPageHandler('/withdraw/([A-Za-z0-9]+)/?', '\Idno\Pages\Entity\Withdraw');
 
                 /** Annotations */
                 $this->addPageHandler('/view/([A-Za-z0-9]+)/annotations/([A-Za-z0-9]+)?', '\Idno\Pages\Annotation\View');
-                $this->addPageHandler('/[0-9]+/([\%A-Za-z0-9\-\_]+)/annotations/([A-Za-z0-9]+)?', '\Idno\Pages\Annotation\View');
-                $this->addPageHandler('/[0-9]+/([\%\A-Za-z0-9\-\_]+)/annotations/([A-Za-z0-9]+)/delete/?', '\Idno\Pages\Annotation\Delete'); // Delete annotation
+                $this->addPageHandler($permalink_route.'/annotations/([A-Za-z0-9]+)?', '\Idno\Pages\Annotation\View');
+                $this->addPageHandler($permalink_route.'/annotations/([A-Za-z0-9]+)/delete/?', '\Idno\Pages\Annotation\Delete'); // Delete annotation
                 $this->addPageHandler('/annotation/post/?', '\Idno\Pages\Annotation\Post');
 
                 /** Bookmarklets and sharing */

--- a/Idno/Pages/Admin/Home.php
+++ b/Idno/Pages/Admin/Home.php
@@ -51,6 +51,7 @@
                 $user_avatar_favicons = $this->getInput('user_avatar_favicons');
                 $wayback_machine      = $this->getInput('wayback_machine');
                 $items_per_page       = (int)$this->getInput('items_per_page');
+                $permalink_structure  = $this->getInput('permalink_structure');
                 if ($open_registration == 'true') {
                     $open_registration = true;
                 } else {
@@ -86,21 +87,22 @@
                 } else {
                     $wayback_machine = false;
                 }
-                if (!empty($title)) \Idno\Core\Idno::site()->config->config['title'] = $title;
-                \Idno\Core\Idno::site()->config->config['homepagetitle'] = trim($homepagetitle);
-                if (!empty($description)) \Idno\Core\Idno::site()->config->config['description'] = $description;
-                if (!empty($url)) \Idno\Core\Idno::site()->config->config['url'] = $url;
-                if (!empty($path)) \Idno\Core\Idno::site()->config->config['path'] = $path;
-                if (!empty($host)) \Idno\Core\Idno::site()->config->config['host'] = $host;
-                \Idno\Core\Idno::site()->config->config['hub'] = $hub;
-                if (!empty($items_per_page) && is_int($items_per_page)) \Idno\Core\Idno::site()->config->config['items_per_page'] = $items_per_page;
-                \Idno\Core\Idno::site()->config->config['open_registration']    = $open_registration;
-                \Idno\Core\Idno::site()->config->config['walled_garden']        = $walled_garden;
-                \Idno\Core\Idno::site()->config->config['show_privacy']         = $show_privacy;
-                \Idno\Core\Idno::site()->config->config['indieweb_citation']    = $indieweb_citation;
-                \Idno\Core\Idno::site()->config->config['indieweb_reference']   = $indieweb_reference;
-                \Idno\Core\Idno::site()->config->config['user_avatar_favicons'] = $user_avatar_favicons;
-                \Idno\Core\Idno::site()->config->config['wayback_machine']      = $wayback_machine;
+                if (!empty($title)) \Idno\Core\Idno::site()->config->title = $title;
+                \Idno\Core\Idno::site()->config->homepagetitle = trim($homepagetitle);
+                if (!empty($description)) \Idno\Core\Idno::site()->config->description = $description;
+                if (!empty($url)) \Idno\Core\Idno::site()->config->url = $url;
+                if (!empty($path)) \Idno\Core\Idno::site()->config->path = $path;
+                if (!empty($host)) \Idno\Core\Idno::site()->config->host = $host;
+                \Idno\Core\Idno::site()->config->hub = $hub;
+                if (!empty($items_per_page) && is_int($items_per_page)) \Idno\Core\Idno::site()->config->items_per_page = $items_per_page;
+                \Idno\Core\Idno::site()->config->open_registration    = $open_registration;
+                \Idno\Core\Idno::site()->config->walled_garden        = $walled_garden;
+                \Idno\Core\Idno::site()->config->show_privacy         = $show_privacy;
+                \Idno\Core\Idno::site()->config->indieweb_citation    = $indieweb_citation;
+                \Idno\Core\Idno::site()->config->indieweb_reference   = $indieweb_reference;
+                \Idno\Core\Idno::site()->config->user_avatar_favicons = $user_avatar_favicons;
+                \Idno\Core\Idno::site()->config->wayback_machine      = $wayback_machine;
+                \Idno\Core\Idno::site()->config->permalink_structure  = $permalink_structure;
 
                 \Idno\Core\Idno::site()->triggerEvent('admin/home/save');
 

--- a/Tests/Core/PermalinkStructureTest.php
+++ b/Tests/Core/PermalinkStructureTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Core {
+
+    class PermalinkStructureTest extends \Tests\KnownTestCase {
+
+        private function createEntry()
+        {
+            $rnd = rand(0,9999).'-'.time();
+            $entity = new \IdnoPlugins\Text\Entry();
+            $entity->setOwner($this->user());
+            $entity->title = "The Title $rnd";
+            $entity->body = 'Unlikely to be present elsewhere in the post template: hamstring baseball duckbill firecracker';
+            $entity->save($add_to_feed=true);
+            return $entity;
+        }
+
+        public function testPermalinks()
+        {
+            $entity = $this->createEntry();
+            $base = \Idno\Core\Idno::site()->config()->getDisplayUrl();
+            $year = strftime('%Y', $entity->created);
+            $month = strftime('%m', $entity->created);
+            $day = strftime('%d', $entity->created);
+            $slug = $entity->getSlug();
+
+            // default
+            \Idno\Core\Idno::site()->config()->permalink_structure = null;
+            \Idno\Core\Idno::site()->config()->save();
+            $this->assertEquals('/:year/:slug', \Idno\Core\Idno::site()->config()->getPermalinkStructure());
+            $this->assertEquals("$base$year/$slug", $entity->getURL());
+            $contents = file_get_contents($entity->getURL());
+            $this->assertContains('hamstring baseball duckbill firecracker', $contents);
+
+            // /year/month/slug
+            \Idno\Core\Idno::site()->config()->permalink_structure = '/:year/:month/:slug';
+            \Idno\Core\Idno::site()->config()->save();
+            $this->assertEquals("$base$year/$month/$slug", $entity->getURL());
+            $contents = file_get_contents($entity->getURL());
+            $this->assertContains('hamstring baseball duckbill firecracker', $contents);
+
+
+            $entity->delete();
+        }
+    }
+
+}

--- a/Tests/Core/SessionTest.php
+++ b/Tests/Core/SessionTest.php
@@ -32,13 +32,8 @@ namespace Tests\Core {
             $this->assertFalse(is_object(\Idno\Core\Idno::site()->session()->currentUser()));
         }
         
-        
         public static function tearDownAfterClass() {
-            
             \Idno\Core\Idno::site()->session()->logUserOff();
-            
-            // Delete users, if we've created some but forgot to clean up
-            if (\Tests\KnownTestCase::$testUser) \Tests\KnownTestCase::$testUser->delete();
         }
     }
     

--- a/Tests/KnownTestCase.php
+++ b/Tests/KnownTestCase.php
@@ -80,10 +80,15 @@ namespace Tests {
          * @return \Idno\Entities\User
          */
         public static function tearDownAfterClass() {
-            
             // Delete users, if we've created some but forgot to clean up
-            if (static::$testUser) static::$testUser->delete();
-            if (static::$testAdmin) static::$testAdmin->delete();
+            if (static::$testUser) {
+                static::$testUser->delete();
+                static::$testUser = false;
+            }
+            if (static::$testAdmin) {
+                static::$testAdmin->delete();
+                static::$testAdmin = false;
+            }
         }
     }
 

--- a/templates/default/admin/home.tpl.php
+++ b/templates/default/admin/home.tpl.php
@@ -7,8 +7,8 @@
 </div>
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
-	    
-        <form action="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() ?>admin/" class="navbar-form admin" method="post">
+
+        <form action="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() ?>admin/" class="admin" method="post">
 
             <div class="row">
                 <div class="col-md-10">
@@ -71,6 +71,33 @@
                 <div class="col-md-6"><p class="config-desc">This is the number of content posts displayed on each page.</p>
                 </div>
             </div>
+
+            <!-------->
+
+            <div class="row">
+                <div class="col-md-2">
+                    <p><label class="control-label" for="permalink_structure"><strong>Permalink Structure</strong></label></p>
+                </div>
+                <div class="col-md-4">
+                    <?php foreach (array(
+                        '/:year/:slug' => '/:year/:slug <strong>(default)</strong>',
+                        '/:year/:month/:slug' => '/:year/:month/:slug',
+                        '/:year/:month/:day/:slug' => '/:year/:month/:day/:slug',
+                    ) as $value => $label) { ?>
+                        <div class="radio">
+                            <label>
+                                <input type="radio" name="permalink_structure" value="<?=$value?>"
+                                  <?= \Idno\Core\Idno::site()->config()->getPermalinkStructure() == $value ? 'checked' : ''?> />
+                                <?=$label?>
+                            </label>
+                        </div>
+                    <?php } ?>
+                </div>
+                <div class="col-md-6"><p class="config-desc">How permalinks for individual posts are constructed.</p>
+                </div>
+            </div>
+
+
 
             <?=$this->draw('admin/home/settings/details')?>
 
@@ -152,7 +179,7 @@
                 }
 
                 echo $this->draw('admin/home/settings/privacy');
-                
+
             ?>
 
             <!---------->
@@ -233,5 +260,3 @@
     </div>
 
 </div>
-
-


### PR DESCRIPTION
Allow the administrator to choose one of

* `/:year/:slug`
* `/:year/:month/:slug`
* `/:year/:month/:day/:slug`

We may want to add a nag screen or some other protection against breaking old permalinks, e.g. maybe `/year/slug` should be made to always redirect to whatever the current configuration is.

Fixes #1139 (at least to the extent that I redefined #1139)