### PR TITLE
Adds the ability to set a static page as the homepage.

### DIFF
--- a/IdnoPlugins/StaticPages/Main.php
+++ b/IdnoPlugins/StaticPages/Main.php
@@ -15,6 +15,9 @@
                 \Idno\Core\Idno::site()->addPageHandler('/staticpages?/edit/?', 'IdnoPlugins\StaticPages\Pages\Edit');
                 \Idno\Core\Idno::site()->addPageHandler('/staticpages?/edit/([A-Za-z0-9]+)/?', '\IdnoPlugins\StaticPages\Pages\Edit');
                 \Idno\Core\Idno::site()->addPageHandler('/staticpages?/delete/([A-Za-z0-9]+)/?', '\IdnoPlugins\StaticPages\Pages\Delete');
+                \Idno\Core\Idno::site()->addPageHandler('/staticpages?/homepage/set/([A-Za-z0-9]+)/?', 'IdnoPlugins\StaticPages\Pages\SetHomepage');
+                \Idno\Core\Idno::site()->addPageHandler('/staticpages?/homepage/clear/([A-Za-z0-9]+)/?', 'IdnoPlugins\StaticPages\Pages\ClearHomepage');
+
                 \Idno\Core\Idno::site()->addPageHandler('/admin/staticpages/?', 'IdnoPlugins\StaticPages\Pages\Admin');
                 \Idno\Core\Idno::site()->addPageHandler('/admin/staticpages/add/?', 'IdnoPlugins\StaticPages\Pages\Admin\AddCategory');
                 \Idno\Core\Idno::site()->addPageHandler('/admin/staticpages/edit/?', 'IdnoPlugins\StaticPages\Pages\Admin\EditCategory');
@@ -25,9 +28,63 @@
 
                 \Idno\Core\Idno::site()->addPageHandler('/pages/([A-Za-z0-9\-\_]+)/?', 'IdnoPlugins\StaticPages\Pages\View');
 
+                // This makes sure that the homepage is accessible even when it is overridden.
+                \Idno\Core\Idno::site()->addPageHandler('/content/default/?', 'Idno\Pages\Homepage');
+
+                \Idno\Core\Idno::site()->hijackPageHandler('', 'IdnoPlugins\StaticPages\Pages\Homepage');
+                \Idno\Core\Idno::site()->hijackPageHandler('/', 'IdnoPlugins\StaticPages\Pages\Homepage');
+
                 \Idno\Core\Idno::site()->template()->extendTemplate('admin/menu/items', 'staticpages/admin/menu');
                 \Idno\Core\Idno::site()->template()->prependTemplate('shell/toolbar/links', 'staticpages/toolbar', true);
+            }
 
