### PR TITLE
Use a library to count characters when composing a status

### DIFF
--- a/IdnoPlugins/Status/external/brevity-js/LICENSE
+++ b/IdnoPlugins/Status/external/brevity-js/LICENSE
@@ -1,0 +1,116 @@
+CC0 1.0 Universal
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator and
+subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the
+purpose of contributing to a commons of creative, cultural and scientific
+works ("Commons") that the public can reliably and without fear of later
+claims of infringement build upon, modify, incorporate in other works, reuse
+and redistribute as freely as possible in any form whatsoever and for any
+purposes, including without limitation commercial purposes. These owners may
+contribute to the Commons to promote the ideal of a free culture and the
+further production of creative, cultural and scientific works, or to gain
+reputation or greater distribution for their Work in part through the use and
+efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation
+of additional consideration or compensation, the person associating CC0 with a
+Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
+and publicly distribute the Work under its terms, with knowledge of his or her
+Copyright and Related Rights in the Work and the meaning and intended legal
+effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not limited
+to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display, communicate,
+  and translate a Work;
+
+  ii. moral rights retained by the original author(s) and/or performer(s);
+
+  iii. publicity and privacy rights pertaining to a person's image or likeness
+  depicted in a Work;
+
+  iv. rights protecting against unfair competition in regards to a Work,
+  subject to the limitations in paragraph 4(a), below;
+
+  v. rights protecting the extraction, dissemination, use and reuse of data in
+  a Work;
+
+  vi. database rights (such as those arising under Directive 96/9/EC of the
+  European Parliament and of the Council of 11 March 1996 on the legal
+  protection of databases, and under any national implementation thereof,
+  including any amended or successor version of such directive); and
+
+  vii. other similar, equivalent or corresponding rights throughout the world
+  based on applicable law or treaty, and any national implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention of,
+applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+and Related Rights and associated claims and causes of action, whether now
+known or unknown (including existing as well as future claims and causes of
+action), in the Work (i) in all territories worldwide, (ii) for the maximum
+duration provided by applicable law or treaty (including future time
+extensions), (iii) in any current or future medium and for any number of
+copies, and (iv) for any purpose whatsoever, including without limitation
+commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
+the Waiver for the benefit of each member of the public at large and to the
+detriment of Affirmer's heirs and successors, fully intending that such Waiver
+shall not be subject to revocation, rescission, cancellation, termination, or
+any other legal or equitable action to disrupt the quiet enjoyment of the Work
+by the public as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason be
+judged legally invalid or ineffective under applicable law, then the Waiver
+shall be preserved to the maximum extent permitted taking into account
+Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
+is so judged Affirmer hereby grants to each affected person a royalty-free,
+non transferable, non sublicensable, non exclusive, irrevocable and
+unconditional license to exercise Affirmer's Copyright and Related Rights in
+the Work (i) in all territories worldwide, (ii) for the maximum duration
+provided by applicable law or treaty (including future time extensions), (iii)
+in any current or future medium and for any number of copies, and (iv) for any
+purpose whatsoever, including without limitation commercial, advertising or
+promotional purposes (the "License"). The License shall be deemed effective as
+of the date CC0 was applied by Affirmer to the Work. Should any part of the
+License for any reason be judged legally invalid or ineffective under
+applicable law, such partial invalidity or ineffectiveness shall not
+invalidate the remainder of the License, and in such case Affirmer hereby
+affirms that he or she will not (i) exercise any of his or her remaining
+Copyright and Related Rights in the Work or (ii) assert any associated claims
+and causes of action with respect to the Work, in either case contrary to
+Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+  a. No trademark or patent rights held by Affirmer are waived, abandoned,
+  surrendered, licensed or otherwise affected by this document.
+
+  b. Affirmer offers the Work as-is and makes no representations or warranties
+  of any kind concerning the Work, express, implied, statutory or otherwise,
+  including without limitation warranties of title, merchantability, fitness
+  for a particular purpose, non infringement, or the absence of latent or
+  other defects, accuracy, or the present or absence of errors, whether or not
+  discoverable, all to the greatest extent permissible under applicable law.
+
+  c. Affirmer disclaims responsibility for clearing rights of other persons
+  that may apply to the Work or any use thereof, including without limitation
+  any person's Copyright and Related Rights in the Work. Further, Affirmer
+  disclaims responsibility for obtaining any necessary consents, permissions
+  or other rights required for any use of the Work.
+
+  d. Affirmer understands and acknowledges that Creative Commons is not a
+  party to this document and has no duty or obligation with respect to this
+  CC0 or use of the Work.
+
+For more information, please see
+<http://creativecommons.org/publicdomain/zero/1.0/>

