### PR TITLE
PSR3 Logging

### DIFF
--- a/Idno/Caching/MemoryCache.php
+++ b/Idno/Caching/MemoryCache.php
@@ -23,14 +23,14 @@
 
                 if (isset($this->cache[$key])) {
                     if (\Idno\Core\Idno::site()->config()->debug) {
-                        Idno\Core\Idno::site()->logging->log("Loading $key");
+                        Idno\Core\Idno::site()->logging->debug("Loading $key");
                     }
 
                     return $this->cache[$key];
                 }
 
                 if (\Idno\Core\Idno::site()->config()->debug) {
-                    Idno\Core\Idno::site()->logging->log("$key not cached");
+                    Idno\Core\Idno::site()->logging->debug("$key not cached");
                 }
 
                 return false;
@@ -44,7 +44,7 @@
             public function store($key, $value)
             {
                 if (\Idno\Core\Idno::site()->config()->debug)
-                    Idno\Core\Idno::site()->logging->log("Caching $key");
+                    Idno\Core\Idno::site()->logging->debug("Caching $key");
 
                 $this->cache[$key] = $value;
 

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -475,11 +475,11 @@
                             $title = md5(rand() . microtime(true));
                         }
                     }
-                    \Idno\Core\Idno::site()->logging()->log("Setting resilient slug", LOGLEVEL_DEBUG);
+                    \Idno\Core\Idno::site()->logging()->debug("Setting resilient slug");
                     $this->setSlugResilient($title);
-                    \Idno\Core\Idno::site()->logging()->log("Set resilient slug", LOGLEVEL_DEBUG);
+                    \Idno\Core\Idno::site()->logging()->debug("Set resilient slug");
                 } else {
-                    \Idno\Core\Idno::site()->logging()->log("Had slug: " . $this->getSlug(), LOGLEVEL_DEBUG);
+                    \Idno\Core\Idno::site()->logging()->debug("Had slug: " . $this->getSlug());
                 }
 
                 // Force users to be public
@@ -533,7 +533,7 @@
                         \Idno\Core\Idno::site()->events()->dispatch('syndicate', $event);
                     } catch (\Exception $e) {
                         \Idno\Core\Idno::site()->session()->addErrorMessage("There was a problem syndicating.");
-                        \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                        \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                     }
                 }
             }

--- a/Idno/Core/Email.php
+++ b/Idno/Core/Email.php
@@ -183,7 +183,7 @@
 
                 } catch (\Exception $e) {
                     // Lets log errors rather than silently drop them
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage(), LOGLEVEL_ERROR);
+                    \Idno\Core\Idno::site()->logging()->error('Error sending mail', ['error' => $e]);
                 }
 
                 return 0;

--- a/Idno/Core/Hub.php
+++ b/Idno/Core/Hub.php
@@ -152,11 +152,11 @@
                     if (!empty($details)) {
                         try {
                             if (!$this->userIsRegistered(\Idno\Core\Idno::site()->session()->currentUser())) {
-                                \Idno\Core\Idno::site()->logging->log("User isn't registered on hub; registering ...");
+                                \Idno\Core\Idno::site()->logging->info("User isn't registered on hub; registering ...");
                                 $this->registerUser(\Idno\Core\Idno::site()->session()->currentUser());
                             }
                         } catch (\Exception $e) {
-                            \Idno\Core\Idno::site()->logging->log($e->getMessage());
+                            \Idno\Core\Idno::site()->logging->error('Exception registering user on hub', ['error' => $e]);
                         }
                     }
                 }

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -131,9 +131,9 @@
 
                 // No URL is a critical error, default base fallback is now a warning (Refs #526)
                 if (!$this->config->url) throw new \Exception('Known was unable to work out your base URL! You might try setting url="http://yourdomain.com/" in your config.ini');
-                if ($this->config->url == '/') \Idno\Core\Idno::site()->logging->log('Base URL has defaulted to "/" because Known was unable to detect your server name. '
+                if ($this->config->url == '/') $this->logging->warning('Base URL has defaulted to "/" because Known was unable to detect your server name. '
                     . 'This may be because you\'re loading Known via a script. '
-                    . 'Try setting url="http://yourdomain.com/" in your config.ini to remove this message', LOGLEVEL_WARNING);
+                    . 'Try setting url="http://yourdomain.com/" in your config.ini to remove this message');
 
                 // Connect to a Known hub if one is listed in the configuration file
                 // (and this isn't the hub!)
@@ -439,7 +439,7 @@
                         $this->public_pages[] = $handler;
                     }
                 } else {
-                    $this->logging()->log("Could not add $pattern. $handler not found", LOGLEVEL_ERROR);
+                    $this->logging()->error("Could not add $pattern. $handler not found");
                 }
             }
 

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -27,10 +27,10 @@
             public $pagehandlers;
             public $public_pages;
             public $syndication;
+            /* @var \Psr\Log\LoggerInterface $logging */
             public $logging;
-            /* @var \Idno\Core\Logging $logging */
-            public static $site;
             /* @var \Idno\Core\Idno $site */
+            public static $site;
             public $currentPage;
             public $known_hub;
             public $helper_robot;
@@ -109,7 +109,7 @@
                 $this->logging = new Logging();
                 $this->config->load();
 