+            /**
+             * Sets a static page as the homepage, overwriting the current setting if one is set.
+             * @param $pageId
+             * @return bool
+             */
+            function setAsHomepage($pageId)
+            {
+
+                if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {
+                    if (\Idno\Core\Idno::site()->session()->currentUser()->isAdmin()) {
+                        if (!empty(\Idno\Common\Entity::getByID($pageId))) {
+                            \Idno\Core\Idno::site()->config->staticPages['homepage'] = $pageId;
+                            return \Idno\Core\Idno::site()->config->save();
+                        }
+                    }
+                }
+
+                return false;
+
+            }
+
+            /**
+             * Removes a previously set static page from acting as the homepage. This will re-enable Known's default
+             * behavior.
+             * @return bool
+             */
+            function clearHomepage()
+            {
+
+                if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {
+                    if (\Idno\Core\Idno::site()->session()->currentUser()->isAdmin()) {
+                        unset(\Idno\Core\Idno::site()->config->staticPages['homepage']);
+                        return \Idno\Core\Idno::site()->config->save();
+                    }
+                }
+
+                return false;
+
+            }
+
+            /**
+             * Gets the ID of the page which is currently acting as the homepage, if any is set.
+             * @return string
+             */
+            function getCurrentHomepageId()
+            {
+                return \Idno\Core\Idno::site()->config->staticPages['homepage'];
             }
 
             /**
@@ -45,7 +102,7 @@
                         if (is_array($categories)) {
                             $categories = implode("\n", $categories);
                         }
-                        \Idno\Core\Idno::site()->config->staticPages = ['categories' => $categories];
+                        \Idno\Core\Idno::site()->config->staticPages['categories'] = $categories;
 
                         return \Idno\Core\Idno::site()->config->save();
 

--- a/IdnoPlugins/StaticPages/Pages/ClearHomepage.php
+++ b/IdnoPlugins/StaticPages/Pages/ClearHomepage.php
@@ -1,0 +1,38 @@
+<?php
+
+    namespace IdnoPlugins\StaticPages\Pages {
+
+        use Idno\Common\Page;
+
+        class ClearHomepage extends Page
+        {
+
+            function getContent()
+            {
+                $this->forward(\Idno\Core\Idno::site()->config()->getURL() . 'admin/staticpages/');
+            }
+
+            function postContent()
+            {
+                $this->adminGatekeeper();
+
+                if (!empty($this->arguments)) {
+                    $object = \IdnoPlugins\StaticPages\StaticPage::getByID($this->arguments[0]);
+                }
+                if (empty($object)) {
+                    $this->forward(\Idno\Core\Idno::site()->config()->getURL() . 'admin/staticpages/');
+                }
+                if ($staticpages = \Idno\Core\Idno::site()->plugins()->get('StaticPages')) {
+
+                    if ($staticpages->getCurrentHomepageId() == $this->arguments[0]) {
+                        $staticpages->clearHomepage();
+                    }
+
+                }
+                $this->forward(\Idno\Core\Idno::site()->config()->getURL() . 'admin/staticpages/');
+
+            }
+
+        }
+
+    }

--- a/IdnoPlugins/StaticPages/Pages/Homepage.php
+++ b/IdnoPlugins/StaticPages/Pages/Homepage.php
@@ -1,0 +1,64 @@
+<?php
+
+    namespace IdnoPlugins\StaticPages\Pages {
+
+        /**
+         * Default class to serve the homepage
+         */
+        class Homepage extends \Idno\Pages\Homepage
+        {
+
+            // Handle GET requests to the entity
+
+            function getContent()
+            {
+                if ($staticpages = \Idno\Core\Idno::site()->plugins()->get('StaticPages')) {
+                    if (!empty($staticpages->getCurrentHomepageId())) {
+                        $object = \Idno\Common\Entity::getByID($staticpages->getCurrentHomepageId());
+                        if (empty($object)) {
+                            $object = \Idno\Common\Entity::getBySlug($staticpages->getCurrentHomepageId());
+                        }
+
+                        if (empty($object)) {
+                            $this->goneContent();
+                        }
+
+                        // From here, we know the object is set
+
+                        // Ensure we're talking about pages ...
+                        if (!($object instanceof \IdnoPlugins\StaticPages\StaticPage)) {
+                            $this->goneContent();
+                        }
+
+                        // Check that we can see it
+                        if (!$object->canRead()) {
+                            $this->deniedContent();
+                        }
+
+                        // Forward if necessary
+                        if (!empty($object->forward_url) && !\Idno\Core\Idno::site()->session()->isAdmin()) {
+                            $this->forward($object->forward_url);
+                        }
+
+                        $this->setOwner($object->getOwner());
+                        $this->setPermalink(); // This is a permalink
+                        $this->setLastModifiedHeader($object->updated); // Say when this was last modified
+                        $t = \Idno\Core\Idno::site()->template();
+                        $t->__(array(
+
+                            'title'       => $object->getTitle(),
+                            'body'        => $t->__(array('object' => $object))->draw('staticpages/page'),
+                            'description' => $object->getShortDescription()
+
+                        ))->drawPage();
+
+                    }
+
+                }
+
+                parent::getContent();
+            }
+
+        }
+
+    }

