### PR TITLE
Fixes the broken status/replies datamodel

### DIFF
--- a/IdnoPlugins/Status/Status.php
+++ b/IdnoPlugins/Status/Status.php
@@ -15,14 +15,12 @@
                 $inreplyto = \Idno\Core\Idno::site()->currentPage()->getInput('inreplyto');
                 $body      = \Idno\Core\Idno::site()->currentPage()->getInput('body');
 
-                if (!empty(\Idno\Core\Idno::site()->config()->split_replies)) {
-                    if (!empty($inreplyto)) {
-                        return new Reply();
-                    }
+                if (!empty($inreplyto)) {
+                    return new Reply();
+                }
 
-                    if ($body[0] == '@') {
-                        return new Reply();
-                    }
+                if ($body[0] == '@') {
+                    return new Reply();
                 }
 
                 return new Status();


### PR DESCRIPTION
Ensure replies are always created as replies in order to prevent a broken/inconsistent data model.

Hiding replies as replies needs to be handled in the UX otherwise users perceive behaviour as a bug