### PR TITLE
set_time_limit won't work in safemode

### DIFF
--- a/Idno/start.php
+++ b/Idno/start.php
@@ -52,7 +52,7 @@
     }
 
 // Set time limit if we're using less
-    if (ini_get('max_execution_time') < 120) {
+    if (ini_get('max_execution_time') < 120 && ini_get('safe_mode')) {
         set_time_limit(120);
     }
 


### PR DESCRIPTION
Small fix to suppress warnings on shared hosts where php.ini/safe mode can't be modified.