### PR TITLE
Remove getRelativePublishDate().

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -867,26 +867,6 @@
             }
 
             /**
-             * Return the creation date of this entity, relative to now.
-             * @return string
-             */
-            function getRelativePublishDate()
-            {
-                $distance = time() - $this->created;
-                if ($distance < 86400) {
-                    if ($distance < 60) {
-                        return $distance . 's';
-                    } else if ($distance < 3600) {
-                        return ceil($distance / 60) . 'm';
-                    } else {
-                        return ceil($distance / 60 / 60) . 'h';
-                    }
-                } else {
-                    return date('M d Y', $this->created);
-                }
-            }
-
-            /**
              * Set the access group of this object
              * @param mixed $access The ID of the access group or an AccessGroup object
              * return true|false


### PR DESCRIPTION
getRelativePublishDate() does not appear to be used and isn't localised in either timezone or language.

This sort of thing is better handled on the fly computing from a GMT timestamp to local wallclock, with translations applied (e.g. by timeago on the main template)

Closes #729
Refs #339