--- a/IdnoPlugins/StaticPages/Pages/SetHomepage.php
+++ b/IdnoPlugins/StaticPages/Pages/SetHomepage.php
@@ -1,0 +1,38 @@
+<?php
+
+    namespace IdnoPlugins\StaticPages\Pages {
+
+        use Idno\Common\Page;
+
+        class SetHomepage extends Page
+        {
+
+            function getContent()
+            {
+                $this->forward(\Idno\Core\Idno::site()->config()->getURL() . 'admin/staticpages/?test=0');
+            }
+
+            function postContent()
+            {
+                $this->adminGatekeeper();
+
+                if (!empty($this->arguments)) {
+                    $object = \IdnoPlugins\StaticPages\StaticPage::getByID($this->arguments[0]);
+                }
+                if (empty($object)) {
+                    $this->forward(\Idno\Core\Idno::site()->config()->getURL() . 'admin/staticpages/?test=1');
+                }
+                if ($staticpages = \Idno\Core\Idno::site()->plugins()->get('StaticPages')) {
+
+                    $success = $staticpages->setAsHomepage($this->arguments[0]);
+
+                }
+                $this->forward(\Idno\Core\Idno::site()->config()->getURL() . 'admin/staticpages/?test=2');
+
+            }
+
+        }
+
+    }
+
+?>

--- a/IdnoPlugins/StaticPages/StaticPage.php
+++ b/IdnoPlugins/StaticPages/StaticPage.php
@@ -35,6 +35,24 @@
                 return 0;
             }
 
