### PR TITLE
Caching resources

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,6 +9,11 @@
     RewriteRule ^(.*)$ - [ENV=BASE:%2]
 
     RewriteRule ^js/canary\.js$ %{ENV:BASE}/js/default.js [L]
+
+    # The query string cache trick doesn't really work, so use rewrite rules instead
+    RewriteRule ^js/[0-9]+/(.*)$ %{ENV:BASE}/js/$1 [L]    
+    RewriteRule ^css/[0-9]+/(.*)$ %{ENV:BASE}/css/$1 [L]    
+
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)$ %{ENV:BASE}/index.php?/$1 [L,QSA]

--- a/htaccess.dist
+++ b/htaccess.dist
@@ -9,6 +9,11 @@
     RewriteRule ^(.*)$ - [ENV=BASE:%2]
 
     RewriteRule ^js/canary\.js$ %{ENV:BASE}/js/default.js [L]
+
+    # The query string cache trick doesn't really work, so use rewrite rules instead
+    RewriteRule ^js/[0-9]+/(.*)$ %{ENV:BASE}/js/$1 [L]    
+    RewriteRule ^css/[0-9]+/(.*)$ %{ENV:BASE}/css/$1 [L]    
+
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)$ %{ENV:BASE}/index.php?/$1 [L,QSA]

--- a/templates/default/shell.tpl.php
+++ b/templates/default/shell.tpl.php
@@ -229,7 +229,7 @@
     <![endif]-->
 
     <!-- Default Known JavaScript -->
-    <script src="<?= \Idno\Core\Idno::site()->config()->getStaticURL() . 'js/default.js?20150406' ?>"></script>
+    <script src="<?= \Idno\Core\Idno::site()->config()->getStaticURL() . 'js/' . \Idno\Core\Idno::site()->machineVersion() . '/default.js' ?>"></script>
 
     <!-- To silo is human, to syndicate divine -->
     <link rel="alternate" type="application/rss+xml" title="<?= htmlspecialchars($vars['title']) ?>"

--- a/templates/default/shell/css.tpl.php
+++ b/templates/default/shell/css.tpl.php
@@ -1,2 +1,2 @@
-<link href="<?= \Idno\Core\Idno::site()->config()->getStaticURL() ?>css/default.css?20150907" rel="stylesheet">
-<link href="<?= \Idno\Core\Idno::site()->config()->getStaticURL() ?>css/defaultb3.css?20150123" rel="stylesheet">
+<link href="<?= \Idno\Core\Idno::site()->config()->getStaticURL() ?>css/<?= \Idno\Core\Idno::site()->machineVersion() ?>/default.css" rel="stylesheet">
+<link href="<?= \Idno\Core\Idno::site()->config()->getStaticURL() ?>css/<?= \Idno\Core\Idno::site()->machineVersion() ?>/defaultb3.css" rel="stylesheet">


### PR DESCRIPTION
The ?yyyymmdd query string caching trick doesn't work terribly well with some browsers and any caching proxy.

In the default configuration a proxy will strip the query string, and so see the foo.js?12345 and foo.js?67890 as the same thing, returning a HIT for the earlier version.

Alternatively, another common configuration, anything with a query string is treated as dynamic, and so uncacheable. 

Either way, not good.

This patch provides a rewrite rule that takes a number prior to the path on JS and CSS standard files, allowing new versions to be incremented with machine version numbers.