### PR TITLE
No forwarding

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -540,14 +540,14 @@
             function gatekeeper()
             {
                 if (!\Idno\Core\Idno::site()->session()->isLoggedIn()) {
-                    $this->setResponse(403);
+                    $this->deniedContent();
 
-                    // Forwarding loses the response code, so is only helpful if this is not an API request
-                    if (!\Idno\Core\Idno::site()->session()->isAPIRequest()) {
-                        $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login?fwd=' . urlencode($_SERVER['REQUEST_URI']));
-                    } else {
-                        $this->deniedContent();
-                    }
+//                    // Forwarding loses the response code, so is only helpful if this is not an API request
+//                    if (!\Idno\Core\Idno::site()->session()->isAPIRequest()) {
+//                        $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login?fwd=' . urlencode($_SERVER['REQUEST_URI']));
+//                    } else {
+//                        $this->deniedContent();
+//                    }
                 }
             }
 
@@ -559,13 +559,14 @@
             function createGatekeeper()
             {
                 if (!\Idno\Core\Idno::site()->canWrite()) {
-                    $this->setResponse(403);
-
-                    if (!\Idno\Core\Idno::site()->session()->isAPIRequest()) {
-                        $this->forward();
-                    } else {
-                        $this->deniedContent();
-                    }
+                    $this->deniedContent();
+//                    $this->setResponse(403);
+//
+//                    if (!\Idno\Core\Idno::site()->session()->isAPIRequest()) {
+//                        $this->forward();
+//                    } else {
+//                        $this->deniedContent();
+//                    }
                 }
                 $this->gatekeeper();
             }
@@ -578,12 +579,13 @@
             function reverseGatekeeper()
             {
                 if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {
-                    $this->setResponse(403);
-                    if (!\Idno\Core\Idno::site()->session()->isAPIRequest()) {
-                        $this->forward();
-                    } else {
-                        $this->deniedContent();
-                    }
+                    $this->deniedContent();
+//                    $this->setResponse(403);
+//                    if (!\Idno\Core\Idno::site()->session()->isAPIRequest()) {
+//                        $this->forward();
+//                    } else {
+//                        $this->deniedContent();
+//                    }
 
                 }
             }
@@ -602,13 +604,14 @@
                     }
                 }
                 if (!$ok) {
-                    $this->setResponse(403);
-
-                    if (!\Idno\Core\Idno::site()->session()->isAPIRequest()) {
-                        $this->forward();
-                    } else {
-                        $this->deniedContent();
-                    }
+                    $this->deniedContent();
+//                    $this->setResponse(403);
+//
+//                    if (!\Idno\Core\Idno::site()->session()->isAPIRequest()) {
+//                        $this->forward();
+//                    } else {
+//                        $this->deniedContent();
+//                    }
                 }
             }
 

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -547,12 +547,12 @@
                     if (!\Idno\Core\Idno::site()->session()->isLoggedOn()) {
                         $class = get_class(Idno::site()->currentPage());
                         if (!\Idno\Core\Idno::site()->isPageHandlerPublic($class)) {
-                            \Idno\Core\Idno::site()->currentPage()->setResponse(403);
-                            if (!\Idno\Core\Idno::site()->session()->isAPIRequest()) {
-                                \Idno\Core\Idno::site()->currentPage()->forward(Idno::site()->config()->getURL() . 'session/login/?fwd=' . urlencode($_SERVER['REQUEST_URI']));
-                            } else {
+//                            \Idno\Core\Idno::site()->currentPage()->setResponse(403);
+//                            if (!\Idno\Core\Idno::site()->session()->isAPIRequest()) {
+//                                \Idno\Core\Idno::site()->currentPage()->forward(Idno::site()->config()->getURL() . 'session/login/?fwd=' . urlencode($_SERVER['REQUEST_URI']));
+//                            } else {
                                 \Idno\Core\Idno::site()->currentPage()->deniedContent();
-                            }
+//                            }
                         }
                     }
                 }