+            function getSetAsHomepageURL()
+            {
+                return \Idno\Core\site()->config()->getDisplayURL() . $this->getClassSelector() . '/homepage/set/' . $this->getID();
+            }
+
+            function getClearHomepageURL()
+            {
+                return \Idno\Core\site()->config()->getDisplayURL() . $this->getClassSelector() . '/homepage/clear/' . $this->getID();
+            }
+
+            function isHomepage()
+            {
+                if ($staticpages = \Idno\Core\site()->plugins()->get('StaticPages')) {
+                    return $staticpages->getCurrentHomepageId() == $this->getID();
+                }
+                return false;
+            }
+
             function getActivityStreamsObjectType()
             {
                 return 'article';

--- a/IdnoPlugins/StaticPages/plugin.ini
+++ b/IdnoPlugins/StaticPages/plugin.ini
@@ -1,6 +1,6 @@
 [Plugin description]
 name =              "Static pages"
-version =           0.1
+version =           0.2
 author =            "Known"
 author_email =      "feedback@withknown.com"
 author_url =        "http://withknown.com"

--- a/IdnoPlugins/StaticPages/templates/default/shell/toolbar/content/default.tpl.php
+++ b/IdnoPlugins/StaticPages/templates/default/shell/toolbar/content/default.tpl.php
@@ -1,0 +1,17 @@
+<?php
+
+    $url = \Idno\Core\Idno::site()->config()->getDisplayURL();
+
+    if ($staticpages = \Idno\Core\Idno::site()->plugins()->get('StaticPages')) {
+        if (!empty($staticpages->getCurrentHomepageId())) {
+            $url .= 'content/default/';
+        }
+    }
+
+    $url .= $vars['search'];
+
+    $title = 'Default content';
+
+    echo $this->__(array( 'url' => $url, 'title' => $title ))->draw('shell/toolbar/content/entry');
+
+?>

--- a/IdnoPlugins/StaticPages/templates/default/staticpages/admin.tpl.php
+++ b/IdnoPlugins/StaticPages/templates/default/staticpages/admin.tpl.php
@@ -1,3 +1,22 @@
+<style>
+    .home-icon {
+        display: block;
+        width: 100%;
+        height: 100%;
+        text-align: center;
+    }
+
+    .home-icon:hover .no-hover,
+    .home-icon .hover {
+        display: none;
+    }
+
+    .home-icon:hover .hover,
+    .home-icon .no-hover {
+        display: inline;
+    }
+</style>
+
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
         <?= $this->draw('admin/menu') ?>
@@ -30,7 +49,8 @@
                 <table style="width: 100%; margin-bottom: 3em">
                     <thead>
                         <tr class="pages">
-                            <td class="pages" width="35%">Title</td>
+                            <td class="pages" width="5%">&nbsp;</td>
+                            <td class="pages" width="30%">Title</td>
                             <td class="pages" width="35%">Category</td>
                             <td class="pages" width="15%">&nbsp;</td>
                             <td class="pages" width="15%">&nbsp;</td>
@@ -53,11 +73,45 @@
                                         ?>
                                         <tr class="items" data-value="<?= $page->getID() ?>">
                                             <td>
+                                                <?php
+                                                if ($page->isHomepage()) {
+
+                                                    echo  \Idno\Core\site()->actions()->createLink($page->getClearHomepageURL(), '<icon class="fa fa-home no-hover"></icon><icon class="fa fa-times hover"></icon>', array(), array('method' => 'POST', 'class' => 'home-icon', 'title' => 'Clear Homepage', 'confirm' => true, 'confirm-text' => 'Are you sure you want to clear this from your homepage?'));
+
+                                                } else {
+
+                                                    echo  \Idno\Core\site()->actions()->createLink($page->getSetAsHomepageURL(), '<icon class="fa fa-home hover"></icon><div class="no-hover">&nbsp;</div>', array(), array('method' => 'POST', 'class' => 'home-icon', 'title' => 'Set as Homepage', 'confirm' => true, 'confirm-text' => 'Are you sure you want to set this page as your homepage?'));
+
+                                                }
+
+                                            ?>
+                                            </td>
+                                            <td>
                                                 <a href="<?= $page->getURL() ?>"><?= htmlspecialchars($page->getTitle()) ?></a>
                                             </td>
                                             <td>
                                                 <?= $category ?>
                                             </td>
+                                            <!--td>
+                                                <?php
+                                                if ($page->isHomepage()) {
+
+                                                    ?>
+                                                    <icon class="fa fa-times"></icon>
+                                                    <?=  \Idno\Core\site()->actions()->createLink($page->getClearHomepageURL(), 'Clear Homepage', array(), array('method' => 'POST', 'class' => 'edit', 'confirm' => true, 'confirm-text' => 'Are you sure you want to clear this from your homepage?'));?>
+                                                <?php
+
+                                                } else {
+
+                                                    ?>
+                                                    <icon class="fa fa-check"></icon>
+                                                    <?=  \Idno\Core\site()->actions()->createLink($page->getSetAsHomepageURL(), 'Set as Homepage', array(), array('method' => 'POST', 'class' => 'edit', 'confirm' => true, 'confirm-text' => 'Are you sure you want to set this page as your homepage?'));?>
+                                                <?php
+
+                                                }
+
+                                            ?>
+                                            </td-->
                                             <td>
                                                 <icon class="fa fa-pencil"></icon> <a href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() ?>staticpage/edit/<?= $page->_id ?>">Edit</a>
                                             </td>

--- a/IdnoPlugins/StaticPages/templates/default/staticpages/toolbar.tpl.php
+++ b/IdnoPlugins/StaticPages/templates/default/staticpages/toolbar.tpl.php
@@ -12,57 +12,66 @@
 
                         if (!empty($pages)) {
                             foreach($pages as $page) {
-                                ?>
-                                <li>
-                                	<ul class="nav">
-                                    	<li>
-                                        	<a href="<?= $page->getURL() ?>"><?= htmlspecialchars($page->getTitle()) ?></a>
-											</li>
-                                	</ul>
-                                </li>
-                                <?php
+                                if (!$page->isHomepage()) {
+                                    ?>
+                                    <li>
+                                    	<ul class="nav">
+                                        	<li>
+                                            	<a href="<?= $page->getURL() ?>"><?= htmlspecialchars($page->getTitle()) ?></a>
+    											</li>
+                                    	</ul>
+                                    </li>
+                                    <?php
+                                }
                             }
                         }
 
                     } else {
 
-                        ?>
+                        // If the category's only element is a the homepage, we should suppress it rather than showing
+                        // an empty dropdown. At this point, the array is proven to be non-empty so there's no need to
+                        // guard for that here.
+                        if ( count($pages) > 1 || !array_values($pages)[0]->isHomepage() ) {
+                            ?>
 
-                       <li>
-                        <ul class="nav">
-                            <li class="dropdown">
-                                <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                                    <?= $category ?>
-                                    <b class="caret"></b>
-                                </a>
-                                <ul class="dropdown-menu">
-                                    <?php
-
-                                        if (substr($category, 0, 1) == '#') {
-                                            ?>
-                                            <li>
-                                                <a href="<?= \Idno\Core\Idno::site()->config()->getURL() ?>content/all/?q=<?= urlencode($category) ?>">Stream</a>
-                                            </li>
+                           <li>
+                            <ul class="nav">
+                                <li class="dropdown">
+                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                                        <?= $category ?>
+                                        <b class="caret"></b>
+                                    </a>
+                                    <ul class="dropdown-menu">
                                         <?php
-                                        }
-                                        if (!empty($pages)) {
-                                            foreach ($pages as $page) {
+
+                                            if (substr($category, 0, 1) == '#') {
                                                 ?>
                                                 <li>
-                                                    <a href="<?= $page->getURL() ?>"><?= htmlspecialchars($page->getTitle()) ?></a>
+                                                    <a href="<?= \Idno\Core\Idno::site()->config()->getURL() ?>content/all/?q=<?= urlencode($category) ?>">Stream</a>
                                                 </li>
                                             <?php
                                             }
-                                        }
+                                            if (!empty($pages)) {
+                                                foreach ($pages as $page) {
+                                                    if (!$page->isHomepage()) {
+                                                        ?>
+                                                        <li>
+                                                            <a href="<?= $page->getURL() ?>"><?= htmlspecialchars($page->getTitle()) ?></a>
+                                                        </li>
+                                                    <?php
+                                                    }
+                                                }
+                                            }
 
-                                    ?>
-                                </ul>
-                            </li>
-                        </ul>
-                        
-                       </li>
+                                        ?>
+                                    </ul>
+                                </li>
+                            </ul>
 
-                    <?php
+                           </li>
+
+                        <?php
+                        }
                     }
 
                 }

