### PR TITLE
bugfix: PuSH was not pinging the homepage

### DIFF
--- a/Idno/Core/PubSubHubbub.php
+++ b/Idno/Core/PubSubHubbub.php
@@ -258,7 +258,7 @@
                     $homepage_types   = \Idno\Core\Idno::site()->config()->getHomepageContentTypes();
                     $type_in_homepage = false;
                     if ($object instanceof Entity) {
-                        if (in_array($object->getContentType(), $homepage_types)) {
+                        if (in_array($object->getContentType()->getEntityClass(), $homepage_types)) {
                             $type_in_homepage = true;
                         }
                     }


### PR DESCRIPTION
PuSH pings weren't being sent for / because it was checking for the ContentType itself rather than the class that the ContentType represents