### PR TITLE
bugfix: preserve site title during registration

### DIFF
--- a/external/bonita/includes/Bonita/Templates.php
+++ b/external/bonita/includes/Bonita/Templates.php
@@ -56,7 +56,7 @@
 				
 			/**
 			 * Chainable function to allow variables to be added as an array.
-			 * @param $vars Variables to add to the template (eg array('name1' => 'value1', 'name2' => 'value2'))
+			 * @param $vars array Variables to add to the template (eg array('name1' => 'value1', 'name2' => 'value2'))
 			 * @return \Bonita\Templates this template object
 			 */
 				function __($vars) {

--- a/templates/default/onboarding/register.tpl.php
+++ b/templates/default/onboarding/register.tpl.php
@@ -41,7 +41,7 @@
 
                     if (!empty($vars['set_name'])) {
                         ?>
-                        <input type="hidden" name="set_name" value="<?= htmlentities($set_name) ?>">
+                        <input type="hidden" name="set_name" value="<?= htmlentities($vars['set_name']) ?>">
                         <?php
                     }
 

--- a/templates/default/shell/simple/messages.tpl.php
+++ b/templates/default/shell/simple/messages.tpl.php
@@ -1,8 +1,7 @@
 <?php
 
-    $messages = $vars['messages'];
-
-    if (!empty($messages)) {
+    if (!empty($vars['messages'])) {
+        $messages = $vars['messages'];
 
         ?>
         <div class="alerts">


### PR DESCRIPTION
There were two issues:

1. if ($ok = true) instead of if ($ok == true) was hiding an earlier error
2. installing the mysql schema can return false or 0 but still have been
   successful. adding some logic to check the PDO::errorInfo() error code.

Fixes #1174