### PR TITLE
call MentionClient::sendSupportedMentions instead of sendWebmentionPa…

### DIFF
--- a/Idno/Core/Webmention.php
+++ b/Idno/Core/Webmention.php
@@ -58,8 +58,12 @@
 
                 // Load webmention-client
                 require_once \Idno\Core\Idno::site()->config()->path . '/external/mention-client-php/src/IndieWeb/MentionClient.php';
+
                 $client = new \Idno\Core\MentionClient($sourceURL);
-                return $client->sendWebmentionPayload($targetURL);
+
+                // $client->sendWebmentionPayload on its own would have no effect
+                // because no webmention endpoint has been discovered yet.
+                return $client->sendSupportedMentions($targetURL);
             }
 
             /**


### PR DESCRIPTION
…yload

sendWebmentionPayload on its own does nothing because the webmention
endpoint hasn't been discovered yet. In order to send a single webmention,
we need to call MentionClient::supportsWebmention() first, which is what
MentionClient::sendSupportedMentions() does.