-                if (isset($this->config->loglevel)) {
+                if (isset($this->config->loglevel) && $this->logging instanceof Logging) {
                     $this->logging->setLogLevel($this->config->loglevel);
                 }
 
@@ -264,7 +264,7 @@
 
             /**
              * Returns the current logging interface
-             * @return \Idno\Core\Logging
+             * @return \Psr\Log\LoggerInterface
              */
             function &logging()
             {
@@ -751,7 +751,7 @@
                 if (!empty(site()->config()->noping)) {
                     return '';
                 }
-                
+
                 $results    = Webservice::post('https://withknown.com/vendor-services/messages/', array(
                     'url'     => site()->config()->getURL(),
                     'title'   => site()->config()->getTitle(),

--- a/Idno/Core/Logging.php
+++ b/Idno/Core/Logging.php
@@ -9,12 +9,14 @@
 
     namespace Idno\Core {
 
-        class Logging extends \Idno\Common\Component
+        use Idno\Common\Component;
+        use Psr\Log\LoggerInterface;
+        use Psr\Log\LogLevel;
+
+        class Logging extends Component implements LoggerInterface
         {
             public $loglevel_filter = 4;
             private $identifier;
-
-            private $contexts = [];
 
             /**
              * Create a basic logger to log to the PHP log.
@@ -24,14 +26,13 @@
              */
             public function __construct($loglevel_filter = 0, $identifier = null)
             {
-                if (!$identifier) $identifier = \Idno\Core\Idno::site()->config->host;
-                if (isset(\Idno\Core\Idno::site()->config->loglevel)) {
-                    $loglevel_filter = \Idno\Core\Idno::site()->config->loglevel;
+                if (!$identifier) $identifier = Idno::site()->config->host;
+                if (isset(Idno::site()->config->loglevel)) {
+                    $loglevel_filter = Idno::site()->config->loglevel;
                 }
 
                 $this->loglevel_filter = $loglevel_filter;
                 $this->identifier      = $identifier;
-                $this->contexts        = [];
             }
 
             /**
@@ -44,56 +45,55 @@
             }
 
             /**
-             * Set the context
+             * Check whether a LogLevel meets the current loglevel_filter.
+             * @param  string $level
+             * @return boolean true if messages at this level should be logged
              */
-            public function setContext($context)
+            private function passesFilter($level)
             {
-                $this->clearContexts();
-                $this->pushContext($context);
-            }
-
-            /**
-             * Clear logging contexts.
-             */
-            public function clearContexts()
-            {
-                $this->contexts = [];
-            }
-
-            /**
-             * Push a context onto log.
-             * @param type $context
-             */
-            public function pushContext($context)
-            {
-                array_push($this->contexts, trim($context));
-            }
-
-            /**
-             * Remove a logging context from the stack
-             * @return context
-             */
-            public function popContext()
-            {
-                return array_pop($this->contexts);
+                switch($level) {
+                case LogLevel::EMERGENCY: case LogLevel::ALERT:
+                case LogLevel::CRITICAL: case LogLevel::ERROR:
+                    return $this->loglevel_filter >= LOGLEVEL_ERROR;
+                case LogLevel::WARNING:
+                    return $this->loglevel_filter >= LOGLEVEL_WARNING;
+                case LogLevel::NOTICE: case LogLevel::INFO:
+                    return $this->loglevel_filter >= LOGLEVEL_INFO;
+                case LogLevel::DEBUG:
+                    return $this->loglevel_filter >= LOGLEVEL_DEBUG;
+                }
+                return false;
             }
 
             /**
              * Write a message to the log.
-             * @param type $message
-             * @param type $level
+             * @param string $level
+             * @param string $message
+             * @param array  $context
              */
-            public function log($message, $level = 3)
+            public function log($level, $message=LOGLEVEL_INFO, array $context = array())
             {
+                // backward compatibility
+                if (is_string($level) && is_int($message)) {
+                    // TODO in a future version, warn that this
+                    // calling style is deprecated and will eventually
+                    // go away.
+                    $temp = $level;
+                    if ($message === LOGLEVEL_ERROR)   $level = LogLevel::ERROR;
+                    if ($message === LOGLEVEL_WARNING) $level = LogLevel::WARNING;
+                    if ($message === LOGLEVEL_INFO)    $level = LogLevel::INFO;
+                    if ($message === LOGLEVEL_DEBUG)   $level = LogLevel::DEBUG;
+                    $message = $temp;
+                }
 
                 // See if this message isn't filtered out
-                if ($level <= $this->loglevel_filter) {
+                if ($this->passesFilter($level)) {
 
                     // Construct log message
 
                     // Trace for debug (when filtering is set to debug, always add a trace)
                     $trace = "";
-                    if ($this->loglevel_filter == 4) {
+                    if ($this->loglevel_filter == LOGLEVEL_DEBUG) {
                         $backtrace = @debug_backtrace(false, 2);
                         if ($backtrace) {
                             // Never show this
@@ -103,21 +103,137 @@
                         }
                     }
 
-                    // Level
-                    if ($level == 1) $level = "ERROR";
-                    if ($level == 2) $level = "WARNING";
-                    if ($level == 3) $level = "INFO";
-                    if ($level == 4) $level = "DEBUG";
-
-                    // Logging contexts
-                    $contexts = '';
-                    if (!empty($this->contexts)) {
-                        $contexts = ' [' . implode(';', $this->contexts) . ']';
+                    if ($context) {
+                        // borrowed from Monolog's LineFormatter
+                        if (is_bool($context)) {
+                            $context = var_export($context, true);
+                        } else if (is_scalar($context)) {
+                            $context = (string) $context;
+                        } else {
+                            $context = json_encode($context, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+                        }
+                        $message .= ' ' . $context;
                     }
 
-                    error_log("Known ({$this->identifier}$contexts): $level - $message{$trace}");
+                    error_log("Known ({$this->identifier}): $level - $message{$trace}");
                 }
             }
+
+            /**
+             * System is unusable.
+             *
+             * @param string $message
+             * @param array  $context
+             *
+             * @return null
+             */
+            public function emergency($message, array $context = array())
+            {
+                $this->log(LogLevel::EMERGENCY, $message, $context);
+            }
+
+            /**
+             * Action must be taken immediately.
+             *
+             * Example: Entire website down, database unavailable, etc. This should
+             * trigger the SMS alerts and wake you up.
+             *
+             * @param string $message
+             * @param array  $context
+             *
+             * @return null
+             */
+            public function alert($message, array $context = array())
+            {
+                $this->log(LogLevel::ALERT, $message, $context);
+            }
+
+            /**
+             * Critical conditions.
+             *
+             * Example: Application component unavailable, unexpected exception.
+             *
+             * @param string $message
+             * @param array  $context
+             *
+             * @return null
+             */
+            public function critical($message, array $context = array())
+            {
+                $this->log(LogLevel::CRITICAL, $message, $context);
+            }
+
+            /**
+             * Runtime errors that do not require immediate action but should typically
+             * be logged and monitored.
+             *
+             * @param string $message
+             * @param array  $context
+             *
+             * @return null
+             */
+            public function error($message, array $context = array())
+            {
+                $this->log(LogLevel::ERROR, $message, $context);
+            }
+
+            /**
+             * Exceptional occurrences that are not errors.
+             *
+             * Example: Use of deprecated APIs, poor use of an API, undesirable things
+             * that are not necessarily wrong.
+             *
+             * @param string $message
+             * @param array  $context
+             *
+             * @return null
+             */
+            public function warning($message, array $context = array())
+            {
+                $this->log(LogLevel::WARNING, $message, $context);
+            }
+
+            /**
+             * Normal but significant events.
+             *
+             * @param string $message
+             * @param array  $context
+             *
+             * @return null
+             */
+            public function notice($message, array $context = array())
+            {
+                $this->log(LogLevel::NOTICE, $message, $context);
+            }
+
+            /**
+             * Interesting events.
+             *
+             * Example: User logs in, SQL logs.
+             *
+             * @param string $message
+             * @param array  $context
+             *
+             * @return null
+             */
+            public function info($message, array $context = array())
+            {
+                $this->log(LogLevel::INFO, $message, $context);
+            }
+
+            /**
+             * Detailed debug information.
+             *
+             * @param string $message
+             * @param array  $context
+             *
+             * @return null
+             */
+            public function debug($message, array $context = array())
+            {
+                $this->log(LogLevel::DEBUG, $message, $context);
+            }
+
         }
 
         define('LOGLEVEL_OFF', 0);

--- a/Idno/Core/PubSubHubbub.php
+++ b/Idno/Core/PubSubHubbub.php
@@ -85,9 +85,9 @@
                                     'hub.topic'    => $feed, // Subscribe to rss
                                 ));
 
-                                \Idno\Core\Idno::site()->logging->log("Pubsub: " . print_r($return, true));
+                                \Idno\Core\Idno::site()->logging->info("Pubsub subscribed", ['response' => $return]);
                             } else
-                                \Idno\Core\Idno::site()->logging->log("Pubsub: No hubs found");
+                                \Idno\Core\Idno::site()->logging->info("Pubsub: No hubs found");
                         }
                     }
                 });
@@ -121,7 +121,7 @@
                             'hub.topic'    => $following->pubsub_self
                         ));
 
-                        \Idno\Core\Idno::site()->logging->log("Pubsub: " . print_r($return, true));
+                        \Idno\Core\Idno::site()->logging->info("Pubsub unsubscribed.", ['response' => $return]);
                     }
                 });
             }
