### PR TITLE
ignore addtl clicks on contentCreateButton

### DIFF
--- a/js/default.js
+++ b/js/default.js
@@ -21,7 +21,15 @@ function bindControls() {
     $('.ignore-this').hide();
 }
 
+var isCreateFormVisible = false;
+
 function contentCreateForm(plugin) {
+    if (isCreateFormVisible) {
+        // Ignore additional clicks on create button
+        return;
+    }
+
+    isCreateFormVisible = true;
     $.ajax(wwwroot() + plugin + '/edit/', {
         dataType: 'html',
         success: function (data) {
@@ -34,12 +42,14 @@ function contentCreateForm(plugin) {
         },
         error: function (error) {
             $('#contentTypeButtonBar').slideDown(400);
+            isCreateFormVisible = false;
         }
 
     });
 }
 
 function hideContentCreateForm() {
+    isCreateFormVisible = false;
     if (window.contentPage == true) {
         $('#contentTypeButtonBar').slideDown(200);
         $('#contentCreate').slideUp(200);

--- a/templates/default/content/create.tpl.php
+++ b/templates/default/content/create.tpl.php
@@ -11,11 +11,12 @@
 
                 foreach ($vars['contentTypes'] as $contentType) {
                     /* @var Idno\Common\ContentType $contentType */
+                    $entityType = $contentType->camelCase($contentType->getEntityClassName());
                     ?>
 
-                    <a class="contentTypeButton" id="<?= $contentType->getClassSelector() ?>Button"
+                    <a class="contentTypeButton" id="<?= $entityType ?>Button"
                        href="<?= $contentType->getEditURL() ?>"
-                       onclick="contentCreateForm('<?= $contentType->camelCase($contentType->getEntityClassName()) ?>'); return false;">
+                       onclick="contentCreateForm('<?= $entityType ?>'); return false;">
                         <span class="contentTypeLogo"><?= $contentType->getIcon() ?></span>
                         <?= $contentType->getTitle() ?>
                     </a>


### PR DESCRIPTION
Use a flag to avoid the situation where you can click a content create
button multiple times. Opening a second editor on top of the first
editor can erase content (if you're on a slow enough connection that
it is noticeable).

Fixes #1167