### PR TITLE
MySQL optimization/bugfixes

### DIFF
--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -820,7 +820,7 @@
                     $metadata_joins   = 0;
                     $non_md_variables = array();
                     $where            = $this->build_where_from_array($parameters, $variables, $metadata_joins, $non_md_variables, 'and', $collection);
-                    for ($i = 0; $i <= $metadata_joins; $i++) {
+                    for ($i = 1; $i <= $metadata_joins; $i++) {
                         $query .= " left join metadata md{$i} on md{$i}.entity = {$collection}.uuid ";
                     }
                     if (!empty($where)) {

--- a/schemas/mysql/2015061501.sql
+++ b/schemas/mysql/2015061501.sql
@@ -1,2 +1,3 @@
 ALTER TABLE `entities` CHANGE `owner` `owner` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;
 ALTER TABLE `entities` CHANGE `entity_subtype` `entity_subtype` VARCHAR( 64 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;
+UPDATE `versions` SET `value` = '2015061501' WHERE `label` = 'schema';


### PR DESCRIPTION
* Prevent extra md join on MySQL::countRecords, md# names are indexed from 1.
* Make sure to write the schema version out after executing 2015061501.sql; otherwise it was running on every request!