@@ -287,7 +287,7 @@
                         }
 
                         $formdata = 'hub.mode=publish&hub.url=' . implode(',', $encurls);
-                        \Idno\Core\Idno::site()->logging()->log('Pinging ' . $hub . ' with data ' . $formdata);
+                        \Idno\Core\Idno::site()->logging()->info('Pinging ' . $hub . ' with data ' . $formdata);
                         \Idno\Core\Webservice::post($hub, $formdata, array(
                             'Content-Type' => 'application/x-www-form-urlencoded'));
                     }

--- a/Idno/Core/Reader.php
+++ b/Idno/Core/Reader.php
@@ -40,7 +40,7 @@
                             return $this->mf2FeedToFeedItems($parsed_content, $url);
                         }
                     } catch (\Exception $e) {
-                        Idno::site()->logging()->log($e->getMessage());
+                        Idno::site()->logging()->error('Error parsing feed', ['error' => $e]);
                     }
                 }
 
@@ -139,7 +139,7 @@
                 if (!filter_var($url, FILTER_VALIDATE_URL)) {
                     return false;
                 }
-                
+
                 if ($result = Webservice::get($url)) {
                     return $this->parseFeed($result['content'], $url);
                 }

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -54,7 +54,7 @@
                     $this->validate();
                 } catch (\Exception $ex) {
                     // Session didn't validate, log & destroy
-                    \Idno\Core\Idno::site()->logging->log($ex->getMessage(), LOGLEVEL_ERROR);
+                    \Idno\Core\Idno::site()->logging->error('Error validating session', ['error' => $ex]);
 
                     $_SESSION = [];
                     session_destroy();
@@ -325,7 +325,7 @@
                 // Unset all session variables, as per PHP docs.
                 $_SESSION = [];
 
-                // Really log the user off by destroying the cookie 
+                // Really log the user off by destroying the cookie
                 // See https://secure.php.net/manual/en/function.session-destroy.php
                 if (!defined('KNOWN_UNIT_TEST')) {
                     if (ini_get("session.use_cookies")) {
@@ -395,7 +395,7 @@
 
                 // auth standard API requests
                 if (!$return && !empty($_SERVER['HTTP_X_KNOWN_USERNAME']) && !empty($_SERVER['HTTP_X_KNOWN_SIGNATURE'])) {
-                    \Idno\Core\Idno::site()->logging()->log("Attempting to auth via API credentials", LOGLEVEL_DEBUG);
+                    \Idno\Core\Idno::site()->logging()->debug("Attempting to auth via API credentials");
 
                     $this->setIsAPIRequest(true);
 
@@ -405,18 +405,18 @@
                     }
 
                     if ($user = \Idno\Entities\User::getByHandle($_SERVER['HTTP_X_KNOWN_USERNAME'])) {
-                        \Idno\Core\Idno::site()->logging()->log("API auth found user by username: " . $user->getName(), LOGLEVEL_DEBUG);
+                        \Idno\Core\Idno::site()->logging()->debug("API auth found user by username: " . $user->getName());
                         $key  = $user->getAPIkey();
                         $hmac = trim($_SERVER['HTTP_X_KNOWN_SIGNATURE']);
                         //$compare_hmac = base64_encode(hash_hmac('sha256', explode('?', $_SERVER['REQUEST_URI'])[0], $key, true));
                         $compare_hmac = base64_encode(hash_hmac('sha256', ($_SERVER['REQUEST_URI']), $key, true));
 
                         if ($hmac == $compare_hmac) {
-                            \Idno\Core\Idno::site()->logging()->log("API auth verified signature for user: " . $user->getName(), LOGLEVEL_DEBUG);
+                            \Idno\Core\Idno::site()->logging()->debug("API auth verified signature for user: " . $user->getName());
                             // TODO maybe this should set the current user without modifying $_SESSION?
                             $return = $this->refreshSessionUser($user);
                         } else {
-                            \Idno\Core\Idno::site()->logging()->log("API auth failed signature validation for user: " . $user->getName(), LOGLEVEL_DEBUG);
+                            \Idno\Core\Idno::site()->logging()->debug("API auth failed signature validation for user: " . $user->getName());
                         }
                     }
                 }
@@ -439,7 +439,7 @@
                             $ip      = trim($proxies[0]);
                         }
 
-                        \Idno\Core\Idno::site()->logging()->log("API Login failure from $ip", LOGLEVEL_ERROR);
+                        \Idno\Core\Idno::site()->logging()->error("API Login failure from $ip");
                         \Idno\Core\Idno::site()->currentPage()->deniedContent();
                     }
                 }

--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -43,7 +43,7 @@
 
                 switch (strtolower($verb)) {
                     case 'post':
-                        
+
                         // Check for old style @file uploads and try and convert them
                         if (!empty($params) && is_array($params)) {
                             foreach ($params as $k => $v) {
@@ -56,7 +56,7 @@
                                             curl_setopt($curl_handle, CURLOPT_SAFE_UPLOAD, true);
                                         }
                                     } catch (\Exception $ex) {
-                                        \Idno\Core\Idno::site()->logging->log($ex->getMessage(), LOGLEVEL_ERROR);
+                                        \Idno\Core\Idno::site()->logging->error("Error sending $verb to $endpoint", ['error' => $ex]);
                                         if (defined('CURLOPT_SAFE_UPLOAD')) { // 5.4 compat
                                             curl_setopt($curl_handle, CURLOPT_SAFE_UPLOAD, false);
                                         }
@@ -64,7 +64,7 @@
                                 }
                             }
                         }