--- a/templates/default/forms/link.tpl.php
+++ b/templates/default/forms/link.tpl.php
@@ -7,10 +7,10 @@
     if (empty($vars['method']) || !in_array($vars['method'],array('GET','POST','PUT','DELETE'))) $vars['method'] = 'POST';
 
 ?>
-<a <?php if (!empty($vars['class'])) { ?> class="<?=$vars['class'];?>" <?php } ?> href="<?=($vars['url'])?>" onclick="<?php 
+<a <?php if (!empty($vars['class'])) { ?> class="<?=$vars['class'];?>" <?php } ?> <?php if (!empty($vars['title'])) { ?> title="<?=$vars['title'];?>" <?php } ?> href="<?=($vars['url'])?>" onclick="<?php 
     if ($vars['confirm']) {
         ?>if (confirm('<?= addslashes($vars['confirm-text']); ?>')) { $('#<?=$uniqueID?>').submit(); return false; } else { return false; } <?php
-    } else { 
+    } else {
         ?>$('#<?=$uniqueID?>').submit(); return false; <?php
     } ?>"><?=($vars['label'])?></a>
 <?php

--- a/templates/default/shell/toolbar/content.tpl.php
+++ b/templates/default/shell/toolbar/content.tpl.php
@@ -11,13 +11,17 @@
         }
 
         ?>
-        
+
             <li class="dropdown" tabindex="3">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
                     <?php
 
                         if (!empty($vars['content'])) {
-                            echo \Idno\Common\ContentType::categoryTitleSlugsToFriendlyName($vars['content']);
+                            $friendly_name = \Idno\Common\ContentType::categoryTitleSlugsToFriendlyName($vars['content']);
+                        }
+
+                        if (!empty($friendly_name)) {
+                            echo $friendly_name;
                         } else {
                             echo 'Filter content';
                         }
