### PR TITLE
Do not suppress errors in templates

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -144,7 +144,7 @@
                     $this->parseJSONPayload();
                     $return = $this->postContent();
                 } else {
-                    throw new \Exception('The page you were on timed out.');
+                    throw new \Exception('Invalid CSRF token.');
                 }
 
                 if (\Idno\Core\Idno::site()->session()->isAPIRequest()) {
@@ -906,7 +906,10 @@
              */
             public function getAssets($class)
             {
-                return $this->assets[$class];
+                if (isset($this->assets[$class])) {
+                    return $this->assets[$class];
+                }
+                return false;
             }
 
             /**

--- a/Idno/Core/Template.php
+++ b/Idno/Core/Template.php
@@ -231,7 +231,7 @@
             function sanitize_html($html)
             {
                 $html = site()->triggerEvent('text/filter', [], $html);
-                
+
                 return $html;
             }
 
@@ -461,7 +461,11 @@
             function getCurrentURLWithVar($variable_name, $value)
             {
                 $components = parse_url($this->getCurrentURL());
-                parse_str($components['query'], $url_var_array);
+                if (isset($components['query'])) {
+                    parse_str($components['query'], $url_var_array);
+                } else {
+                    $url_var_array = [];
+                }
                 $url_var_array[$variable_name] = $value;
                 $components['query'] = http_build_query($url_var_array);
                 $url                 = $components['scheme'] . '://' . $components['host'] . $components['path'];

--- a/IdnoPlugins/IndiePub/Pages/IndieAuth/Auth.php
+++ b/IdnoPlugins/IndiePub/Pages/IndieAuth/Auth.php
@@ -24,9 +24,14 @@
                 $state        = $this->getInput('state');
                 $scope        = $this->getInput('scope');
 
-                 if (empty($me) || parse_url($me, PHP_URL_HOST) != parse_url( $user->getURL(), PHP_URL_HOST)) {
+                if (empty($me)) {
                      $this->setResponse(403);
-                     echo $me.' does not match the logged in user '.$user->getURL().'.';
+                     echo "\"me\" parameter must be provided.";
+                     exit;
+                }
+                 if (parse_url($me, PHP_URL_HOST) != parse_url($user->getURL(), PHP_URL_HOST)) {
+                     $this->setResponse(403);
+                     echo "\"$me\" does not match the logged in user \"{$user->getURL()}\".";
                      exit;
                  }
 

--- a/external/bonita/includes/Bonita/Templates.php
+++ b/external/bonita/includes/Bonita/Templates.php
@@ -76,36 +76,36 @@
 				function draw($templateName, $returnBlank = true) {
 					$templateName = preg_replace('/^_[A-Z0-9\/]+/i','',$templateName);
 					if (!empty($templateName)) {
-					
+
 						// Add the Bonita base path to our additional paths list
 						$paths = \Bonita\Main::getPaths();
-						
+
 						// Add template types to an array; ensure we revert to default
 						$templateTypes = array($this->getTemplateType());
 						if ($this->fallbackToDefault)
 						{
 						    if ($this->getTemplateType() != 'default') $templateTypes[] = 'default';
 						}
-						
+
 						// Cycle through the additional paths and check for the template file
 						// - if it exists, break out of the foreach
 						foreach($templateTypes as $templateType)
 						foreach($paths as $basepath) {
 							$path = $basepath . '/templates/'.$templateType.'/' . $templateName . '.tpl.php';
 							if (file_exists($path)) {
-						
+
 								// Special vars:
 								$vars = $this->vars;
 								$t = $this;
-							
+
 								ob_start();
-								@include $path;
+								include $path;
 								return ob_get_clean();
-								
+
 								// Break out of the foreach path
 								// (although this code should be unreachable)
 								break;
-								
+
 							}
 						}
 					}

--- a/external/torophp/src/Toro.php
+++ b/external/torophp/src/Toro.php
@@ -19,7 +19,7 @@ class Toro
                 $path_info = (strpos($_SERVER['REQUEST_URI'], '?') > 0) ? strstr($_SERVER['REQUEST_URI'], '?', true) : $_SERVER['REQUEST_URI'];
             }
         //}
-        
+
         $discovered_handler = null;
         $regex_matches = array();
 

--- a/templates/default/shell.tpl.php
+++ b/templates/default/shell.tpl.php
@@ -362,7 +362,7 @@
 </div>
 <!-- Everything below this should be includes, not content -->
 
-<?php if (!empty($_SERVER["HTTP_X_PJAX"])): ?>
+<?php if (empty($_SERVER["HTTP_X_PJAX"])): ?>
 <!-- Le javascript -->
 <!-- Placed at the end of the document so the pages load faster -->
 <script

--- a/templates/default/shell.tpl.php
+++ b/templates/default/shell.tpl.php
@@ -23,6 +23,7 @@
         $objectIcon = false;
     }
     $pageOwner = $currentPage->getOwner();
+    $description = isset($vars['description']) ? $vars['description'] : '';
 
 ?>
 <!DOCTYPE html>
@@ -32,7 +33,7 @@
     <title><?= htmlspecialchars($vars['title']); ?></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="viewport" content="initial-scale=1.0" media="(device-height: 568px)"/>
-    <meta name="description" content="<?= htmlspecialchars(strip_tags($vars['description'])) ?>">
+    <meta name="description" content="<?= htmlspecialchars(strip_tags($description)) ?>">
     <meta name="generator" content="Known https://withknown.com">
     <meta http-equiv="Content-Language" content="<?= $lang; ?>">
 
@@ -113,7 +114,7 @@
             $has_twitter_account = false;
             if (!empty($pageOwner->profile['url'])) {
                 foreach ($pageOwner->profile['url'] as $profile_url) {
-                    if ($profile_url[0] == '@') {
+                    if (!empty($profile_url) && $profile_url[0] == '@') {
                         if (preg_match("/\@[a-z0-9_]+/i", $profile_url)) {
                             $has_twitter_account = true;
                             $twitter_account     = $profile_url;
@@ -159,7 +160,7 @@
     <!-- Dublin Core -->
     <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/">
     <meta name="DC.title" content="<?= htmlspecialchars($vars['title']) ?>">
-    <meta name="DC.description" content="<?= htmlspecialchars($vars['description']) ?>"><?php
+    <meta name="DC.description" content="<?= htmlspecialchars($description) ?>"><?php
 
         if ($currentPage->isPermalink()) {
             /* @var \Idno\Common\Entity $object */
@@ -361,7 +362,7 @@
 </div>
 <!-- Everything below this should be includes, not content -->
 
-<?php if (!$_SERVER["HTTP_X_PJAX"]): ?>
+<?php if (!empty($_SERVER["HTTP_X_PJAX"])): ?>
 <!-- Le javascript -->
 <!-- Placed at the end of the document so the pages load faster -->
 <script


### PR DESCRIPTION
Unsilencing errors in template rendering helps debugging
when there are problems (including syntax errors) in the template.
Changed @include  to include, and fix some warnings that were
happening when rendering templates in general.

Fixes #1145