-                        
+
                         curl_setopt($curl_handle, CURLOPT_POST, 1);
                         curl_setopt($curl_handle, CURLOPT_POSTFIELDS, $params);
                         curl_setopt($curl_handle, CURLOPT_HTTPHEADER, array("Content-type: multipart/form-data"));
@@ -182,7 +182,7 @@
                 $content     = substr($buffer, $header_size);
 
                 if ($error = curl_error($curl_handle)) {
-                    \Idno\Core\Idno::site()->logging->log($error, LOGLEVEL_ERROR);
+                    \Idno\Core\Idno::site()->logging->error('error send Webservice request', ['error' => $error]);
                 }
 
                 self::$lastRequest  = curl_getinfo($curl_handle, CURLINFO_HEADER_OUT);
@@ -271,7 +271,7 @@
                 try {
                     return curl_exec($ch);
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error('error sending Webservice request', ['error' => $e]);
 
                     return false;
                 }
@@ -413,9 +413,9 @@
             static function fileToCurlFile($fileuploadstring) {
                 if ($fileuploadstring[0] == '@') {
                     $bits = explode(';', $fileuploadstring);
-                    
+
                     $file = $name = $mime = null;
-                  
+
                     foreach ($bits as $bit) {
                         // File
                         if ($bit[0] == '@') {
@@ -429,11 +429,11 @@
                             $tmp = explode('=', $bit);
                             $mime = trim($tmp[1], ' ;');
                         }
-                        
+
                     }
-                    
+
                     if ($file) {
-                        
+
                         if (class_exists('CURLFile')) {
                             return new \CURLFile($file, $mime, $name);
                         } else {
@@ -441,7 +441,7 @@
                         }
                     }
                 }
-                
+
                 return false;
             }
         }

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -101,7 +101,7 @@
                                         $statement = $client->prepare($sql);
                                         $statement->execute();
                                     } catch (\Exception $e) {
-                                        //\Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                                        //\Idno\Core\Idno::site()->logging()->error($e->getMessage());
                                         error_log($e->getMessage());
                                     }
                                 }
@@ -113,7 +113,7 @@
                                         $statement = $client->prepare($sql);
                                         $statement->execute();
                                     } catch (\Exception $e) {
-                                        //\Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                                        //\Idno\Core\Idno::site()->logging()->error($e->getMessage());
                                         error_log($e->getMessage());
                                     }
                                 }
@@ -150,7 +150,7 @@
                         return $statement->fetchAll(\PDO::FETCH_OBJ);
                     }
                 } catch (\Exception $e) {
-                    //\Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    //\Idno\Core\Idno::site()->logging()->error($e->getMessage());
                     error_log($e->getMessage());
                 }
 
@@ -273,7 +273,7 @@
                     $contents = json_encode($array);
                 } catch (\Exception $e) {
                     $contents = json_encode([]);
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
 
                     return false;
                 }
@@ -348,7 +348,7 @@
                                         $value = json_encode($value);
                                     } catch (\Exception $e) {
                                         $value = json_encode([]);
-                                        \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                                        \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                                     }
                                 }
                                 if (empty($value)) {
@@ -365,11 +365,11 @@
                     }
                     $client->commit();
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                     $client->rollback();
                 }
 
-                \Idno\Core\Idno::site()->logging()->log('saveRecord(): insert or update took ' . (microtime(true) - $benchmark_start) . 's', LOGLEVEL_DEBUG);
+                \Idno\Core\Idno::site()->logging()->debug('saveRecord(): insert or update took ' . (microtime(true) - $benchmark_start) . 's');
 
                 return $retval;
             }
@@ -415,7 +415,7 @@
                         }
                     }
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                 }
 
                 return false;
@@ -591,7 +591,7 @@
                     }
 
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
 
                     return false;
                 }
@@ -791,7 +791,7 @@
 
                     return $output;
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
 
                     return false;
                 }
@@ -880,7 +880,7 @@
                     }
 
                 } catch (Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
 
                     return false;
                 }
@@ -923,7 +923,7 @@
 
                 } catch (\Exception $e) {
 
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
 
                     return false;
 

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -120,7 +120,7 @@
                         return $statement->fetchAll(\PDO::FETCH_OBJ);
                     }
                 } catch (\Exception $e) {
-                    //\Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    //\Idno\Core\Idno::site()->logging()->error($e->getMessage());
                     error_log($e->getMessage());
                 }
 
@@ -226,7 +226,7 @@
                     $contents = json_encode($array);
                 } catch (\Exception $e) {
                     $contents = json_encode([]);
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error('Exception saving record', ['error' => $e]);
 
                     return false;
                 }
@@ -288,7 +288,7 @@
                                         $value = json_encode($value);
                                     } catch (\Exception $e) {
                                         $value = json_encode([]);
-                                        \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                                        \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                                     }
                                 }
                                 if (empty($value)) {
@@ -304,7 +304,7 @@
                     }
                 } catch (\Exception $e) {
                     error_log($e->getMessage());
-                    //\Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    //\Idno\Core\Idno::site()->logging()->error($e->getMessage());
                 }
 
                 return false;
@@ -351,7 +351,7 @@
                         }
                     }
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                 }
 
                 return false;
@@ -529,7 +529,7 @@
                     }
 
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error('Exception while fetching records', ['error' => $e]);
 
                     return false;
                 }
@@ -755,7 +755,7 @@
                     }
 
                 } catch (Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error('Exception while fetching objects', ['error' => $e]);
 
                     return false;
                 }
@@ -798,7 +798,7 @@
 
                 } catch (\Exception $e) {
 
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error('Exception deleting record', ['error' => $e]);
 
                     return false;
 

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -105,7 +105,7 @@
                         return $statement->fetchAll(\PDO::FETCH_OBJ);
                     }
                 } catch (\Exception $e) {
-                    //\Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    //\Idno\Core\Idno::site()->logging()->error($e->getMessage());
                     error_log($e->getMessage());
                 }
 
@@ -192,7 +192,7 @@
                     $contents = json_encode($array);
                 } catch (\Exception $e) {
                     $contents = json_encode([]);
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
 
                     return false;
                 }
@@ -254,7 +254,7 @@
                                         $value = json_encode($value);
                                     } catch (\Exception $e) {
                                         $value = json_encode([]);
-                                        \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                                        \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                                     }
                                 }
                                 if (empty($value)) {
@@ -269,7 +269,7 @@
                         return $array['_id'];
                     }
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                 }
 
                 return false;
@@ -295,7 +295,7 @@
                         }
                     }
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                 }
 
                 return false;
@@ -476,7 +476,7 @@
                     }
 
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
 
                     return false;
                 }
@@ -695,7 +695,7 @@
                     }
 
                 } catch (Exception $e) {
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
 
                     return false;
                 }