@@ -26,21 +30,16 @@
                     <span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu" role="menu">
-                    <li><a href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . $search ?>"><span class="dropdown-menu-icon">&nbsp;</span>
-                            Default content</a></li>
-                    <li><a href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/' . $search ?>"><span class="dropdown-menu-icon">&nbsp;</span>
-                            All content</a></li>
                     <?php
+
+                        echo $this->__(array( 'search' => $search ))->draw("shell/toolbar/content/default");
+                        echo $this->__(array( 'search' => $search ))->draw("shell/toolbar/content/all");
 
                         foreach ($content_types as $content_type) {
 
                             if (empty($content_type->hide)) {
                                 /* @var Idno\Common\ContentType $content_type */
-                                ?>
-                                <li><a
-                                    href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() ?>content/<?= $content_type->getCategoryTitleSlug() ?>/<?= $search ?>"><span
-                                        class="dropdown-menu-icon"><?= $content_type->getIcon() ?></span> <?= $content_type->getCategoryTitle() ?>
-                                </a></li><?php
+                                echo $this->__(array( 'content_type' => $content_type, 'search' => $search ))->draw("shell/toolbar/content/type");
                             }
                         }
 

--- a/templates/default/shell/toolbar/content/all.tpl.php
+++ b/templates/default/shell/toolbar/content/all.tpl.php
@@ -1,0 +1,8 @@
+<?php
+
+    $url = \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/' . $vars['search'];
+    $title = 'All content';
+
+    echo $this->__(array( 'url' => $url, 'title' => $title ))->draw('shell/toolbar/content/entry');
+
+?>

--- a/templates/default/shell/toolbar/content/default.tpl.php
+++ b/templates/default/shell/toolbar/content/default.tpl.php
@@ -1,0 +1,8 @@
+<?php
+
+    $url = \Idno\Core\Idno::site()->config()->getDisplayURL() . $vars['search'];
+    $title = 'Default content';
+
+    echo $this->__(array( 'url' => $url, 'title' => $title ))->draw('shell/toolbar/content/entry');
+
+?>

--- a/templates/default/shell/toolbar/content/entry.tpl.php
+++ b/templates/default/shell/toolbar/content/entry.tpl.php
@@ -1,0 +1,12 @@
+<li>
+    <a href="<?= $vars['url'] ?>">
+        <span class="dropdown-menu-icon"><?php
+            if (!empty($vars['icon'])) {
+                echo $vars['icon'];
+            } else {
+                echo '&nbsp;';
+            }
+        ?></span>
+        <?= $vars['title'] ?>
+    </a>
+</li>

--- a/templates/default/shell/toolbar/content/type.tpl.php
+++ b/templates/default/shell/toolbar/content/type.tpl.php
@@ -1,0 +1,15 @@
+<?php
+
+    $content_type = $vars['content_type'];
+
+    if (!empty($content_type)) {
+
+        $url = \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/' . $content_type->getCategoryTitleSlug() . '/' . $vars['search'];
+        $icon = $content_type->getIcon();
+        $title = $content_type->getCategoryTitle();
+
+        echo $this->__(array( 'url' => $url, 'icon' => $icon, 'title' => $title ))->draw('shell/toolbar/content/entry');
+
+    }
+
+?>


### PR DESCRIPTION
I'm new to Known, and my day job is not PHP so this probably needs some cleanup.

Anyway, my primary motivation for this plugin was to make it easier to customize the homepage without too much work creating plugins and themes. I knew that I had the ability to create static pages, but none of them could be promoted to the homepage.

This adds the ability to set a page as your homepage by pressing the "home" icon on the pages admin page. In order for the homepage not to disappear completely, I needed to modify the "links" template in order to allow me to modify the default link. In addition, I added the ability to set a title on links created by "createLink" in order to condense the homepage toggle down to just an icon in order to save space.

I tried to make the former homepage discoverable, but I'm not in love with how this does that. Please, give me any and all suggestions you may have.