### PR TITLE
Reconcile DataConcierge::getAnyRecord with other DBs

### DIFF
--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -110,9 +110,8 @@
              */
             function load()
             {
-                if ($config = \Idno\Core\Idno::site()->db()->getAnyObject('config')) {
+                if ($config = \Idno\Core\Idno::site()->db()->getAnyRecord('config')) {
                     $this->default_config = false;
-                    $config = $config->getAttributes();
                     unset($config['dbname']); // Ensure we don't accidentally load protected data from db
                     unset($config['dbpass']);
                     unset($config['dbhost']);

--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -110,35 +110,31 @@
              */
             function load()
             {
-                if ($config = \Idno\Core\Idno::site()->db()->getAnyRecord('config')) {
+                if ($config = \Idno\Core\Idno::site()->db()->getAnyObject('config')) {
                     $this->default_config = false;
-                    if ($config instanceof \Idno\Common\Entity) {
-                        $config = $config->getAttributes();
-                        unset($config['dbname']); // Ensure we don't accidentally load protected data from db
-                        unset($config['dbpass']);
-                        unset($config['dbhost']);
-                        unset($config['dbstring']);
-                        unset($config['path']);
-                        unset($config['url']);
-                        unset($config['host']);
-                        unset($config['feed']);
-                        unset($config['uploadpath']);
-                        //unset($config['initial_plugins']);
-                        //unset($config['antiplugins']);
-                        //unset($config['alwaysplugins']);
-                        unset($config['session_path']);
-                        unset($config['session_hash_function']);
-                        unset($config['sessions_database']);
-                        unset($config['cookie_jar']);
-                        unset($config['proxy_string']);
-                        unset($config['proxy_type']);
-                        unset($config['disable_ssl_verify']);
-                        unset($config['upload_tmp_dir']);
-                        unset($config['bypass_fulltext_search']);
-                    }
-                    if (is_array($config)) {
-                        $this->config = array_merge($this->config, $config);
-                    }
+                    $config = $config->getAttributes();
+                    unset($config['dbname']); // Ensure we don't accidentally load protected data from db
+                    unset($config['dbpass']);
+                    unset($config['dbhost']);
+                    unset($config['dbstring']);
+                    unset($config['path']);
+                    unset($config['url']);
+                    unset($config['host']);
+                    unset($config['feed']);
+                    unset($config['uploadpath']);
+                    //unset($config['initial_plugins']);
+                    //unset($config['antiplugins']);
+                    //unset($config['alwaysplugins']);
+                    unset($config['session_path']);
+                    unset($config['session_hash_function']);
+                    unset($config['sessions_database']);
+                    unset($config['cookie_jar']);
+                    unset($config['proxy_string']);
+                    unset($config['proxy_type']);
+                    unset($config['disable_ssl_verify']);
+                    unset($config['upload_tmp_dir']);
+                    unset($config['bypass_fulltext_search']);
+                    $this->config = array_merge($this->config, $config);
                 }
                 $this->loadIniFiles();
 

--- a/Idno/Core/DataConcierge.php
+++ b/Idno/Core/DataConcierge.php
@@ -154,7 +154,7 @@
              * Converts a database row into an Idno entity
              *
              * @param array $row
-             * @return \Idno\Common\Entity
+             * @return \Idno\Common\Entity | false
              */
             function rowToEntity($row)
             {
@@ -196,11 +196,27 @@
              * Retrieves ANY record from a collection
              *
              * @param string $collection
-             * @return mixed
+             * @return array
              */
             function getAnyRecord($collection = 'entities')
             {
                 return $this->database->$collection->findOne();
+            }
+
+            /**
+             * Retrieves ANY object from a collection.
+             *
+             * @param string $collection
+             * @return \Idno\Common\Entity | false
+             */
+            function getAnyObject($collection = 'entities')
+            {
+                if ($row = $this->getAnyRecord($collection)) {
+                    if ($obj = $this->rowToEntity($row)) {
+                        return $obj;
+                    }
+                }
+                return false;
             }
 
             /**
@@ -424,7 +440,7 @@
 
                 return array('$or' => array(array('body' => $regexObj), array('title' => $regexObj), array('tags' => $regexObj), array('description' => $regexObj)));
             }
-            
+
             /**
              * Internal function which ensures collections are sanitised.
              * @return string Contents of $collection stripped of invalid characters.

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -34,9 +34,9 @@
                         header('Location: ' . \Idno\Core\Idno::site()->config()->forward_on_empty);
                         exit;
                     } else {
-                        
+
                         http_response_code(500);
-                        
+
                         if (\Idno\Core\Idno::site()->config()->debug) {
                             $message = '<p>' . $e->getMessage() . '</p>';
                             $message .= '<p>' . $connection_string . '</p>';
@@ -375,7 +375,7 @@
             {
                 try {
                     $collection = $this->sanitiseCollection($collection);
-                    
+
                     $statement = $this->client->prepare("select distinct {$collection}.* from " . $collection . " where uuid = :uuid");
                     if ($statement->execute(array(':uuid' => $uuid))) {
                         return $statement->fetch(\PDO::FETCH_ASSOC);
@@ -421,7 +421,7 @@
             function getRecord($id, $collection = 'entities')
             {
                 $collection = $this->sanitiseCollection($collection);
-                
+
                 $statement = $this->client->prepare("select {$collection}.* from " . $collection . " where _id = :id");
                 if ($statement->execute(array(':id' => $id))) {
                     return $statement->fetch(\PDO::FETCH_ASSOC);
@@ -434,20 +434,16 @@
              * Retrieves ANY record from a collection
              *
              * @param string $collection
-             * @return mixed
+             * @return array
              */
             function getAnyRecord($collection = 'entities')
             {
                 try {
                     $collection = $this->sanitiseCollection($collection);
-                
+
                     $statement = $this->client->prepare("select {$collection}.* from " . $collection . " limit 1");
                     if ($statement->execute()) {
                         if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
-                            if ($obj = $this->rowToEntity($row)) {
-                                return $obj;
-                            }
-
                             return $row;
                         }
                     }
@@ -548,7 +544,7 @@
             {
                 try {
                     $collection = $this->sanitiseCollection($collection);
-                    
+
                     // Build query
                     $query            = "select distinct {$collection}.* from {$collection} ";
                     $variables        = array();
@@ -840,7 +836,7 @@
                 try {
 
                     $collection = $this->sanitiseCollection($collection);
-                    
+
                     // Build query
                     $query            = "select count(distinct {$collection}.uuid) as total from {$collection} ";
                     $variables        = array();
@@ -895,7 +891,7 @@
                 try {
 
                     $collection = $this->sanitiseCollection($collection);
-                    
+
                     $client = $this->client;
                     /* @var \PDO $client */
                     $statement = $client->prepare("delete from {$collection} where _id = :id");

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -276,33 +276,12 @@
 
                     $statement = $this->client->prepare("select distinct {$collection}.* from " . $collection . " where uuid = :uuid");
                     if ($statement->execute(array(':uuid' => $uuid))) {
-                        return $statement->fetch(\PDO::FETCH_ASSOC);
+                        if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+                            return json_decode($row['contents'], true);
+                        }
                     }
                 } catch (\Exception $e) {
                     \Idno\Core\Idno::site()->logging()->log($e->getMessage());
-                }
-
-                return false;
-            }
-
-            /**
-             * Converts a database row into a Known entity
-             *
-             * @param array $row
-             * @return \Idno\Common\Entity
-             */
-            function rowToEntity($row)
-            {
-                if (!empty($row['entity_subtype']) && !empty($row['contents'])) {
-                    if (class_exists($row['entity_subtype'])) {
-
-                        $contents = (array)json_decode($row['contents'], true);
-
-                        $object = new $row['entity_subtype']();
-                        $object->loadFromArray($contents);
-
-                        return $object;
-                    }
                 }
 
                 return false;
@@ -322,7 +301,9 @@
 
                 $statement = $this->client->prepare("select {$collection}.* from " . $collection . " where _id = :id");
                 if ($statement->execute(array(':id' => $id))) {
-                    return $statement->fetch(\PDO::FETCH_ASSOC);
+                    if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+                        return json_decode($row['contents'], true);
+                    }
                 }
 
                 return false;
@@ -342,7 +323,7 @@
                     $statement = $this->client->prepare("select {$collection}.* from " . $collection . " limit 1");
                     if ($statement->execute()) {
                         if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
-                            return $row;
+                            return json_decode($row['contents'], true);
                         }
                     }
                 } catch (\Exception $e) {
@@ -466,8 +447,14 @@
 
 //                    error_log(str_replace(array_keys($variables), array_values($variables), $query));
 
-                    if ($result = $statement->execute($variables)) {
-                        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+                    if ($statement->execute($variables)) {
+                        if ($rows = $statement->fetchAll(\PDO::FETCH_ASSOC)) {
+                            $records = [];
+                            foreach ($rows as $row) {
+                                $records[] = json_decode($row['contents'], true);
+                            }
+                            return $records;
+                        }
                     }
 
                 } catch (\Exception $e) {

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -40,9 +40,9 @@
                         header('Location: ' . \Idno\Core\Idno::site()->config()->forward_on_empty);
                         exit;
                     } else {
-                        
+
                         http_response_code(500);
-                        
+
                         if (\Idno\Core\Idno::site()->config()->debug) {
                             $message = '<p>' . $e->getMessage() . '</p>';
                             $message .= '<p>' . $connection_string . '</p>';
@@ -273,7 +273,7 @@
             {
                 try {
                     $collection = $this->sanitiseCollection($collection);
-                    
+
                     $statement = $this->client->prepare("select distinct {$collection}.* from " . $collection . " where uuid = :uuid");
                     if ($statement->execute(array(':uuid' => $uuid))) {
                         return $statement->fetch(\PDO::FETCH_ASSOC);
@@ -319,7 +319,7 @@
             function getRecord($id, $collection = 'entities')
             {
                 $collection = $this->sanitiseCollection($collection);
-                
+
                 $statement = $this->client->prepare("select {$collection}.* from " . $collection . " where _id = :id");
                 if ($statement->execute(array(':id' => $id))) {
                     return $statement->fetch(\PDO::FETCH_ASSOC);
@@ -332,20 +332,16 @@
              * Retrieves ANY record from a collection
              *
              * @param string $collection
-             * @return mixed
+             * @return array
              */
             function getAnyRecord($collection = 'entities')
             {
                 try {
                     $collection = $this->sanitiseCollection($collection);
-                
+
                     $statement = $this->client->prepare("select {$collection}.* from " . $collection . " limit 1");
                     if ($statement->execute()) {
                         if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
-                            if ($obj = $this->rowToEntity($row)) {
-                                return $obj;
-                            }
-
                             return $row;
                         }
                     }
@@ -446,7 +442,7 @@
             {
                 try {
                     $collection = $this->sanitiseCollection($collection);
-                    
+
                     // Build query
                     $query            = "select distinct {$collection}.* from {$collection} ";
                     $variables        = array();
@@ -676,7 +672,7 @@
                 try {
 
                     $collection = $this->sanitiseCollection($collection);
-                    
+
                     // Build query
                     $query            = "select count(distinct {$collection}.uuid) as total from {$collection} ";
                     $variables        = array();
@@ -730,7 +726,7 @@
                 try {
 
                     $collection = $this->sanitiseCollection($collection);
-                    
+
                     $client = $this->client;
                     /* @var \PDO $client */
                     $statement = $client->prepare("delete from {$collection} where _id = :id");

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -279,7 +279,9 @@
 
                     $statement = $this->client->prepare("select distinct {$collection}.* from " . $collection . " where uuid = :uuid");
                     if ($statement->execute(array(':uuid' => $uuid))) {
-                        return $statement->fetch(\PDO::FETCH_ASSOC);
+                        if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+                            return json_decode($row['contents'], true);
+                        }
                     }
                 } catch (\Exception $e) {
                     \Idno\Core\Idno::site()->logging()->log($e->getMessage());
@@ -302,7 +304,9 @@
 
                 $statement = $this->client->prepare("select {$collection}.* from " . $collection . " where _id = :id");
                 if ($statement->execute(array(':id' => $id))) {
-                    return $statement->fetch(\PDO::FETCH_ASSOC);
+                    if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+                        return json_decode($row['contents'], true);
+                    }
                 }
 
                 return false;
@@ -322,35 +326,12 @@
                     $statement = $this->client->prepare("select {$collection}.* from " . $collection . " limit 1");
                     if ($statement->execute()) {
                         if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
-                            return $row;
+                            return json_decode($row['contents'], true);
                         }
                     }
                 } catch (\Exception $e) {
                     if (\Idno\Core\Idno::site()->session() == null)
                         die($e->getMessage());
-                }
-
-                return false;
-            }
-
-            /**
-             * Converts a database row into a Known entity
-             *
-             * @param array $row
-             * @return \Idno\Common\Entity
-             */
-            function rowToEntity($row)
-            {
-                if (!empty($row['entity_subtype']) && !empty($row['contents'])) {
-                    if (class_exists($row['entity_subtype'])) {
-
-                        $contents = (array)json_decode($row['contents'], true);
-
-                        $object = new $row['entity_subtype']();
-                        $object->loadFromArray($contents);
-
-                        return $object;
-                    }
                 }
 
                 return false;
@@ -472,8 +453,14 @@
 
                     $statement = $client->prepare($query);
 
-                    if ($result = $statement->execute($variables)) {
-                        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+                    if ($statement->execute($variables)) {
+                        if ($rows = $statement->fetchAll(\PDO::FETCH_ASSOC)) {
+                            $records = [];
+                            foreach($rows as $row) {
+                                $records[] = json_decode($row['contents'], true);
+                            }
+                            return $records;
+                        }
                     }
 
                 } catch (\Exception $e) {

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -45,9 +45,9 @@
                             header('Location: ' . \Idno\Core\Idno::site()->config()->forward_on_empty);
                             exit;
                         } else {
-                            
+
                             http_response_code(500);
-                            
+
                             if (\Idno\Core\Idno::site()->config()->debug) {
                                 $message = '<p>' . $e->getMessage() . '</p>';
                                 $message .= '<p>' . $connection_string . '</p>';
@@ -165,7 +165,7 @@
                         return $array['_id'];
                     }
                 }*/
-                
+
                 $collection = $this->sanitiseCollection($collection);
 
                 if (empty($array['_id'])) {
@@ -276,7 +276,7 @@
             {
                 try {
                     $collection = $this->sanitiseCollection($collection);
-                
+
                     $statement = $this->client->prepare("select distinct {$collection}.* from " . $collection . " where uuid = :uuid");
                     if ($statement->execute(array(':uuid' => $uuid))) {
                         return $statement->fetch(\PDO::FETCH_ASSOC);
@@ -299,7 +299,7 @@
             function getRecord($id, $collection = 'entities')
             {
                 $collection = $this->sanitiseCollection($collection);
-                
+
                 $statement = $this->client->prepare("select {$collection}.* from " . $collection . " where _id = :id");
                 if ($statement->execute(array(':id' => $id))) {
                     return $statement->fetch(\PDO::FETCH_ASSOC);
@@ -312,20 +312,16 @@
              * Retrieves ANY record from a collection
              *
              * @param string $collection
-             * @return mixed
+             * @return array
              */
             function getAnyRecord($collection = 'entities')
             {
                 try {
                     $collection = $this->sanitiseCollection($collection);
-                
+
                     $statement = $this->client->prepare("select {$collection}.* from " . $collection . " limit 1");
                     if ($statement->execute()) {
                         if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
-                            if ($obj = $this->rowToEntity($row)) {
-                                return $obj;
-                            }
-
                             return $row;
                         }
                     }
@@ -450,7 +446,7 @@
                 try {
 
                     $collection = $this->sanitiseCollection($collection);
-                    
+
                     // Build query
                     $query            = "select distinct {$collection}.* from {$collection} ";
                     $variables        = array();
@@ -673,7 +669,7 @@
                 try {
 
                     $collection = $this->sanitiseCollection($collection);
-                
+
                     // Build query
                     $query            = "select count(distinct {$collection}.uuid) as total from {$collection} ";
                     $variables        = array();

--- a/Tests/API/BasicAPITest.php
+++ b/Tests/API/BasicAPITest.php
@@ -1,33 +1,33 @@
 <?php
 
 namespace Tests\API {
-    
+
     /**
      * Initial api tests.
      */
     class BasicAPITest extends \Tests\KnownTestCase  {
-        
+
         public function testConnection() {
-            
+
             $user = \Tests\KnownTestCase::user();
-            
+
             $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . '', [], [
 				    'Accept: application/json',
 				]);
-            
+
             $content = json_decode($result['content']);
             $response = $result['response'];
-            
+
             $this->assertTrue(empty($result['error']));
             $this->assertTrue(!empty($content));
             $this->assertTrue($response == 200);
-            
+
         }
-        
+
         public function testAuthenticated() {
-            
+
             $user = \Tests\KnownTestCase::user();
-            
+
             $result = \Idno\Core\Webservice::post(\Idno\Core\Idno::site()->config()->url . 'status/edit', [
                 'body' => "Making a nice test post via the api",
             ], [

--- a/Tests/Core/PermalinkStructureTest.php
+++ b/Tests/Core/PermalinkStructureTest.php
@@ -11,7 +11,7 @@ namespace Tests\Core {
             $entity->setOwner($this->user());
             $entity->title = "The Title $rnd";
             $entity->body = 'Unlikely to be present elsewhere in the post template: hamstring baseball duckbill firecracker';
-            $entity->save($add_to_feed=true);
+            $entity->save(true);
             return $entity;
         }
 

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -1,19 +1,19 @@
 <?php
 
 namespace Tests\Data {
-    
+
     /**
      * Test the currently configured DataConcierge.
      */
     class DataConciergeTest extends \Tests\KnownTestCase {
-        
+
         public static $object;
         public static $uuid;
         public static $id;
         public static $url;
-        
+
         public static $fts_objects;
-        
+
         public static function setUpBeforeClass()
         {
             $obj = new \Idno\Entities\GenericDataItem();
@@ -22,25 +22,25 @@ namespace Tests\Data {
             $obj->variable1 = 'test';
             $obj->variable2 = 'test again';
             $id = $obj->save();
-            
+
             // Save for later retrieval
             self::$id = $id;
             self::$uuid = $obj->getUUID();
             self::$url = $obj->getUrl();
             self::$object = $obj;
         }
-        
+
         /**
          * Versions test (if applicable)
          */
         public function testVersions() {
             if (is_callable([\Idno\Core\Idno::site()->db(), 'getVersions'])) {
                 $versions = \Idno\Core\Idno::site()->db()->getVersions();
-                
+
                 $this->assertTrue(is_array($versions));
             }
         }
-        
+
         /**
          * Create an object.
          */
@@ -49,10 +49,10 @@ namespace Tests\Data {
             $this->assertFalse(empty(self::$id));
             $this->assertTrue(is_string(self::$uuid));
             $this->assertTrue(is_string(self::$url));
-            
+
             $this->validateObject(self::$object);
         }
-        
+
         /**
          * Attempt to retrieve record by UUID.
          */
@@ -63,7 +63,7 @@ namespace Tests\Data {
                     )
             );
         }
-        
+
         /**
          * Attempt to retrieve record by ID.
          */
@@ -74,61 +74,57 @@ namespace Tests\Data {
                     )
             );
         }
-        
+
         /**
          * Attempt to get any object
          */
         public function testGetAnyRecord() {
-            $obj = \Idno\Core\Idno::site()->db()->getAnyRecord();
-           
-            $this->assertFalse(empty($obj));
-            if (is_array($obj))
-            {
-                print "WARNING: getAnyRecord for this DataConcierge returned an Array. This is inconsistent, but we're converting.";
-                $obj = \Idno\Core\Idno::site()->db()->rowToEntity($obj);
-            }
-            
+            $arr = \Idno\Core\Idno::site()->db()->getAnyRecord();
+
+            $this->assertFalse(empty($arr));
+            $this->assertTrue(is_array($arr));
+            $obj = \Idno\Core\Idno::site()->db()->rowToEntity($arr);
             $this->assertTrue(is_object($obj));
         }
-        
+
         /**
          * Test getByID
          */
         public function testGetById() {
             $obj = \Idno\Entities\GenericDataItem::getByID(self::$id);
-            
+
             $this->validateObject($obj);
         }
-        
+
         /**
          * Test getByID
          */
         public function testGetByUUID() {
             $obj = \Idno\Entities\GenericDataItem::getByUUID(self::$uuid);
-            
+
             $this->validateObject($obj);
         }
-        
+
         public function testGetByMetadata() {
-            
+
             $null = \Idno\Entities\GenericDataItem::get(['variable1' => 'not']);
             $this->assertTrue(empty($null));
-            
+
             $objs = \Idno\Entities\GenericDataItem::get(['variable1' => 'test']);
             $this->assertTrue(is_array($objs));
             $this->validateObject($objs[0]);
         }
-        
+
         public function testGetByMetadataMulti() {
-            
+
             $null = \Idno\Entities\GenericDataItem::get(['variable1' => 'test', 'variable2' => 'not']);
             $this->assertTrue(empty($null));
-            
+
             $objs = \Idno\Entities\GenericDataItem::get(['variable1' => 'test', 'variable2' => 'test again']);
             $this->assertTrue(is_array($objs));
             $this->validateObject($objs[0]);
         }
-        
+
         public function testSearchShort() {
             $search = array();
 
@@ -137,14 +133,14 @@ namespace Tests\Data {
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
             $this->assertTrue(is_int($count));
             $this->assertTrue($count > 0);
-            
+
             $feed  = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
             $this->assertTrue(is_array($feed));
             $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));
         }
-        
+
         public function testSearchLong() {
-            
+
             /** Create couple of FTS objects, since MySQL FTS tables operate in natural language mode */
             $obj = new \Idno\Entities\GenericDataItem();
             $obj->setDatatype('UnitTestObject');
@@ -152,17 +148,17 @@ namespace Tests\Data {
             $obj->variable1 = 'test';
             $obj->variable2 = 'test again';
             $id = $obj->save();
-            
+
             $obj2 = new \Idno\Entities\GenericDataItem();
             $obj2->setDatatype('UnitTestObject');
             $obj2->setTitle("This is some other text because mysql is a pain.");
             $obj2->variable1 = 'test';
             $obj2->variable2 = 'test again';
             $id = $obj2->save();
-            
+
             self::$fts_objects = [$obj, $obj2];
-            
-            
+
+
             $search = array();
 
             $search = \Idno\Core\Idno::site()->db()->createSearchArray("language");
@@ -170,11 +166,11 @@ namespace Tests\Data {
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
             $this->assertTrue(is_int($count));
             $this->assertTrue($count > 0);
-           
+
             $feed  = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_array($feed)); 
+            $this->assertTrue(is_array($feed));
             $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));
-            
+
             // Clean up
             if (static::$fts_objects) {
                 foreach (static::$fts_objects as $obj) {
@@ -182,26 +178,26 @@ namespace Tests\Data {
                 }
             }
         }
-        
+
         public function testCountObjects() {
             $cnt = \Idno\Entities\GenericDataItem::count(['variable1' => 'test']);
-            
+
             $this->assertTrue(is_int($cnt));
             $this->assertTrue($cnt > 0);
         }
-        
+
         /**
          * Helper function to validate object.
          */
         protected function validateObject($obj) {
-            
+
             $this->assertTrue($obj instanceof \Idno\Entities\GenericDataItem);
             $this->assertEquals("".self::$object->getID(), "".$obj->getID());
             $this->assertEquals("".self::$id, "".$obj->getID());
             $this->assertEquals(self::$uuid, $obj->getUUID());
             $this->assertEquals(self::$url, $obj->getUrl());
         }
-        
+
         public static function tearDownAfterClass() {
             if (static::$object) static::$object->delete();
             if (static::$fts_objects) {

--- a/Tests/KnownTestCase.php
+++ b/Tests/KnownTestCase.php
@@ -6,60 +6,60 @@ namespace Tests {
 
         /// Admin user
         public static $testAdmin;
-        
+
         /// Regular user
         public static $testUser;
-        
+
         /**
          * Return a test user, creating it if necessary.
          * @return \Idno\Entities\User
          */
         protected function &user() {
-            
+
             // Have we already got a user?
-            if (static::$testUser) 
+            if (static::$testUser)
                 return static::$testUser;
-            
+
             // Get a user (shouldn't happen)
             if ($user = \Idno\Entities\User::getByHandle('testuser'))
             {
                 static::$testUser = $user;
-            
+
                 return $user;
             }
-            
+
             // No user there, so create one
             $user = new \Idno\Entities\User();
             $user->handle = 'testuser';
             $user->email = 'hello@withknown.com';
             $user->setPassword(md5(rand())); // Set password to something random to mitigate security holes if cleanup fails
             $user->setTitle('Test User');
-            
+
             $user->save();
-            
+
             static::$testUser = $user;
-            
+
             return $user;
         }
-        
+
         /**
          * Return an admin test user, creating it if necessary.
          * @return \Idno\Entities\User
          */
         protected function &admin() {
-            
+
             // Have we already got a user?
-            if (static::$testAdmin) 
+            if (static::$testAdmin)
                 return static::$testAdmin;
-            
+
             // Get a user (shouldn't happen)
             if ($user = \Idno\Entities\User::getByHandle('testadmin'))
             {
                 static::$testAdmin = $user;
-            
+
                 return $user;
             }
-            
+
             // No user there, so create one
             $user = new \Idno\Entities\User();
             $user->handle = 'testadmin';
@@ -67,19 +67,27 @@ namespace Tests {
             $user->setPassword(md5(rand())); // Set password to something random to mitigate security holes if cleanup fails
             $user->setTitle('Test Admin User');
             $user->setAdmin(true);
-            
+
             $user->save();
-            
+
             static::$testAdmin = $user;
-            
+
             return $user;
         }
-        
+
+        /**
+         * Set settings.
+         */
+        public static function setupBeforeClass()
+        {
+            \Idno\Core\Idno::site()->config()->hub = '';
+        }
+
         /**
          * Clean up framework.
-         * @return \Idno\Entities\User
          */
-        public static function tearDownAfterClass() {
+        public static function tearDownAfterClass()
+        {
             // Delete users, if we've created some but forgot to clean up
             if (static::$testUser) {
                 static::$testUser->delete();


### PR DESCRIPTION
Mongo's getAnyRecord always returned an array while
other implementations converted the array to an object
if possible.

Changed all DBs to return an array for getAnyRecord and
added DataConcierge::getAnyObject.

(Config was the only thing using this function
and this allows us to remove some special casing from its
init)

Fixes #978