@@ -738,7 +738,7 @@
 
                 } catch (\Exception $e) {
 
-                    \Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
 
                     return false;
 

--- a/Idno/Entities/File.php
+++ b/Idno/Entities/File.php
@@ -211,7 +211,7 @@
                     try {
                         return $fs->findOne(array('_id' => \Idno\Core\Idno::site()->db()->processID($id)));
                     } catch (\Exception $e) {
-                        \Idno\Core\Idno::site()->logging->log($e->getMessage(), LOGLEVEL_ERROR);
+                        \Idno\Core\Idno::site()->logging->error($e->getMessage());
                     }
                 }
 
@@ -270,37 +270,37 @@
              */
             static function getFileDataFromAttachment($attachment)
             {
-                \Idno\Core\Idno::site()->logging->log(json_encode($attachment), LOGLEVEL_DEBUG);
+                \Idno\Core\Idno::site()->logging->debug("getting file data from attachment", ['attachment' => $attachment]);
                 if (!empty($attachment['_id'])) {
-                    //\Idno\Core\Idno::site()->logging->log("Checking attachment ID", LOGLEVEL_DEBUG);
+                    //\Idno\Core\Idno::site()->logging->debug("Checking attachment ID");
                     if ($bytes = self::getFileDataByID((string)$attachment['_id'])) {
-                        //\Idno\Core\Idno::site()->logging->log("Retrieved some bytes", LOGLEVEL_DEBUG);
+                        //\Idno\Core\Idno::site()->logging->debug("Retrieved some bytes");
                         if (strlen($bytes)) {
-                            //\Idno\Core\Idno::site()->logging->log("Bytes! " . $bytes, LOGLEVEL_DEBUG);
+                            //\Idno\Core\Idno::site()->logging->debug("Bytes! " . $bytes);
                             return $bytes;
                         } else {
-                            //\Idno\Core\Idno::site()->logging->log("Sadly no bytes", LOGLEVEL_DEBUG);
+                            //\Idno\Core\Idno::site()->logging->debug("Sadly no bytes");
                         }
                     } else {
-                        //\Idno\Core\Idno::site()->logging->log("No bytes retrieved", LOGLEVEL_DEBUG);
+                        //\Idno\Core\Idno::site()->logging->debug("No bytes retrieved");
                     }
                 } else {
-                    \Idno\Core\Idno::site()->logging->log("Empty attachment _id", LOGLEVEL_DEBUG);
+                    \Idno\Core\Idno::site()->logging->debug("Empty attachment _id");
                 }
                 if (!empty($attachment['url'])) {
                     try {
                         if ($bytes = @file_get_contents($attachment['url'])) {
-                            \Idno\Core\Idno::site()->logging->log("Returning bytes", LOGLEVEL_DEBUG);
+                            \Idno\Core\Idno::site()->logging->debug("Returning bytes");
 
                             return $bytes;
                         } else {
-                            \Idno\Core\Idno::site()->logging->log("Couldn't get bytes from " . $attachment['url'], LOGLEVEL_DEBUG);
+                            \Idno\Core\Idno::site()->logging->debug("Couldn't get bytes from " . $attachment['url']);
                         }
                     } catch (\Exception $e) {
-                        \Idno\Core\Idno::site()->logging->log("Couldn't get bytes from " . $attachment['url'], LOGLEVEL_DEBUG);
+                        \Idno\Core\Idno::site()->logging->debug("Couldn't get bytes from " . $attachment['url']);
                     }
                 } else {
-                    \Idno\Core\Idno::site()->logging->log('Attachment url was empty ' . $attachment['url'], LOGLEVEL_DEBUG);
+                    \Idno\Core\Idno::site()->logging->debug('Attachment url was empty ' . $attachment['url']);
                 }
 
                 return false;
@@ -317,7 +317,7 @@
                     try {
                         return $file->getBytes();
                     } catch (\Exception $e) {
-                        \Idno\Core\Idno::site()->logging->log($e->getMessage(), LOGLEVEL_ERROR);
+                        \Idno\Core\Idno::site()->logging->error($e->getMessage());
                     }
                 }
 

--- a/Idno/Files/LocalFileSystem.php
+++ b/Idno/Files/LocalFileSystem.php
@@ -89,13 +89,13 @@
                         if (!@file_put_contents($data_file, $metadata)) {
                                 throw new \Exception("There was a problem saving the file's metadata");
                         }