--- a/Tests/Core/GatekeeperTest.php
+++ b/Tests/Core/GatekeeperTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Core {
+    
+    /**
+     * Test gatekeepers
+     */
+    class GatekeeperTest extends \Tests\KnownTestCase  {
+        
+        public function testGatekeeper() {
+            $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'account/settings/', [], []);
+            
+            $response = $result['response'];
+            $this->assertTrue(empty($result['error']));
+            $this->assertTrue($response == 403);
+            
+            $user = \Tests\KnownTestCase::user();
+            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)));
+            
+            $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'account/settings/', [], [
+                'X-KNOWN-USERNAME: ' . $user->handle,
+		'X-KNOWN-SIGNATURE: ' . base64_encode(hash_hmac('sha256', '/account/settings/', $user->getAPIkey(), true)),
+
+            ]);
+            
+            $response = $result['response']; 
+            $this->assertTrue(empty($result['error']));
+            $this->assertTrue($response == 200);
+            
+            \Idno\Core\Idno::site()->session()->logUserOff();
+        }
+        
+        public function testAdminGatekeeper() {
+            $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'admin/', [], []);
+            
+            $response = $result['response'];
+            $this->assertTrue(empty($result['error']));
+            $this->assertTrue($response == 403);
+            
+            $user = \Tests\KnownTestCase::user();
+            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)));
+            
+            // Try normal user
+            \Idno\Core\Idno::site()->session()->logUserOff();
+            $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'admin/', [], [
+                'X-KNOWN-USERNAME: ' . $user->handle,
+		'X-KNOWN-SIGNATURE: ' . base64_encode(hash_hmac('sha256', '/admin/', $user->getAPIkey(), true)),
+
+            ]);
+            
+            $response = $result['response'];
+            $this->assertTrue(empty($result['error']));
+            $this->assertTrue($response == 403);
+            
+            
+            // Try admin 
+            $user = \Tests\KnownTestCase::admin();
+            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)));
+            
+            $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'admin/', [], [
+                'X-KNOWN-USERNAME: ' . $user->handle,
+		'X-KNOWN-SIGNATURE: ' . base64_encode(hash_hmac('sha256', '/admin/', $user->getAPIkey(), true)),
+
+            ]);
+            
+            $response = $result['response'];
+            $this->assertTrue(empty($result['error']));
+            $this->assertTrue($response == 200);
+            
+            \Idno\Core\Idno::site()->session()->logUserOff();
+        }
+        
+        
+    }
+    
+}

--- a/templates/default/pages/403.tpl.php
+++ b/templates/default/pages/403.tpl.php
@@ -15,4 +15,12 @@
             </p>
         </div>
     </div>
+    
+    <?php
+    // Display the login form, if the user is not currently logged in. 
+    // If they're logged out, this is probably why they're denied.
+    if (!\Idno\Core\Idno::site()->session()->isLoggedIn()) { 
+        echo $this->__(['fwd' => $_SERVER['REQUEST_URI']])->draw('account/login'); 
+    } 
+    ?>
 </div>

--- a/templates/default/pages/403.tpl.php
+++ b/templates/default/pages/403.tpl.php
@@ -11,16 +11,20 @@
         <div class="col-md-offset-1 col-md-10">
             <p class="p-summary">It looks like you don't have permission to view this content. Sorry!</p>
             <p>
+                <?php
+                // Display the login link, if the user is not currently logged in. 
+                // If they're logged out, this is probably why they're denied.
+                if (!\Idno\Core\Idno::site()->session()->isLoggedIn()) { 
+                    ?>
+                <a href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login?fwd=' . urlencode($_SERVER['REQUEST_URI']); ?>">Click here to log in.</a> 
+                <?php
+                } else {
+                ?>
                 <a href="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>">Click here to head back to the <?=\Idno\Core\Idno::site()->config()->title?> homepage</a>.
+                <?php } ?>
             </p>
         </div>
     </div>
     
-    <?php
-    // Display the login form, if the user is not currently logged in. 
-    // If they're logged out, this is probably why they're denied.
-    if (!\Idno\Core\Idno::site()->session()->isLoggedIn()) { 
-        echo $this->__(['fwd' => $_SERVER['REQUEST_URI']])->draw('account/login'); 
-    } 
-    ?>
+    
 </div>

--- a/templates/default/pages/403.tpl.php
+++ b/templates/default/pages/403.tpl.php
@@ -16,7 +16,7 @@
                 // If they're logged out, this is probably why they're denied.
                 if (!\Idno\Core\Idno::site()->session()->isLoggedIn()) { 
                     ?>
-                <a href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login?fwd=' . urlencode($_SERVER['REQUEST_URI']); ?>">Click here to log in.</a> 
+                <a id="soft-forward" href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login?fwd=' . urlencode($_SERVER['REQUEST_URI']); ?>">Click here to log in, or wait a moment and you will be taken there...</a>                 
                 <?php
                 } else {
                 ?>

--- a/templates/default/shell.tpl.php
+++ b/templates/default/shell.tpl.php
@@ -442,6 +442,17 @@
     });
 
     /**
+     * "Soft" forward a link on a page.
+     */
+    $(document).ready(function(){
+        var url = $('#soft-forward').attr('href');
+        
+        if (!!url) {
+            window.location = url;
+        }
+    });
+    
+    /**
      * Handle Twitter tweet embedding
      */
     $(document).ready(function () {


### PR DESCRIPTION
Pages now return correct error code (as opposed to forwarding and losing the response code).