### PR TITLE
Refs #1247: Run DB optimisation on a shutdown hook.

### DIFF
--- a/Idno/Pages/Admin/Home.php
+++ b/Idno/Pages/Admin/Home.php
@@ -15,13 +15,15 @@
             function getContent()
             {
                 $this->adminGatekeeper(); // Admins only
-                $lastOptTime = empty(\Idno\Core\Idno::site()->config()->dboptimized) ? 0 : \Idno\Core\Idno::site()->config()->dboptimized;
-                if (($time = time()) - $lastOptTime > 24 * 60 * 60) {
-                    \Idno\Core\Idno::site()->logging()->log("Optimizing database tables. Last run " . date('Y-m-d H:i:s', $lastOptTime));
-                    \Idno\Core\Idno::site()->db()->optimize();
-                    \Idno\Core\Idno::site()->config()->dboptimized = $time;
-                    \Idno\Core\Idno::site()->config()->save();
-                }
+                register_shutdown_function(function () {
+                    $lastOptTime = empty(\Idno\Core\Idno::site()->config()->dboptimized) ? 0 : \Idno\Core\Idno::site()->config()->dboptimized;
+                    if (($time = time()) - $lastOptTime > 24 * 60 * 60) {
+                        \Idno\Core\Idno::site()->logging()->log("Optimizing database tables. Last run " . date('Y-m-d H:i:s', $lastOptTime));
+                        \Idno\Core\Idno::site()->db()->optimize();
+                        \Idno\Core\Idno::site()->config()->dboptimized = $time;
+                        \Idno\Core\Idno::site()->config()->save();
+                    }
+                });
                 if ($messages = \Idno\Core\Idno::site()->getVendorMessages()) {
                     \Idno\Core\Idno::site()->session()->addMessage($messages);
                 }


### PR DESCRIPTION
This permits db optimisation to take place after the page has been rendered and sent, allowing the user to continue.

Does not require user to configure cron on their system.