-                    
+
                         return $id;
                     } catch (\Exception $e) {
 
                         // Ensure we capture the real error message
-                        \Idno\Core\Idno::site()->logging()->log($e->getMessage());
-                        
+                        \Idno\Core\Idno::site()->logging()->error('Exception while uploading file', ['error' => $e]);
+
                         \Idno\Core\Idno::site()->session()->addMessage("Something went wrong saving your file.");
                         if (\Idno\Core\Idno::site()->session()->isAdmin()) {
                             \Idno\Core\Idno::site()->session()->addMessage("Check that your upload directory is writeable by the web server and try again.");

--- a/Idno/Pages/Account/Settings/Following/Bookmarklet.php
+++ b/Idno/Pages/Account/Settings/Following/Bookmarklet.php
@@ -133,7 +133,7 @@
 
                         // No user found, so create it if it's remote
                         if (!\Idno\Entities\User::isLocalUUID($uuid)) {
-                            \Idno\Core\Idno::site()->logging->log("Creating new remote user", LOGLEVEL_DEBUG);
+                            \Idno\Core\Idno::site()->logging->debug("Creating new remote user");
 
                             $new_user = new \Idno\Entities\RemoteUser();
 
@@ -150,19 +150,19 @@
 
                         }
                     } else
-                        \Idno\Core\Idno::site()->logging->log("New user found as " . $new_user->uuid, LOGLEVEL_DEBUG);
+                        \Idno\Core\Idno::site()->logging->debug("New user found as " . $new_user->uuid);
 
                     if ($new_user) {
 
-                        \Idno\Core\Idno::site()->logging->log("Trying a follow", LOGLEVEL_DEBUG);
+                        \Idno\Core\Idno::site()->logging->debug("Trying a follow");
 
                         if ($user->addFollowing($new_user)) {
 
-                            \Idno\Core\Idno::site()->logging->log("User added to following", LOGLEVEL_DEBUG);
+                            \Idno\Core\Idno::site()->logging->debug("User added to following");
 
                             if ($user->save()) {
 
-                                \Idno\Core\Idno::site()->logging->log("Following saved", LOGLEVEL_DEBUG);
+                                \Idno\Core\Idno::site()->logging->debug("Following saved");
 
                                 // Ok, we've saved the new user, now, lets subscribe to their feeds
                                 if ($feed = \Idno\Core\Idno::site()->reader()->getFeedObject($new_user->getURL())) {
@@ -176,7 +176,7 @@
 
                             }
                         } else {
-                            \Idno\Core\Idno::site()->logging->log('Could not follow user for some reason (probably already following)', LOGLEVEL_DEBUG);
+                            \Idno\Core\Idno::site()->logging->debug('Could not follow user for some reason (probably already following)');
                             \Idno\Core\Idno::site()->session()->addErrorMessage('You\'re already following ' . $this->getInput('name'));
                         }
                     } else

--- a/Idno/Pages/Admin/Home.php
+++ b/Idno/Pages/Admin/Home.php
@@ -18,7 +18,7 @@
                 register_shutdown_function(function () {
                     $lastOptTime = empty(\Idno\Core\Idno::site()->config()->dboptimized) ? 0 : \Idno\Core\Idno::site()->config()->dboptimized;
                     if (($time = time()) - $lastOptTime > 24 * 60 * 60) {
-                        \Idno\Core\Idno::site()->logging()->log("Optimizing database tables. Last run " . date('Y-m-d H:i:s', $lastOptTime));
+                        \Idno\Core\Idno::site()->logging()->info("Optimizing database tables. Last run " . date('Y-m-d H:i:s', $lastOptTime));
                         \Idno\Core\Idno::site()->db()->optimize();
                         \Idno\Core\Idno::site()->config()->dboptimized = $time;
                         \Idno\Core\Idno::site()->config()->save();

--- a/Idno/Pages/Entity/View.php
+++ b/Idno/Pages/Entity/View.php
@@ -83,7 +83,7 @@
                     }
                 }
                 if (empty($object)) {
-                    \Idno\Core\Idno::site()->logging->log("No object was found with ID {$this->arguments[0]}.", LOGLEVEL_ERROR);
+                    \Idno\Core\Idno::site()->logging->error("No object was found with ID {$this->arguments[0]}.");
 
                     return false;
                 }

--- a/Idno/Pages/Hub/Register/Site.php
+++ b/Idno/Pages/Hub/Register/Site.php
@@ -14,7 +14,7 @@
 
                 $this->flushBrowser();
 
-                \Idno\Core\Idno::site()->logging->log('Site registration message received', LOGLEVEL_DEBUG);
+                \Idno\Core\Idno::site()->logging->debug('Site registration message received');
 
                 $token      = $this->getInput('token');
                 $auth_token = $this->getInput('auth_token');

--- a/Idno/Pages/Hub/Register/User.php
+++ b/Idno/Pages/Hub/Register/User.php
@@ -14,7 +14,7 @@
 
                 $this->flushBrowser();
 
-                \Idno\Core\Idno::site()->logging->log("Loading the user registration callback", LOGLEVEL_DEBUG);
+                \Idno\Core\Idno::site()->logging->debug("Loading the user registration callback");
 
                 $contents   = $this->getInput('content');
                 $auth_token = $this->getInput('auth_token');

--- a/Idno/Pages/Pubsubhubbub/Callback.php
+++ b/Idno/Pages/Pubsubhubbub/Callback.php
@@ -32,7 +32,7 @@
                 $hub_challenge     = $this->getInput('hub.challenge', $this->getInput('hub_challenge'));
                 $hub_lease_seconds = $this->getInput('hub.lease_seconds', $this->getInput('hub_lease_seconds'));
 
-                \Idno\Core\Idno::site()->logging->log("Pubsub: $hub_mode verification ping ", LOGLEVEL_DEBUG);
+                \Idno\Core\Idno::site()->logging->debug("Pubsub: $hub_mode verification ping ");
 
                 switch ($hub_mode) {
                     case 'subscribe':
@@ -48,7 +48,7 @@
                             $subscriber->pubsub_pending = serialize($new);
                             $subscriber->save();
 
-                            \Idno\Core\Idno::site()->logging->log("Pubsub: $hub_challenge", LOGLEVEL_DEBUG);
+                            \Idno\Core\Idno::site()->logging->debug("Pubsub: $hub_challenge");
                             echo $hub_challenge;
                             exit;
                         }
@@ -60,7 +60,7 @@
 
             function post()
             {
-                \Idno\Core\Idno::site()->logging->log("Pubsub: Ping received", LOGLEVEL_DEBUG);
+                \Idno\Core\Idno::site()->logging->debug("Pubsub: Ping received");
 
                 // Since we've overloaded post, we need to parse the arguments
                 $arguments = func_get_args();
@@ -80,7 +80,7 @@
                     $this->goneContent();
                 }
 
-                \Idno\Core\Idno::site()->logging->log("Pubsub: Ping received, pinging out...", LOGLEVEL_DEBUG);
+                \Idno\Core\Idno::site()->logging->debug("Pubsub: Ping received, pinging out...");
 
                 \Idno\Core\Idno::site()->triggerEvent('pubsubhubbub/ping', array(
                     'subscriber'   => $subscriber,

--- a/Idno/Pages/Webmentions/Endpoint.php
+++ b/Idno/Pages/Webmentions/Endpoint.php
@@ -67,12 +67,12 @@
                                 } else {
                                     $error      = 'no_link_found';
                                     $error_text = 'The source URI does not contain a link to the target URI.';
-                                    \Idno\Core\Idno::site()->logging->log('No link from ' . $source . ' to ' . $target, LOGLEVEL_ERROR);
+                                    \Idno\Core\Idno::site()->logging->warning('No link from ' . $source . ' to ' . $target);
                                 }
                             } else {
                                 $error      = 'source_not_found';
                                 $error_text = 'The source content for ' . $source . ' could not be obtained.';
-                                \Idno\Core\Idno::site()->logging->log('No content from ' . $source, LOGLEVEL_ERROR);
+                                \Idno\Core\Idno::site()->logging->warning('No content from '.$source);
                             }
                         } else {
                             $error      = 'target_not_supported';
@@ -81,7 +81,7 @@
                     } else {
                         $error      = 'target_not_found';
                         $error_text = 'The target page ' . $target . ' does not exist.';
-                        \Idno\Core\Idno::site()->logging()->log('Could not find handler for ' . $target, LOGLEVEL_ERROR);
+                        \Idno\Core\Idno::site()->logging()->error('Could not find handler for ' . $target);
                     }
                 }
                 $this->setResponse(400); // Webmention failed.

--- a/Idno/start.php
+++ b/Idno/start.php
@@ -25,7 +25,7 @@
                 rawurlencode("Fatal error in Known install at {$_SERVER['SERVER_NAME']}{$_SERVER['REQUEST_URI']}") . "&body=" . rawurlencode($error_message) . "\">email us for more information</a>.";
 
             if (isset(\Idno\Core\Idno::site()->logging) && \Idno\Core\Idno::site()->logging)
-                \Idno\Core\Idno::site()->logging->log($error_message, LOGLEVEL_ERROR);
+                \Idno\Core\Idno::site()->logging->error($error_message);
             else
                 error_log($error_message);
 

--- a/Idno/start.php
+++ b/Idno/start.php
@@ -97,6 +97,9 @@
 // Symfony is used for routing, observer design pattern support, and a bunch of other fun stuff
     $known_loader->registerNamespace('Symfony\Component', dirname(dirname(__FILE__)) . '/external');
 
+// Implement the PSR-3 logging interface
+    $known_loader->registerNamespace('Psr\Log', dirname(dirname(__FILE__)) . '/external/log');
+
 // Using Toro for URL routing
     require_once(dirname(dirname(__FILE__)) . '/external/torophp/src/Toro.php');
 

--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -178,7 +178,7 @@
                             } else {
                                 $syndication = array(trim(str_replace('.com', '', $syndicate)));
                             }
