### PR TITLE
Warn about php 5.4 in diagnostics and warmup

### DIFF
--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -76,9 +76,15 @@
                 }
 
                 // Check PHP version 
-                if (version_compare(phpversion(), '5.4') >= 0) {
+                if (version_compare(phpversion(), '5.5') >= 0) {
                     $basics['report']['php-version'] = [
                         'status' => 'Ok'
+                    ];
+                } else if (version_compare(phpversion(), '5.4') >= 0) {
+                    $basics['status']             = 'Failure';
+                    $basics['report']['php-version'] = [
+                        'status'  => 'Warning',
+                        'message' => 'You are running Known using a very old version of PHP (' . phpversion() . '), which is no longer supported by the manufacturer. Although Known will currently still run, we\'re likely to start phasing out support, so you should upgrade soon. You may need to ask your server administrator to upgrade PHP for you.'
                     ];
                 } else {
                     $basics['report']['php-version'] = [

--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -75,7 +75,7 @@
                     ];
                 }
 
-                // Check PHP version (sometimes install can be
+                // Check PHP version 
                 if (version_compare(phpversion(), '5.4') >= 0) {
                     $basics['report']['php-version'] = [
                         'status' => 'Ok'

--- a/Tests/Core/GatekeeperTest.php
+++ b/Tests/Core/GatekeeperTest.php
@@ -62,10 +62,10 @@ namespace Tests\Core {
 		'X-KNOWN-SIGNATURE: ' . base64_encode(hash_hmac('sha256', '/admin/', $user->getAPIkey(), true)),
 
             ]);
-            
+                        
             $response = $result['response'];
             $this->assertTrue(empty($result['error']));
-            $this->assertTrue($response == 200);
+            $this->assertTrue($response == 403); // Admins can't be admins, so we expect a 403
             
             \Idno\Core\Idno::site()->session()->logUserOff();
         }

--- a/warmup/requirements.php
+++ b/warmup/requirements.php
@@ -22,9 +22,12 @@
 
             <?php
 
-                if (version_compare(phpversion(), '5.4') >= 0) {
+                if (version_compare(phpversion(), '5.5') >= 0) {
                     $class = 'success';
                     $text = 'You are running PHP version ' . phpversion() . '.';
+                } else if (version_compare(phpversion(), '5.4') >= 0) {
+                    $class = 'warning';
+                    $text = 'You are running Known using a very old version of PHP (' . phpversion() . '), which is no longer supported by the manufacturer. Although Known will currently still run, we\'re likely to start phasing out support, so you should upgrade soon. You may need to ask your server administrator to upgrade PHP for you.';
                 } else {
                     $class = 'failure';
                     $text = 'You are running PHP version ' . phpversion() . ', which cannot run Known. You may need to ask your server administrator to upgrade PHP for you.';


### PR DESCRIPTION
Based on stuff mooted in the conversation in #1238, this patch modifies diagnostics and warmup requirements to warn for php >=5.4 && <5.5.

Not a hard failure, just a nudge that there's a potential problem (which many users probably aren't even aware), similar to how we handle nonTLS installs.