--- a/IdnoPlugins/Status/external/brevity-js/README.md
+++ b/IdnoPlugins/Status/external/brevity-js/README.md
@@ -1,0 +1,76 @@
+# brevity-js
+
+[![Build Status](https://travis-ci.org/kylewm/brevity-js.svg?branch=master)](https://travis-ci.org/kylewm/brevity-js)
+
+A small utility to count characters, autolink, and shorten posts to an
+acceptable tweet-length summary.
+
+This is a port of the Python module of the same name. Please refer to
+https://github.com/kylewm/brevity for documentation.
+
+## Installation
+
+With npm, simply `npm install brevity`.
+
+Otherwise, brevity.js is a single file that can be included
+anywhere. In the browser, it will define `window.brevity` with the
+functions below.  `
+
+## Usage
+
+### tweetLength(text)
+
+Find out how many characters a message will use on Twitter with
+`tweetLength()`:
+
+```javascript
+var brevity = require("brevity");
+var length = brevity.tweetLength('Published my first npm www.npmjs.com/package/brevity and composer packagist.org/packages/kylewm/brevity packages today!');
+console.log(length);  // 99
+```
+
+This text is 119 characters but, due to t.co wrapping, will only use
+99 characters.
+
+### autolink(text)
+
+Convert URLs in plaintext to HTML links.
+
+```javascript
+var brevity = require("brevity");
+var html = brevity.autolink("I'm a big fan of https://en.wikipedia.org/wiki/Firefly_(TV_series) (and its creator https://en.wikipedia.org/wiki/Joss_Whedon)");
+console.log(html);
+```
+
+Note that brevity handles parentheses and other punctuation as you'd
+expect.
+
+### shorten(text)
+
+The `shorten(text)` function takes a message of any length and
+shortens it to a Tweet-length 140 characters, adding an ellipsis at
+the end of it is truncated. It will not truncate a word or URL in the
+middle. Shorten takes a few *optional* parameters that change the way
+the tweet is formed. Any of these parameters can be `null`.
+
+- `permalink` - included after the ellipsis if and only if the text
+  is shortened. Must be a URL or false.
+- `shortpermalink` - included in parentheses at the end of tweets
+  that are not shortened. Must be a URL or false.
+- `shortpermacitation` - included in parentheses at the end of tweets
+  that are not shortened. Must *not* be a URL, e.g. `ttk.me t4fT2`
+- `targetLength` - The target length for the final text. Defaults to
+  140.
+- `linkLength` - The final length of each URL after
+  shortening. Defaults to 23.
+- `formatAsTitle` - take the text as a title of a longer
+  article. Always formats as "Title: $permalink" or "Title…
+  $permalink" if shortened.
+
+```javascript
+var brevity = require("brevity");
+var permalink = "https://kylewm.com/2016/01/brevity-shortens-notes";
+var longnote = "Brevity (github.com/kylewm/brevity-php) shortens notes that are too long to fit in a single tweet. It can also count characters to help you make sure your note won't need to be shortened!";
+var tweet = brevity.shorten(longnote, permalink);
+console.log(tweet);
+```

--- a/IdnoPlugins/Status/external/brevity-js/brevity.js
+++ b/IdnoPlugins/Status/external/brevity-js/brevity.js
@@ -1,0 +1,229 @@
+(function(exports) {
+    "use strict";
+    var LINKIFY_RE = /(?:(?:http|https|file|irc):\/{1,3})?(?:[a-z0-9\-]+\.)+[a-z]{2,}(?::\d{2,6})?(?:(?:\/[\w\/.\-_~.;:%?!@$#&()=+]*)|\b)/gi;
+    var DOMAIN_RE  = /(?:(?:http|https|file|irc):\/{1,3})?((?:[a-z0-9\-]+\.)+)([a-z]{2,})/i;
+    var TLDS = 'aaa aarp abb abbott abogado ac academy accenture accountant accountants aco active actor ad adac ads adult ae aeg aero af afl ag agency ai aig airforce airtel al alibaba alipay allfinanz alsace am amica amsterdam analytics android ao apartments app apple aq aquarelle ar aramco archi army arpa arte as asia associates at attorney au auction audi audio author auto autos aw ax axa az azure ba baidu band bank bar barcelona barclaycard barclays bargains bauhaus bayern bb bbc bbva bcn bd be beats beer bentley berlin best bet bf bg bh bharti bi bible bid bike bing bingo bio biz bj black blackfriday bloomberg blue bm bms bmw bn bnl bnpparibas bo boats boehringer bom bond boo book boots bosch bostik bot boutique br bradesco bridgestone broadway broker brother brussels bs bt budapest bugatti build builders business buy buzz bv bw by bz bzh ca cab cafe cal call camera camp cancerresearch canon capetown capital car caravan cards care career careers cars cartier casa cash casino cat catering cba cbn cc cd ceb center ceo cern cf cfa cfd cg ch chanel channel chat cheap chloe christmas chrome church ci cipriani circle cisco citic city cityeats ck cl claims cleaning click clinic clinique clothing cloud club clubmed cm cn co coach codes coffee college cologne com commbank community company compare computer comsec condos construction consulting contact contractors cooking cool coop corsica country coupons courses cr credit creditcard creditunion cricket crown crs cruises csc cu cuisinella cv cw cx cy cymru cyou cz dabur dad dance date dating datsun day dclk de dealer deals degree delivery dell delta democrat dental dentist desi design dev diamonds diet digital direct directory discount dj dk dm dnp do docs dog doha domains doosan download drive dubai durban dvag dz earth eat ec edeka edu education ee eg email emerck energy engineer engineering enterprises epson equipment er erni es esq estate et eu eurovision eus events everbank exchange expert exposed express fage fail fairwinds faith family fan fans farm fashion fast feedback ferrero fi film final finance financial firestone firmdale fish fishing fit fitness fj fk flights florist flowers flsmidth fly fm fo foo football ford forex forsale forum foundation fox fr fresenius frl frogans fund furniture futbol fyi ga gal gallery game garden gb gbiz gd gdn ge gea gent genting gf gg ggee gh gi gift gifts gives giving gl glass gle global globo gm gmail gmo gmx gn gold goldpoint golf goo goog google gop got gov gp gq gr grainger graphics gratis green gripe group gs gt gu gucci guge guide guitars guru gw gy hamburg hangout haus health healthcare help helsinki here hermes hiphop hitachi hiv hk hm hn hockey holdings holiday homedepot homes honda horse host hosting hoteles hotmail house how hr hsbc ht hu hyundai ibm icbc ice icu id ie ifm iinet il im immo immobilien in industries infiniti info ing ink institute insurance insure int international investments io ipiranga iq ir irish is iselect ist istanbul it itau iwc jaguar java jcb je jetzt jewelry jlc jll jm jmp jo jobs joburg jot joy jp jprs juegos kaufen kddi ke kfh kg kh ki kia kim kinder kitchen kiwi km kn koeln komatsu kp kpn kr krd kred kw ky kyoto kz la lacaixa lamborghini lamer lancaster land landrover lanxess lasalle lat latrobe law lawyer lb lc lds lease leclerc legal lexus lgbt li liaison lidl life lifeinsurance lifestyle lighting like limited limo lincoln linde link live living lixil lk loan loans lol london lotte lotto love lr ls lt ltd ltda lu lupin luxe luxury lv ly ma madrid maif maison makeup man management mango market marketing markets marriott mba mc md me med media meet melbourne meme memorial men menu meo mg mh miami microsoft mil mini mk ml mm mma mn mo mobi mobily moda moe moi mom monash money montblanc mormon mortgage moscow motorcycles mov movie movistar mp mq mr ms mt mtn mtpc mtr mu museum mutuelle mv mw mx my mz na nadex nagoya name navy nc ne nec net netbank network neustar new news nexus nf ng ngo nhk ni nico ninja nissan nl no nokia norton nowruz np nr nra nrw ntt nu nyc nz obi office okinawa om omega one ong onl online ooo oracle orange org organic origins osaka otsuka ovh pa page pamperedchef panerai paris pars partners parts party pe pet pf pg ph pharmacy philips photo photography photos physio piaget pics pictet pictures pid pin ping pink pizza pk pl place play playstation plumbing plus pm pn pohl poker porn post pr praxi press pro prod productions prof promo properties property protection ps pt pub pw py qa qpon quebec racing re read realtor realty recipes red redstone redumbrella rehab reise reisen reit ren rent rentals repair report republican rest restaurant review reviews rexroth rich ricoh rio rip ro rocher rocks rodeo room rs rsvp ru ruhr run rw rwe ryukyu sa saarland safe safety sakura sale salon samsung sandvik sandvikcoromant sanofi sap sapo sarl sas saxo sb sbs sc sca scb schaeffler schmidt scholarships school schule schwarz science scor scot sd se seat security seek select sener services seven sew sex sexy sfr sg sh sharp shell shia shiksha shoes show shriram si singles site sj sk ski skin sky skype sl sm smile sn sncf so soccer social softbank software sohu solar solutions sony soy space spiegel spreadbetting sr srl st stada star starhub statefarm statoil stc stcgroup stockholm storage studio study style su sucks supplies supply support surf surgery suzuki sv swatch swiss sx sy sydney symantec systems sz tab taipei taobao tatamotors tatar tattoo tax taxi tc tci td team tech technology tel telefonica temasek tennis tf tg th thd theater theatre tickets tienda tiffany tips tires tirol tj tk tl tm tmall tn to today tokyo tools top toray toshiba tours town toyota toys tr trade trading training travel travelers travelersinsurance trust trv tt tube tui tushu tv tw tz ua ubs ug uk university uno uol us uy uz va vacations vana vc ve vegas ventures verisign versicherung vet vg vi viajes video villas vin vip virgin vision vista vistaprint viva vlaanderen vn vodka volkswagen vote voting voto voyage vu wales walter wang wanggou watch watches weather webcam weber website wed wedding weir wf whoswho wien wiki williamhill win windows wine wme work works world ws wtc wtf xbox xerox xin xn--11b4c3d xn--1qqw23a xn--30rr7y xn--3bst00m xn--3ds443g xn--3e0b707e xn--3pxu8k xn--42c2d9a xn--45brj9c xn--45q11c xn--4gbrim xn--55qw42g xn--55qx5d xn--6frz82g xn--6qq986b3xl xn--80adxhks xn--80ao21a xn--80asehdb xn--80aswg xn--90a3ac xn--90ais xn--9dbq2a xn--9et52u xn--b4w605ferd xn--c1avg xn--c2br7g xn--cg4bki xn--clchc0ea0b2g2a9gcd xn--czr694b xn--czrs0t xn--czru2d xn--d1acj3b xn--d1alf xn--eckvdtc9d xn--efvy88h xn--estv75g xn--fhbei xn--fiq228c5hs xn--fiq64b xn--fiqs8s xn--fiqz9s xn--fjq720a xn--flw351e xn--fpcrj9c3d xn--fzc2c9e2c xn--g2xx48c xn--gecrj9c xn--h2brj9c xn--hxt814e xn--i1b6b1a6a2e xn--imr513n xn--io0a7i xn--j1aef xn--j1amh xn--j6w193g xn--jlq61u9w7b xn--kcrx77d1x4a xn--kprw13d xn--kpry57d xn--kpu716f xn--kput3i xn--l1acc xn--lgbbat1ad8j xn--mgb9awbf xn--mgba3a3ejt xn--mgba3a4f16a xn--mgbaam7a8h xn--mgbab2bd xn--mgbayh7gpa xn--mgbb9fbpob xn--mgbbh1a71e xn--mgbc0a9azcg xn--mgberp4a5d4ar xn--mgbpl2fh xn--mgbt3dhd xn--mgbtx2b xn--mgbx4cd0ab xn--mk1bu44c xn--mxtq1m xn--ngbc5azd xn--ngbe9e0a xn--node xn--nqv7f xn--nqv7fs00ema xn--nyqy26a xn--o3cw4h xn--ogbpf8fl xn--p1acf xn--p1ai xn--pbt977c xn--pgbs0dh xn--pssy2u xn--q9jyb4c xn--qcka1pmc xn--qxam xn--rhqv96g xn--s9brj9c xn--ses554g xn--t60b56a xn--tckwe xn--unup4y xn--vermgensberater-ctb xn--vermgensberatung-pwb xn--vhquv xn--vuq861b xn--wgbh1c xn--wgbl6a xn--xhq521b xn--xkc2al3hye2a xn--xkc2dl3a5ee0h xn--y9a3aq xn--yfro4i67o xn--ygbi2ammx xn--zfr164b xperia xxx xyz yachts yamaxun yandex ye yodobashi yoga yokohama youtube yt za zara zero zip zm zone zuerich zw'.split(' ');
+
+    function rstrip(str, chars) {
+        chars = chars || ' \t\n\r';
+        for (var ii = str.length - 1 ; ii >= 0 ; --ii) {
+            if (chars.indexOf(str[ii]) === -1) {
+                return str.substring(0, ii+1);
+            }
+        }
+        return '';
+    }
+
+    function lstrip(str, chars) {
+        chars = chars || ' \t\n\r';
+        for (var ii = 0 ; ii < str.length ; ++ii) {
+            if (chars.indexOf(str[ii]) === -1) {
+                return str.substring(ii);
+            }
+        }
+        return '';
+    }
+
+    function makeToken(tag, content, required) {
+        return {
+            tag: tag,
+            content: content,
+            required: required || false,
+        };
+    }
+
+    function hasValidTld(link) {
+        var m = DOMAIN_RE.exec(link);
+        return null !== m && TLDS.indexOf(m[2].toLowerCase()) !== -1;
+    }
+
+    function tokenize(text, skipBareCcTlds) {
+        var links = text.match(LINKIFY_RE) || [];
+        var splits = text.split(LINKIFY_RE) || [];
+
+        for (var ii = 0 ; ii < links.length ; ii++) {
+            // trim trailing punctuation
+            var link = links[ii];
+            var jj = link.length - 1;
+            while (jj >= 0 && '.!?,;:)'.indexOf(link[jj]) !== -1
+                   && (link[jj] !== ')' || link.indexOf('(') === -1)) {
+                --jj;
+                links[ii] = link.substring(0, jj+1);
+                splits[ii+1] = link.substring(jj+1) + splits[ii+1];
+            }
+            link = links[ii];
+
+            // avoid double linking by looking at preceeding 2 chars
+            var prevText = splits[ii];
+            var nextText = splits[ii+1];
+            if (/=["']\s*$/.test(prevText)
+                || /@\s*$/.test(prevText) || /^@/.test(nextText)
+                || /^\s*<\/a/.test(nextText)
+                || !hasValidTld(link)
+                || (skipBareCcTlds
+                    && /[a-z0-9\-]+\.[a-z]{2}$/i.test(link))) {
+                splits[ii] = splits[ii] + links[ii];
+                links[ii] = '';
+                continue
+            }
+        }
+
+        var result = [];
+        for (var ii = 0 ; ii < Math.max(links.length, splits.length) ; ii++) {
+            if (ii < splits.length && splits[ii] !== '') {
+                if (result.length > 0 && result[result.length-1].tag === 'text') {
+                    result[result.length-1].content += splits[ii];
+                } else {
+                    result.push(makeToken('text', splits[ii]));
+                }
+            }
+            if (ii < links.length && links[ii] !== '') {
+                result.push(makeToken('link', links[ii]));
+            }
+        }
+
+        return result;
+    }
+
+    function tweetLength(text) {
+        var arr = tokenize(text, true);
+        var len = 0;
+        for (var ii = 0 ; ii < arr.length ; ii++) {
+            if (arr[ii].tag === 'text') {
+                len += arr[ii].content.length;
+            } else if (arr[ii].tag === 'link') {
+                len += 23;
+            }
+        }
+        return len;
+    }
+
+    function autolink(text) {
+        function addScheme(url) {
+            if (/^\/\//.test(url) || /^(https?|mailto|irc):\/\//.test(url)) {
+                return url;
+            }
+            if (/Https?:\/\//.test(url)) {
+                return 'h' + url.substring(1);
+            }
+            return 'http://' + url;
+        }
+
+        var result = [];
+        var tokens = tokenize(text);
+        for (var ii = 0 ; ii < tokens.length; ii++) {
+            var token = tokens[ii];
+            if (token.tag === 'link') {
+                result.push('<a class="auto-link" href="' + addScheme(token.content) + '">' + token.content + '</a>');
+            } else {
+                result.push(token.content);
+            }
+        }
+        return result.join('');
+    }
+
+    function shorten(text, permalink, permashortlink, permashortcitation,
+                     targetLength, linkLength, formatAsTitle) {
+        targetLength = targetLength || 140;
+        linkLength = linkLength || 23;
+
+        function truncateToNearestWord(text, length) {
+            var delimiters = ',.;: \t\r\n';
+            // try stripping trailing whitespace first
+            text = rstrip(text);
+            if (text.length <= length) {
+                return text;
+            }
+            // walk backwards until we find a delimiter
+            for (var jj = length ; jj >= 0 ; --jj) {
+                if (delimiters.indexOf(text[jj]) !== -1) {
+                    return rstrip(text.substring(0, jj), delimiters);
+                }
+            }
+            return '';
+        }
+
+        function tokenLength(token) {
+            if (token.tag === 'link') {
+                return linkLength;
+            }
+            return token.content.length;
+        }
+
+        function totalLength(tokens) {
+            var total = 0;
+            for (var ii = 0 ; ii < tokens.length ; ++ii) {
+                total += tokenLength(tokens[ii]);
+            }
+            return total;
+        }
+
+        var tokens = tokenize(text, true);
+        var citationTokens = [];
+
+        if (formatAsTitle && permalink) {
+            citationTokens.push(makeToken('text', ': ', true));
+            citationTokens.push(makeToken('link', permalink, true));
+        } else if (permashortlink) {
+            citationTokens.push(makeToken('text', ' (', true));
+            citationTokens.push(makeToken('link', permashortlink, true));
+            citationTokens.push(makeToken('text', ')', true));
+        } else if (permashortcitation) {
+            citationTokens.push(
+                makeToken('text', ' (' + permashortcitation + ')', true));
+        }
+
+        var baseLength = totalLength(tokens);
+        var citationLength = totalLength(citationTokens);
+
+        if (baseLength + citationLength <= targetLength) {
+            tokens = tokens.concat(citationTokens);
+        }
+        else {
+            // add permalink
+            if (permalink) {
+                tokens.push(makeToken('text', '… ', true));
+                tokens.push(makeToken('link', permalink, true));
+            } else {
+                tokens.push(makeToken('text', '…', true));
+            }
+        }
+
+        // drop or shorten tokens, starting from the end
+        for (var ii = tokens.length -1 ; ii >= 0 ; --ii) {
+            var token = tokens[ii];
+            if (token.required) {
+                continue;
+            }
+
+            var over = totalLength(tokens) - targetLength;
+            if (over <= 0) {
+                break;
+            }
+
+            if (token.tag == 'link') {
+                tokens.splice(ii, 1);
+            }
+            else if (token.tag == 'text') {
+                var toklen = tokenLength(token);
+                if (over >= toklen) {
+                    tokens.splice(ii, 1);
+                }
+                else {
+                    token.content = truncateToNearestWord(
+                        token.content, toklen - over);
+                }
+            }
+        }
+
+        return tokens
+            .map(function (tok) { return tok.content; })
+            .join('');
+    }
+
+    exports.tokenize = tokenize;
+    exports.tweetLength = tweetLength;
+    exports.autolink = autolink;
+    exports.shorten = shorten;
+
+}(typeof exports === 'undefined' ? this['brevity']={} : exports));

--- a/IdnoPlugins/Status/external/brevity-js/test/index.html
+++ b/IdnoPlugins/Status/external/brevity-js/test/index.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Mocha Tests</title>
+  <link href="https://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.css" rel="stylesheet" />
+</head>
+<body>
+  <div id="mocha"></div>
+
+  <script src="https://cdn.rawgit.com/jquery/jquery/2.1.4/dist/jquery.min.js"></script>
+  <script src="https://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.js"></script>
+  <script src="http://chaijs.com/chai.js"></script>
+  <script src="/brevity.js"></script>
+
+  <script>mocha.setup('bdd')</script>
+  <script src="/test/test.js"></script>
+
+  <script>
+    $.getJSON('/tests.json', function (testdata) {
+      test.init(brevity, chai.assert, testdata);
+      mocha.checkLeaks();
+      mocha.run();
+    });
+
+  </script>
+</body>
+</html>

--- a/IdnoPlugins/Status/external/brevity-js/test/node-test.js
+++ b/IdnoPlugins/Status/external/brevity-js/test/node-test.js
@@ -1,0 +1,4 @@
+var fs = require('fs');
+var content = fs.readFileSync('tests.json', 'utf8')
+var testdata = JSON.parse(content);
+require('./test.js').init(require('../brevity.js'), require('assert'), testdata);

--- a/IdnoPlugins/Status/external/brevity-js/test/test.js
+++ b/IdnoPlugins/Status/external/brevity-js/test/test.js
@@ -1,0 +1,28 @@
+(function (exports) {
+    exports.init = function (brevity, assert, testdata) {
+        describe('shorten()', function () {
+            testdata['shorten'].forEach(function (testcase) {
+                it('shortens ' + testcase.text.replace(/\s+/g, ' '), function () {
+                    var result = brevity.shorten(
+                        testcase.text,
+                        testcase.permalink,
+                        testcase.permashortlink,
+                        testcase.permashortcitation,
+                        testcase.target_length,
+                        testcase.link_length,
+                        testcase.format_as_title
+                    );
+                    assert.equal(testcase.expected, result);
+                });
+            });
+        });
+        describe('autolink()', function () {
+            testdata['autolink'].forEach(function (testcase) {
+                it('autolinks ' + testcase.text.replace(/\s+/g, ' '), function () {
+                    var result = brevity.autolink(testcase.text);
+                    assert.equal(testcase.expected, result);
+                });
+            });
+        });
+    }
+}(typeof exports === 'undefined' ? this['test']={} : exports));

--- a/IdnoPlugins/Status/external/brevity-js/tests.json
+++ b/IdnoPlugins/Status/external/brevity-js/tests.json
@@ -1,0 +1,104 @@
+{
+    "autolink": [
+        {
+            "expected": "This links to a weird domain <a class=\"auto-link\" href=\"http://deals.blackfriday\">deals.blackfriday</a>.",
+            "text": "This links to a weird domain deals.blackfriday."
+        },
+        {
+            "expected": "<a class=\"auto-link\" href=\"http://starts.with.a.link\">starts.with.a.link</a> and ends with <a href=\"https://kylewm.com/about#me\">HTML</a>.",
+            "text": "starts.with.a.link and ends with <a href=\"https://kylewm.com/about#me\">HTML</a>."
+        },
+        {
+            "expected": "includes <a class=\"auto-link\" href=\"http://ipad-capitalization.com\">Http://ipad-capitalization.com</a>",
+            "text": "includes Http://ipad-capitalization.com"
+        },
+        {
+            "expected": "a matched parenthesis: <a class=\"auto-link\" href=\"http://wikipedia.org/Python_(programming_language)\">http://wikipedia.org/Python_(programming_language)</a> and (an unmatched parenthesis <a class=\"auto-link\" href=\"https://en.wikipedia.org/wiki/Guido_van_Rossum\">https://en.wikipedia.org/wiki/Guido_van_Rossum</a>)",
+            "text": "a matched parenthesis: http://wikipedia.org/Python_(programming_language) and (an unmatched parenthesis https://en.wikipedia.org/wiki/Guido_van_Rossum)"
+        }
+    ],
+    "shorten": [
+        {
+            "permashortcitation": "ttk.me t4_93",
+            "permalink": "http://tantek.com/2015/014/t3/rel-tag-succeeded-web-html-specs",
+            "expected": "Despite Technorati dumping tag & blog search long ago, rel-tag succeeded on web, in #HTML spec https://html.spec.whatwg.org/multipage/semantics.html#linkTypes (ttk.me t4_93)",
+            "text": "Despite Technorati dumping tag & blog search long ago, rel-tag succeeded on web, in #HTML spec https://html.spec.whatwg.org/multipage/semantics.html#linkTypes"
+        },
+        {
+            "permashortcitation": "ttk.me t4_81",
+            "permalink": "http://tantek.com/2015/013/t1/names-ind-ie-indie-vc-not-indieweb",
+            "expected": "Despite names,\nind.ie&indie.vc are NOT #indieweb @indiewebcamp\nindiewebcamp.com/2014-review#Indie_Term_Re-use\n@iainspad @sashtown @thomatronic (ttk.me t4_81)",
+            "text": "Despite names,\nind.ie&indie.vc are NOT #indieweb @indiewebcamp\nindiewebcamp.com/2014-review#Indie_Term_Re-use\n@iainspad @sashtown @thomatronic"
+        },
+        {
+            "expected": "Si H\u00e4ren Engel duurch all, Haus Benn d\u00e9 blo, am wuel Kolrettchen Nuechtegall d\u00e9n. Nun en sch\u00e9i Milliounen, an wee drem d'Welt, do Ierd bl\u00e9nk",
+            "text": "Si H\u00e4ren Engel duurch all, Haus Benn d\u00e9 blo, am wuel Kolrettchen Nuechtegall d\u00e9n. Nun en sch\u00e9i Milliounen, an wee drem d'Welt, do Ierd bl\u00e9nk"
+        },
+        {
+            "expected": "Hey #indieweb, the coming storm of webmention Spam may not be far away. Those of us that have input fields to send\u2026 https://ben.thatmustbe.me/note/2015/1/31/1/",
+            "permalink": "https://ben.thatmustbe.me/note/2015/1/31/1/",
+            "permashortlink": "http://btmb.me/s/6q",
+            "text": "Hey #indieweb, the coming storm of webmention Spam may not be far away. Those of us that have input fields to send send webmentions manually may already be getting them. Look at the mentions on http://aaronparecki.com/articles/2015/01/22/1/why-not-json"
+        },
+        {
+            "expected": "anybody have a wedding ring with the date engraved in ISO 8601? I\u2019ll be damned if I\u2019m going to wear mm.dd.yyyy anywhere on my person.",
+            "permalink": "https://kylewm.com/2015/05/anybody-have-a-wedding-ring-with-the-date-engraved",
+            "text": "anybody have a wedding ring with the date engraved in ISO 8601? I\u2019ll be damned if I\u2019m going to wear mm.dd.yyyy anywhere on my person."
+        },
+        {
+            "expected": "ix freue mich auf die nebenan.hamburg morgen. ich spreche auch ne halbe stunde \u00fcbers #indieweb und\u2026 http://wirres.net/article/articleview/7773/1/6/",
+            "permalink": "http://wirres.net/article/articleview/7773/1/6/",
+            "permashortlink": "http://wirres.net/7773",
+            "text": "ix freue mich auf die nebenan.hamburg morgen. ich spreche auch ne halbe stunde \u00fcbers #indieweb und @reclaim_fm."
+        },
+        {
+            "expected": "@davewiner I stubbed a page on the wiki for https://indiewebcamp.com/River4. Edits/improvmnts from users are welcome! @kevinmarks @julien51 @aaronpk",
+            "text": "@davewiner I stubbed a page on the wiki for https://indiewebcamp.com/River4. Edits/improvmnts from users are welcome! @kevinmarks @julien51 @aaronpk"
+        },
+        {
+            "expected": "This is a long tweet with (foo.com/parenthesized-urls) and urls that wikipedia.org/Contain_(Parentheses), a url with a query string;foo.withknown.com/example?query=parameters",
+            "text": "This is a long tweet with (foo.com/parenthesized-urls) and urls that wikipedia.org/Contain_(Parentheses), a url with a query string;foo.withknown.com/example?query=parameters"
+        },
+        {
+            "expected": "This is a long tweet with (foo.com/parenthesized-urls) and urls that wikipedia.org/Contain_(Parentheses), that is one charc too long:\u2026",
+            "text": "This is a long tweet with (foo.com/parenthesized-urls) and urls that wikipedia.org/Contain_(Parentheses), that is one charc too long:foo.withknown.com/example?query=parameters"
+        },
+        {
+            "expected": "The Telegram Bot API is the best bot API ever. Everyone should learn from it, especially Matrix.org\u2026 https://unrelenting.technology/notes/2015-09-05-00-35-13",
+            "permalink": "https://unrelenting.technology/notes/2015-09-05-00-35-13",
+            "text": "The Telegram Bot API is the best bot API ever. Everyone should learn from it, especially Matrix.org, which currently requires a particular URL structure and registration files.",
+            "comment": "test case-insensitive link matching"
+        },
+        {
+            "text": "url http://foo.co/bar ellipsize http://foo.co/baz",
+            "target_length": 20,
+            "link_length": 5,
+            "expected": "url http://foo.co/bar ellipsize\u2026"
+        },
+        {
+            "text": "too long\nextra whitespace\tbut should include url",
+            "permalink": "http://obj.ca",
+            "target_length": 20,
+            "link_length": 5,
+            "expected": "too long\u2026 http://obj.ca"
+        },
+        {
+            "expected": "trailing slash http://www.foo.co/",
+            "target_length": 20,
+            "link_length": 5,
+            "text": "trailing slash http://www.foo.co/"
+        },
+        {
+            "expected": "The Article Title: http://example.com/article",
+            "permalink": "http://example.com/article",
+            "format_as_title": true,
+            "text": "The Article Title"
+        },
+        {
+            "expected": "The Article Title is Longer Than Will Fit in Just One Single Tweet, and I Find This Situation to be Awfully\u2026 https://example.org/article",
+            "permalink": "https://example.org/article",
+            "format_as_title": true,
+            "text": "The Article Title is Longer Than Will Fit in Just One Single Tweet, and I Find This Situation to be Awfully Frustrating; How About You?"
+        }
+    ]
+}

--- a/IdnoPlugins/Status/templates/default/entity/Status/edit.tpl.php
+++ b/IdnoPlugins/Status/templates/default/entity/Status/edit.tpl.php
@@ -18,7 +18,7 @@
     <div class="row">
 
         <div class="col-md-8 col-md-offset-2 edit-pane">
-            
+
             <p id="counter" style="display:none" class="pull-right">
                 <span class="count"></span>
             </p>
@@ -36,7 +36,7 @@
             </h4>
 
             <textarea required name="body" id="body" class="content-entry mentionable form-control" placeholder="Share a quick note or comment. You can use links and #hashtags."><?php
-                        
+
                 if (!empty($vars['body'])) {
                     echo htmlspecialchars($vars['body']);
                 } else {
@@ -54,7 +54,7 @@
                     var content = $('#body').val();
                     var len = content.length;
                     var element = $('#body');
-                 
+
                     $('#body').focus(function(){
                         $(this).prop('selectionStart', len);
                     });
@@ -64,14 +64,14 @@
             <?php
             }
             ?>
-            
+
             <p>
                 <small><a id="inreplyto-add" href="#"
                           onclick="$('#inreplyto').append('<span><input required type=&quot;url&quot; name=&quot;inreplyto[]&quot; value=&quot;&quot; placeholder=&quot;Add the URL that you\'re replying to&quot; class=&quot;form-control&quot; onchange=&quot;adjust_content(this.value)&quot; /> <small><a href=&quot;#&quot; onclick=&quot;$(this).parent().parent().remove(); return false;&quot;><icon class=&quot;fa fa-times&quot;></icon> Remove URL</a></small><br /></span>'); return false;"><i class="fa fa-reply"></i>
                         Reply to a site</a></small>
             </p>
-            
-            
+
+
             <div id="inreplyto">
                 <?php
                     if (!empty($vars['object']->inreplyto)) {
@@ -82,7 +82,7 @@
                                        placeholder="Add the URL that you're replying to"
                                        class="form-control inreplyto" value="<?= htmlspecialchars($inreplyto) ?>" onchange="adjust_content(this.value)"/>
                                 <small><a href="#"
-                                          onclick="$(this).parent().parent().remove(); return false;"><i class="fa fa-times"></i> 
+                                          onclick="$(this).parent().parent().remove(); return false;"><i class="fa fa-times"></i>
                                           Remove URL</a></small>
                             </p>
                         <?php
@@ -107,9 +107,10 @@
             </p>
         </div>
 
-               
+
     </div>
 </form>
+<script src="<?=\Idno\Core\Idno::site()->config()->getStaticURL()?>IdnoPlugins/Status/external/brevity-js/brevity.js"></script>
 <script>
     function adjust_content(url) {
         var username = url.match(/https?:\/\/([a-z]+\.)?twitter\.com\/(#!\/)?@?([^\/]*)/)[3];
@@ -122,7 +123,7 @@
     }
 
     function count_chars() {
-        var len = $('#body').val().length;
+        var len = brevity.tweetLength($('#body').val());
 
         if (len > 0) {
             if (!$('#counter').is(":visible")) {


### PR DESCRIPTION
brevity-js accounts for t.co shortening that Twitter does when
counting characters, for a more accurate estimate of whether your note
will fit in a tweet.

N.B. I wouldn't be offended if you held off on merging this until after
the 0.9 release. It's a non-trivial change and I have only tested locally
a little.

Fixes #1162