### PR TITLE
posse_links tweaks

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1102,7 +1102,8 @@
              * Sets the POSSE link for this entity to a particular service
              * @param $service The name of the service
              * @param $url The URL of the post
-             * @param $identifier A human-readable identifier
+             * @param $identifier A human-readable account identifier
+             * @param $item_id A Known-readable item identifier
              * @param $account_id A Known-readable account identifier
              * @return bool
              */

--- a/css/default.css
+++ b/css/default.css
@@ -814,11 +814,6 @@ textarea:focus, input[type="url"]:focus {
     outline: 0 none;
 }
 
-select, textarea, input[type="text"], input[type="password"], input[type="datetime"], input[type="datetime-local"], input[type="date"], input[type="month"], input[type="time"], input[type="week"], input[type="number"], input[type="email"], input[type="url"], input[type="tel"], input[type="color"], .uneditable-input {
-	margin-top: 5px;
-	margin-bottom: 10px;
-}
-
 .blank-footer {
     margin: auto;
     padding-top: 50px;

--- a/templates/default/account/settings.tpl.php
+++ b/templates/default/account/settings.tpl.php
@@ -21,10 +21,10 @@
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
 
-        <form class="navbar-form admin" action="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>account/settings/" method="post">
+        <form class="form-horizontal admin" action="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>account/settings/" method="post">
 
 
-            <div class="row">
+            <div class="form-group">
                 <div class="col-md-2">
                     <label class="control-label" for="inputName">Your name</label>
                 </div>
@@ -36,7 +36,7 @@
                 </div>
             </div>
 
-            <div class="row">
+            <div class="form-group">
                 <div class="col-md-2">
                     <label class="control-label" for="inputHandle">Your username</label>
                 </div>
@@ -47,7 +47,7 @@
                 </div>
             </div>
 
-            <div class="row">
+            <div class="form-group">
                 <div class="col-md-2">
                     <label class="control-label" for="inputEmail">Your email address</label>
                 </div>
@@ -59,7 +59,7 @@
                 </div>
             </div>
 
-            <div class="row">
+            <div class="form-group">
                 <div class="col-md-2">
                     <label class="control-label" for="inputPassword">Your password<br>
                     </label>

--- a/templates/default/admin/themes.tpl.php
+++ b/templates/default/admin/themes.tpl.php
@@ -12,9 +12,7 @@
 
             if (!empty($vars['themes_stored']) && is_array($vars['themes_stored'])) {
                 // Check for active theme
-                if (!empty($vars['theme'])){
-                    $currentTheme = $vars['theme'];
-                }
+                $currentTheme = !empty($vars['theme']) ? $vars['theme'] : false;
                 // Loop through the array to pull out active theme and draw it
                 foreach($vars['themes_stored'] as $shortname => $theme) {
                     $theme['shortname'] = $shortname;

--- a/templates/default/content/syndication.tpl.php
+++ b/templates/default/content/syndication.tpl.php
@@ -2,32 +2,35 @@
 
     $buttons = '';
     if (!empty($vars['services'])) {
-        
+
         // Preserve service details for API
         $service_details = [];
-        
+
         foreach($vars['services'] as $service) {
 
             if (\Idno\Core\Idno::site()->syndication()->has($service)) {
-                
+
                 $service_details[$service] = [];
 
                 $button = $this->draw('content/syndication/' . $service);
                 if (empty($button)) {
                     $disabled = '';
                     $posse_links = $vars['posseLinks'];
+
                     if ($accounts = \Idno\Core\Idno::site()->syndication()->getServiceAccounts($service)) {
                         foreach($accounts as $account) {
-                            $posse_service = $posse_links[$service];
-                            if (is_array($posse_service)) {
-                                foreach ($posse_service as $key => $posse_account) {
-                                    if ($posse_account['account_id'] === $account['name']) {
-                                        $disabled = 'disabled';
+                            if (isset($posse_links[$service])) {
+                                $posse_service = $posse_links[$service];
+                                if (is_array($posse_service)) {
+                                    foreach ($posse_service as $posse_account) {
+                                        if ($posse_account['account_id'] === $account['username']) {
+                                            $disabled = 'disabled';
+                                        }
                                     }
                                 }
                             }
                             $service_details[$service][] = ['username' => $account['username'], 'name' => $account['name']];
-                            
+
                             $button .= $this->__(array('service' => $service, 'disabled' => $disabled, 'username' => $account['username'], 'name' => $account['name'], 'selected' => \Idno\Core\Idno::site()->triggerEvent('syndication/selected/' . $service, [
                                 'service' => $service,
                                 'username' => $account['username'],
@@ -50,12 +53,12 @@
             }
 
         }
-        
+
         // Since template vars aren't scoped, reset vars to avoid them appearing in API views
         unset($this->vars['service']);
         unset($this->vars['username']);
         unset($this->vars['name']);
-        
+
         // Output service details for API
         $this->vars['services'] = $service_details;
     }

--- a/templates/default/content/syndication/links.tpl.php
+++ b/templates/default/content/syndication/links.tpl.php
@@ -10,19 +10,19 @@
         Also on:
         <?php
 
-            foreach ($posse as $service => $posse_link) {
-
-                $human_icon = $this->draw('content/syndication/icon/' . $service);
-                if (empty($human_icon)) {
-                    $human_icon = $this->draw('content/syndication/icon/generic');
+            foreach ($posse as $service => $posse_links) {
+                if (is_string($posse_links)) {
+                    $posse_links = [['url' => $posse_links, 'identifier' => $service]];
                 }
 
-                if (is_array($posse_link)) {
-                    foreach($posse_link as $element) {
-                        echo '<a href="' . $element['url'] . '" rel="syndication" class="u-syndication ' . $service . '">' . $human_icon . ' ' . $element['identifier'] . '</a> ';
+                foreach($posse_links as $element) {
+                    $this->username = isset($element['account_id']) ? $element['account_id'] : false;
+                    $human_icon = $this->draw('content/syndication/icon/' . $service);
+                    if (empty($human_icon)) {
+                        $human_icon = $this->draw('content/syndication/icon/generic');
                     }
-                } else {
-                    echo '<a href="' . $posse_link . '" rel="syndication" class="u-syndication ' . $service . '">' . $human_icon . ' ' . $service . '</a> ';
+
+                    echo '<a href="' . $element['url'] . '" rel="syndication" class="u-syndication ' . $service . '">' . $human_icon . ' ' . $element['identifier'] . '</a> ';
                 }
             }
 


### PR DESCRIPTION
* set syndication buttons disabled based on posse_link['username'] rather than 'name'
* pass 'username' to syndication links icon template
* minor theme tweaks; don't hard-code spacing between form elements, it breaks
  bootstrap's form-group spacing