### PR TITLE
allow ContentTypes to override their default edit URL

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1632,7 +1632,7 @@
                     }
                 }
 
-                return \Idno\Core\Idno::site()->config()->getDisplayURL() . $this->getClassSelector() . '/edit';
+                return $this->getEditURL();
 
             }
 

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -436,6 +436,8 @@
                     if ($public == true) {
                         $this->public_pages[] = $handler;
                     }
+                } else {
+                    $this->logging()->log("Could not add $pattern. $handler not found", LOGLEVEL_ERROR);
                 }
             }
 

--- a/js/default.js
+++ b/js/default.js
@@ -23,14 +23,14 @@ function bindControls() {
 
 var isCreateFormVisible = false;
 
-function contentCreateForm(plugin) {
+function contentCreateForm(plugin, editUrl) {
     if (isCreateFormVisible) {
         // Ignore additional clicks on create button
         return;
     }
 
     isCreateFormVisible = true;
-    $.ajax(wwwroot() + plugin + '/edit/', {
+    $.ajax(editUrl, {
         dataType: 'html',
         success: function (data) {
             $('#contentCreate').html(data).slideDown(400);

--- a/templates/default/content/create.tpl.php
+++ b/templates/default/content/create.tpl.php
@@ -16,7 +16,7 @@
 
                     <a class="contentTypeButton" id="<?= $entityType ?>Button"
                        href="<?= $contentType->getEditURL() ?>"
-                       onclick="contentCreateForm('<?= $entityType ?>'); return false;">
+                       onclick="event.preventDefault(); contentCreateForm('<?= $entityType ?>', '<?= $contentType->getEditURL() ?>'); return false;">
                         <span class="contentTypeLogo"><?= $contentType->getIcon() ?></span>
                         <?= $contentType->getTitle() ?>
                     </a>


### PR DESCRIPTION
fixes the remaining conflict between IndePlugins/Reactions/Like and
IdnoPlugins/Like/Like because Reactions can use any edit url it
prefers now (currently using /indielike/edit instead of /like/edit,
which is admittedly a little bit puerile, "my likes are indier than
yours")