### PR TITLE
don't interpret "u-like" and "u-repost" in received webmentions

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1936,11 +1936,6 @@
                                     $mention['url'] = $item['properties']['url'];
                                 }
                             }
-                            if (!empty($item['properties']['like']) && is_array($item['properties']['like'])) {
-                                if (in_array($target, static::getStringURLs($item['properties']['like']))) {
-                                    $mention['type'] = 'like';
-                                }
-                            }
                             if (!empty($item['properties']['like-of']) && is_array($item['properties']['like-of'])) {
                                 if (in_array($target, static::getStringURLs($item['properties']['like-of']))) {
                                     $mention['type'] = 'like';
@@ -1950,7 +1945,7 @@
                                 $mention['type']    = 'rsvp';
                                 $mention['content'] = implode(' ', $item['properties']['rsvp']);
                             }
-                            foreach (array('share', 'repost', 'repost-of') as $verb) {
+                            foreach (array('share', 'repost-of') as $verb) {
                                 if (!empty($item['properties'][$verb]) && is_array($item['properties'][$verb])) {
                                     if (in_array($target, static::getStringURLs($item['properties'][$verb]))) {
                                         $mention['type'] = 'share';


### PR DESCRIPTION
- drop support for receiving old-style mf2 likes and reposts.
- these classes are now more often used to mark up likes and reposts,
  and our own likes can end up being backfed to us if the sender
  implements salmentions

there are ways to do this more intelligently if we need to keep
support for these older classes, but i'm not aware of anyone that
still uses u-like/u-repost exclusively

fixes #1245