-                            \Idno\Core\Idno::site()->logging()->log("Setting syndication: $syndication");
+                            \Idno\Core\Idno::site()->logging()->info("Setting syndication: $syndication");
                             $this->setInput('syndication', $syndication);
                         }
                         if ($entity->saveDataFromInput()) {

--- a/IdnoPlugins/StaticPages/Pages/View.php
+++ b/IdnoPlugins/StaticPages/Pages/View.php
@@ -64,7 +64,7 @@
                     }
                 }
                 if (empty($object)) {
-                    \Idno\Core\Idno::site()->logging->log("No object was found with ID {$this->arguments[0]}.", LOGLEVEL_ERROR);
+                    \Idno\Core\Idno::site()->logging->error("No object was found with ID {$this->arguments[0]}.");
 
                     return false;
                 }

--- a/external/log/LICENSE
+++ b/external/log/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2012 PHP Framework Interoperability Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/external/log/Psr/Log/AbstractLogger.php
+++ b/external/log/Psr/Log/AbstractLogger.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * This is a simple Logger implementation that other Loggers can inherit from.
+ *
+ * It simply delegates all log-level-specific methods to the `log` method to
+ * reduce boilerplate code that a simple Logger that does the same thing with
+ * messages regardless of the error level has to implement.
+ */
+abstract class AbstractLogger implements LoggerInterface
+{
+    /**
+     * System is unusable.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function emergency($message, array $context = array())
+    {
+        $this->log(LogLevel::EMERGENCY, $message, $context);
+    }
+
+    /**
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function alert($message, array $context = array())
+    {
+        $this->log(LogLevel::ALERT, $message, $context);
+    }
+
+    /**
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function critical($message, array $context = array())
+    {
+        $this->log(LogLevel::CRITICAL, $message, $context);
+    }
+
+    /**
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function error($message, array $context = array())
+    {
+        $this->log(LogLevel::ERROR, $message, $context);
+    }
+
+    /**
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function warning($message, array $context = array())
+    {
+        $this->log(LogLevel::WARNING, $message, $context);
+    }
+
+    /**
+     * Normal but significant events.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function notice($message, array $context = array())
+    {
+        $this->log(LogLevel::NOTICE, $message, $context);
+    }
+
+    /**
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function info($message, array $context = array())
+    {
+        $this->log(LogLevel::INFO, $message, $context);
+    }
+
+    /**
+     * Detailed debug information.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function debug($message, array $context = array())
+    {
+        $this->log(LogLevel::DEBUG, $message, $context);
+    }
+}

--- a/external/log/Psr/Log/InvalidArgumentException.php
+++ b/external/log/Psr/Log/InvalidArgumentException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Psr\Log;
+
+class InvalidArgumentException extends \InvalidArgumentException
+{
+}

--- a/external/log/Psr/Log/LogLevel.php
+++ b/external/log/Psr/Log/LogLevel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * Describes log levels.
+ */
+class LogLevel
+{
+    const EMERGENCY = 'emergency';
+    const ALERT     = 'alert';
+    const CRITICAL  = 'critical';
+    const ERROR     = 'error';
+    const WARNING   = 'warning';
+    const NOTICE    = 'notice';
+    const INFO      = 'info';
+    const DEBUG     = 'debug';
+}

--- a/external/log/Psr/Log/LoggerAwareInterface.php
+++ b/external/log/Psr/Log/LoggerAwareInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * Describes a logger-aware instance.
+ */
+interface LoggerAwareInterface
+{
+    /**
+     * Sets a logger instance on the object.
+     *
+     * @param LoggerInterface $logger
+     *
+     * @return null
+     */
+    public function setLogger(LoggerInterface $logger);
+}

--- a/external/log/Psr/Log/LoggerAwareTrait.php
+++ b/external/log/Psr/Log/LoggerAwareTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * Basic Implementation of LoggerAwareInterface.
+ */
+trait LoggerAwareTrait
+{
+    /**
+     * The logger instance.
+     *
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * Sets a logger.
+     *
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+}

--- a/external/log/Psr/Log/LoggerInterface.php
+++ b/external/log/Psr/Log/LoggerInterface.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * Describes a logger instance.
+ *
+ * The message MUST be a string or object implementing __toString().
+ *
+ * The message MAY contain placeholders in the form: {foo} where foo
+ * will be replaced by the context data in key "foo".
+ *
+ * The context array can contain arbitrary data. The only assumption that
+ * can be made by implementors is that if an Exception instance is given
+ * to produce a stack trace, it MUST be in a key named "exception".
+ *
+ * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
+ * for the full interface specification.
+ */
+interface LoggerInterface
+{
+    /**
+     * System is unusable.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function emergency($message, array $context = array());
+
+    /**
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function alert($message, array $context = array());
+
+    /**
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function critical($message, array $context = array());
+
+    /**
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function error($message, array $context = array());
+
+    /**
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function warning($message, array $context = array());
+
+    /**
+     * Normal but significant events.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function notice($message, array $context = array());
+
+    /**
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function info($message, array $context = array());
+
+    /**
+     * Detailed debug information.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function debug($message, array $context = array());
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed  $level
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function log($level, $message, array $context = array());
+}

--- a/external/log/Psr/Log/LoggerTrait.php
+++ b/external/log/Psr/Log/LoggerTrait.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * This is a simple Logger trait that classes unable to extend AbstractLogger
+ * (because they extend another class, etc) can include.
+ *
+ * It simply delegates all log-level-specific methods to the `log` method to
+ * reduce boilerplate code that a simple Logger that does the same thing with
+ * messages regardless of the error level has to implement.
+ */
+trait LoggerTrait
+{
+    /**
+     * System is unusable.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function emergency($message, array $context = array())
+    {
+        $this->log(LogLevel::EMERGENCY, $message, $context);
+    }
+
+    /**
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function alert($message, array $context = array())
+    {
+        $this->log(LogLevel::ALERT, $message, $context);
+    }
+
+    /**
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function critical($message, array $context = array())
+    {
+        $this->log(LogLevel::CRITICAL, $message, $context);
+    }
+
+    /**
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function error($message, array $context = array())
+    {
+        $this->log(LogLevel::ERROR, $message, $context);
+    }
+
+    /**
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function warning($message, array $context = array())
+    {
+        $this->log(LogLevel::WARNING, $message, $context);
+    }
+
+    /**
+     * Normal but significant events.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function notice($message, array $context = array())
+    {
+        $this->log(LogLevel::NOTICE, $message, $context);
+    }
+
+    /**
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function info($message, array $context = array())
+    {
+        $this->log(LogLevel::INFO, $message, $context);
+    }
+
+    /**
+     * Detailed debug information.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function debug($message, array $context = array())
+    {
+        $this->log(LogLevel::DEBUG, $message, $context);
+    }
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed  $level
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    abstract public function log($level, $message, array $context = array());
+}

--- a/external/log/Psr/Log/NullLogger.php
+++ b/external/log/Psr/Log/NullLogger.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * This Logger can be used to avoid conditional log calls.
+ *
+ * Logging should always be optional, and if no logger is provided to your
+ * library creating a NullLogger instance to have something to throw logs at
+ * is a good way to avoid littering your code with `if ($this->logger) { }`
+ * blocks.
+ */
+class NullLogger extends AbstractLogger
+{
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed  $level
+     * @param string $message
+     * @param array  $context
+     *
+     * @return null
+     */
+    public function log($level, $message, array $context = array())
+    {
+        // noop
+    }
+}

--- a/external/log/Psr/Log/Test/LoggerInterfaceTest.php
+++ b/external/log/Psr/Log/Test/LoggerInterfaceTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Psr\Log\Test;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+/**
+ * Provides a base test class for ensuring compliance with the LoggerInterface.
+ *
+ * Implementors can extend the class and implement abstract methods to run this
+ * as part of their test suite.
+ */
+abstract class LoggerInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return LoggerInterface
+     */
+    abstract public function getLogger();
+
+    /**
+     * This must return the log messages in order.
+     *
+     * The simple formatting of the messages is: "<LOG LEVEL> <MESSAGE>".
+     *
+     * Example ->error('Foo') would yield "error Foo".
+     *
+     * @return string[]
+     */
+    abstract public function getLogs();
+
+    public function testImplements()
+    {
+        $this->assertInstanceOf('Psr\Log\LoggerInterface', $this->getLogger());
+    }
+
+    /**
+     * @dataProvider provideLevelsAndMessages
+     */
+    public function testLogsAtAllLevels($level, $message)
+    {
+        $logger = $this->getLogger();
+        $logger->{$level}($message, array('user' => 'Bob'));
+        $logger->log($level, $message, array('user' => 'Bob'));
+
+        $expected = array(
+            $level.' message of level '.$level.' with context: Bob',
+            $level.' message of level '.$level.' with context: Bob',
+        );
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function provideLevelsAndMessages()
+    {
+        return array(
+            LogLevel::EMERGENCY => array(LogLevel::EMERGENCY, 'message of level emergency with context: {user}'),
+            LogLevel::ALERT => array(LogLevel::ALERT, 'message of level alert with context: {user}'),
+            LogLevel::CRITICAL => array(LogLevel::CRITICAL, 'message of level critical with context: {user}'),
+            LogLevel::ERROR => array(LogLevel::ERROR, 'message of level error with context: {user}'),
+            LogLevel::WARNING => array(LogLevel::WARNING, 'message of level warning with context: {user}'),
+            LogLevel::NOTICE => array(LogLevel::NOTICE, 'message of level notice with context: {user}'),
+            LogLevel::INFO => array(LogLevel::INFO, 'message of level info with context: {user}'),
+            LogLevel::DEBUG => array(LogLevel::DEBUG, 'message of level debug with context: {user}'),
+        );
+    }
+
+    /**
+     * @expectedException \Psr\Log\InvalidArgumentException
+     */
+    public function testThrowsOnInvalidLevel()
+    {
+        $logger = $this->getLogger();
+        $logger->log('invalid level', 'Foo');
+    }
+
+    public function testContextReplacement()
+    {
+        $logger = $this->getLogger();
+        $logger->info('{Message {nothing} {user} {foo.bar} a}', array('user' => 'Bob', 'foo.bar' => 'Bar'));
+
+        $expected = array('info {Message {nothing} Bob Bar a}');
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function testObjectCastToString()
+    {
+        $dummy = $this->getMock('Psr\Log\Test\DummyTest', array('__toString'));
+        $dummy->expects($this->once())
+            ->method('__toString')
+            ->will($this->returnValue('DUMMY'));
+
+        $this->getLogger()->warning($dummy);
+
+        $expected = array('warning DUMMY');
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function testContextCanContainAnything()
+    {
+        $context = array(
+            'bool' => true,
+            'null' => null,
+            'string' => 'Foo',
+            'int' => 0,
+            'float' => 0.5,
+            'nested' => array('with object' => new DummyTest),
+            'object' => new \DateTime,
+            'resource' => fopen('php://memory', 'r'),
+        );
+
+        $this->getLogger()->warning('Crazy context data', $context);
+
+        $expected = array('warning Crazy context data');
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function testContextExceptionKeyCanBeExceptionOrOtherValues()
+    {
+        $logger = $this->getLogger();
+        $logger->warning('Random message', array('exception' => 'oops'));
+        $logger->critical('Uncaught Exception!', array('exception' => new \LogicException('Fail')));
+
+        $expected = array(
+            'warning Random message',
+            'critical Uncaught Exception!'
+        );
+        $this->assertEquals($expected, $this->getLogs());
+    }
+}
+
+class DummyTest
+{
+}

--- a/external/log/README.md
+++ b/external/log/README.md
@@ -1,0 +1,45 @@
+PSR Log
+=======
+
+This repository holds all interfaces/classes/traits related to
+[PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md).
+
+Note that this is not a logger of its own. It is merely an interface that
+describes a logger. See the specification for more details.
+
+Usage
+-----
+
+If you need a logger, you can use the interface like this:
+
+```php
+<?php
+
+use Psr\Log\LoggerInterface;
+
+class Foo
+{
+    private $logger;
+
+    public function __construct(LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+    }
+
+    public function doSomething()
+    {
+        if ($this->logger) {
+            $this->logger->info('Doing work');
+        }
+
+        // do something useful
+    }
+}
+```
+
+You can then pick one of the implementations of the interface to get a logger.
+
+If you want to implement the interface, you can require this package and
+implement `Psr\Log\LoggerInterface` in your code. Please read the
+[specification text](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md)
+for details.


### PR DESCRIPTION
- Keep backward compatibility by sniffing method parameters and
  reversing them if necessary (PSR3's log() method swaps $level and $message)
- Change calls to log() to the more specific PSR-3 version

fixes #1177