### PR TITLE
pull common SQL functions to AbstractSQL

### DIFF
--- a/Idno/Core/DataConcierge.php
+++ b/Idno/Core/DataConcierge.php
@@ -16,17 +16,6 @@
         {
 
             protected $client;
-            protected $database;
-            
-
-            /**
-             * Returns an instance of the database reference variable
-             * @return mixed
-             */
-            function getDatabase()
-            {
-                return $this->database;
-            }
 
             /**
              * Performs database optimizations, depending on engine
@@ -40,17 +29,7 @@
             /**
              * Offer a session handler for the current session
              */
-            function handleSession()
-            {
-                ini_set('session.gc_probability', 1);
-
-                $sessionHandler = new \Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler(\Idno\Core\Idno::site()->db()->getClient(), [
-                    'database'   => 'idnosession',
-                    'collection' => 'idnosession'
-                ]);
-
-                session_set_save_handler($sessionHandler, true);
-            }
+            abstract function handleSession();
 
             /**
              * Returns an instance of the database client reference variable
@@ -80,8 +59,8 @@
 
                 return false;
             }
-            
-            
+
+
             /**
              * Retrieves an Idno entity object by its UUID, casting it to the
              * correct class
@@ -102,8 +81,8 @@
 
                 return false;
             }
-            
-            
+
+
             /**
              * Retrieves ANY object from a collection.
              *
@@ -119,7 +98,7 @@
                 }
                 return false;
             }
-            
+
             /**
              * Saves a record to the specified database collection
              *
@@ -129,7 +108,7 @@
              */
             abstract function saveRecord($collection, $array);
 
-            
+
             /**
              * Retrieves a record from the database by its UUID
              *
@@ -159,7 +138,7 @@
 
                 return false;
             }
-            
+
             /**
              * Process the ID appropriately
              * @param $id
@@ -201,7 +180,7 @@
              */
 
             abstract function getObjects($subtypes = '', $search = array(), $fields = array(), $limit = 10, $offset = 0, $collection = 'entities', $readGroups = []);
-            
+
             /**
              * Retrieves a set of records from the database with given parameters, in
              * reverse chronological order
@@ -238,14 +217,14 @@
              * @return int
              */
             abstract function countRecords($parameters, $collection = 'entities');
-            
+
             /**
              * Remove an entity from the database
              * @param string $id
              * @return true|false
              */
             abstract function deleteRecord($id, $collection = 'entities');
-            
+
             /**
              * Retrieve the filesystem associated with the current db, suitable for saving
              * and retrieving files

--- a/Idno/Data/AbstractSQL.php
+++ b/Idno/Data/AbstractSQL.php
@@ -1,0 +1,291 @@
+<?php
+
+    /**
+     * MySQL back-end for Known data.
+     *
+     * @package idno
+     * @subpackage data
+     */
+
+    namespace Idno\Data {
+
+        use Idno\Core\Idno;
+
+        abstract class AbstractSQL extends \Idno\Core\DataConcierge
+        {
+
+            protected $dbname;
+            protected $dbuser;
+            protected $dbpass;
+            protected $dbhost;
+            protected $dbport;
+
+            function __construct($dbuser = null, $dbpass = null, $dbname = null, $dbhost = null, $dbport = null)
+            {
+                $this->dbuser = $dbuser;
+                $this->dbpass = $dbpass;
+                $this->dbname = $dbname;
+                $this->dbhost = $dbhost;
+                $this->dbport = $dbport;
+
+                if (empty($dbuser)) {
+                    $this->dbuser = \Idno\Core\Idno::site()->config()->dbuser;
+                }
+                if (empty($dbpass)) {
+                    $this->dbpass = \Idno\Core\Idno::site()->config()->dbpass;
+                }
+                if (empty($dbname)) {
+                    $this->dbname = \Idno\Core\Idno::site()->config()->dbname;
+                }
+                if (empty($dbhost)) {
+                    $this->dbhost = \Idno\Core\Idno::site()->config()->dbhost;
+                }
+                if (empty($dbport)) {
+                    $this->dbport = \Idno\Core\Idno::site()->config()->dbport;
+                }
+
+                parent::__construct();
+            }
+
+            /**
+             * Retrieve version information from the schema
+             * @return array|bool
+             */
+            function getVersions()
+            {
+                try {
+                    $client = $this->client;
+                    /* @var \PDO $client */
+                    $statement = $client->prepare("select * from versions");
+                    if ($statement->execute()) {
+                        return $statement->fetchAll(\PDO::FETCH_OBJ);
+                    }
+                } catch (\Exception $e) {
+                    //\Idno\Core\Idno::site()->logging()->log($e->getMessage());
+                    error_log($e->getMessage());
+                }
+
+                return false;
+            }
+
+            /**
+             * Handle the session in MySQL
+             */
+            function handleSession()
+            {
+                if (version_compare(phpversion(), '5.3', '>')) {
+                    $sessionHandler = new \Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler($this->client,
+                        array(
+                            'db_table'    => 'session',
+                            'db_id_col'   => 'session_id',
+                            'db_data_col' => 'session_value',
+                            'db_time_col' => 'session_time',
+                        )
+                    );
+
+                    session_set_save_handler($sessionHandler, true);
+                }
+            }
+
+            /**
+             * Returns an instance of the database reference variable
+             * @return string;
+             */
+            function getDatabase()
+            {
+                return $this->database;
+            }
+
+            /**
+             * Returns an instance of the database client reference variable
+             * @return \PDO
+             */
+            function getClient()
+            {
+                return $this->client;
+            }
+
+            /**
+             * SQL doesn't need the ID to be processed.
+             * @param $id
+             * @return string
+             */
+            function processID($id)
+            {
+                return $id;
+            }
+
+            /**
+             * Retrieve objects of a certain kind that we're allowed to see,
+             * (or excluding kinds that we don't want to see),
+             * in reverse chronological order
+             *
+             * @param string|array $subtypes String or array of subtypes we're allowed to see
+             * @param array $search Any extra search terms in array format (eg array('foo' => 'bar')) (default: empty)
+             * @param array $fields An array of fieldnames to return (leave empty for all; default: all)
+             * @param int $limit Maximum number of records to return (default: 10)
+             * @param int $offset Number of records to skip (default: 0)
+             * @param string $collection Collection to query; default: entities
+             * @param array $readGroups Which ACL groups should we check? (default: everything the user can see)
+             * @return array|false Array of elements or false, depending on success
+             */
+
+            function getObjects($subtypes = '', $search = array(), $fields = array(), $limit = 10, $offset = 0, $collection = 'entities', $readGroups = [])
+            {
+
+                // Initialize query parameters to be an empty array
+                $query_parameters = array();
+
+                // Ensure subtypes are recorded properly
+                // and remove subtypes that have an exclamation mark before them
+                // from consideration
+                if (!empty($subtypes)) {
+                    $not = array();
+                    if (!is_array($subtypes)) {
+                        $subtypes = array($subtypes);
+                    }
+                    foreach ($subtypes as $key => $subtype) {
+                        if (substr($subtype, 0, 1) == '!') {
+                            unset($subtypes[$key]);
+                            $not[] = substr($subtype, 1);
+                        }
+                    }
+                    if (!empty($subtypes)) {
+                        if (count($subtypes) === 1) {
+                            $query_parameters['entity_subtype'] = $subtypes[0];
+                        } else {
+                            $query_parameters['entity_subtype']['$in'] = $subtypes;
+                        }
+                    }
+                    if (!empty($not)) {
+                        if (count($not) === 1) {
+                            $query_parameters['entity_subtype']['$not'] = $not[0];
+                        } else {
+                            $query_parameters['entity_subtype']['$not']['$in'] = $not;
+                        }
+                    }
+                }
+
+                // Make sure we're only getting objects that we're allowed to see
+                if (empty($readGroups)) {
+                    $readGroups = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
+                }
+                $query_parameters['access'] = array('$in' => $readGroups);
+
+                // Join the rest of the search query elements to this search
+                $query_parameters = array_merge($query_parameters, $search);
+
+                // Prepare the fields array for searching, if required
+                if (!empty($fields) && is_array($fields)) {
+                    $fields = array_flip($fields);
+                    $fields = array_fill_keys($fields, true);
+                } else {
+                    $fields = array();
+                }
+
+                // Run the query
+                if ($results = $this->getRecords($fields, $query_parameters, $limit, $offset, $collection)) {
+                    $return = array();
+                    foreach ($results as $row) {
+                        $return[] = $this->rowToEntity($row);
+                    }
+
+                    return $return;
+                }
+
+                return array();
+
+            }
+
+
+            /**
+             * Count objects of a certain kind that we're allowed to see
+             *
+             * @param string|array $subtypes String or array of subtypes we're allowed to see
+             * @param array $search Any extra search terms in array format (eg array('foo' => 'bar')) (default: empty)
+             * @param string $collection Collection to query; default: entities
+             */
+            function countObjects($subtypes = '', $search = array(), $collection = 'entities')
+            {
+
+                // Initialize query parameters to be an empty array
+                $query_parameters = array();
+
+                // Ensure subtypes are recorded properly
+                // and remove subtypes that have an exclamation mark before them
+                // from consideration
+                if (!empty($subtypes)) {
+                    $not = array();
+                    if (!is_array($subtypes)) {
+                        $subtypes = array($subtypes);
+                    }
+                    foreach ($subtypes as $key => $subtype) {
+                        if (substr($subtype, 0, 1) == '!') {
+                            unset($subtypes[$key]);
+                            $not[] = substr($subtype, 1);
+                        }
+                    }
+                    if (!empty($subtypes)) {
+                        if (count($subtypes) === 1) {
+                            $query_parameters['entity_subtype'] = $subtypes[0];
+                        } else {
+                            $query_parameters['entity_subtype']['$in'] = $subtypes;
+                        }
+                    }
+                    if (!empty($not)) {
+                        if (count($not) === 1) {
+                            $query_parameters['entity_subtype']['$not'] = $not[0];
+                        } else {
+                            $query_parameters['entity_subtype']['$not']['$in'] = $not;
+                        }
+                    }
+                }
+
+                // Make sure we're only getting objects that we're allowed to see
+                $readGroups                 = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
+                $query_parameters['access'] = array('$in' => $readGroups);
+
+                // Join the rest of the search query elements to this search
+                $query_parameters = array_merge($query_parameters, $search);
+
+                return $this->countRecords($query_parameters, $collection);
+
+            }
+
+            /**
+             * Get database errors
+             * @return mixed
+             */
+            function getErrors()
+            {
+                if (!empty($this->client)) {
+                    return $this->client->errorInfo();
+                }
+
+                return false;
+            }
+
+            /**
+             * Retrieve the filesystem associated with the current db, suitable for saving
+             * and retrieving files
+             * @return bool
+             */
+            function getFilesystem()
+            {
+                // We're not returning a filesystem for MySQL
+                return false;
+            }
+
+            /**
+             * Given a text query, return an array suitable for adding into getFromX calls
+             * @param $query
+             * @return array
+             */
+            function createSearchArray($query)
+            {
+                return array('$search' => array($query));
+            }
+
+        }
+
+    }

--- a/Idno/Data/Mongo.php
+++ b/Idno/Data/Mongo.php
@@ -71,6 +71,21 @@
             }
 
             /**
+             * Offer a session handler for the current session
+             */
+            function handleSession()
+            {
+                ini_set('session.gc_probability', 1);
+
+                $sessionHandler = new \Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler(\Idno\Core\Idno::site()->db()->getClient(), [
+                    'database'   => 'idnosession',
+                    'collection' => 'idnosession'
+                ]);
+
+                session_set_save_handler($sessionHandler, true);
+            }
+
+            /**
              * Saves a record to the specified database collection
              *
              * @param string $collection
@@ -426,4 +441,3 @@
         }
 
     }
-

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -11,41 +11,8 @@
 
         use Idno\Core\Idno;
 
-        class MySQL extends \Idno\Core\DataConcierge
+        class MySQL extends AbstractSQL
         {
-
-            private $dbname;
-            private $dbuser;
-            private $dbpass;
-            private $dbhost;
-            private $dbport;
-
-            function __construct($dbuser = null, $dbpass = null, $dbname = null, $dbhost = null, $dbport = null)
-            {
-                $this->dbuser = $dbuser;
-                $this->dbpass = $dbpass;
-                $this->dbname = $dbname;
-                $this->dbhost = $dbhost;
-                $this->dbport = $dbport;
-
-                if (empty($dbuser)) {
-                    $this->dbuser = \Idno\Core\Idno::site()->config()->dbuser;
-                }
-                if (empty($dbpass)) {
-                    $this->dbpass = \Idno\Core\Idno::site()->config()->dbpass;
-                }
-                if (empty($dbname)) {
-                    $this->dbname = \Idno\Core\Idno::site()->config()->dbname;
-                }
-                if (empty($dbhost)) {
-                    $this->dbhost = \Idno\Core\Idno::site()->config()->dbhost;
-                }
-                if (empty($dbport)) {
-                    $this->dbport = \Idno\Core\Idno::site()->config()->dbport;
-                }
-
-                parent::__construct();
-            }
 
             function init()
             {
@@ -137,27 +104,6 @@
             }
 
             /**
-             * Retrieve version information from the schema
-             * @return array|bool
-             */
-            function getVersions()
-            {
-                try {
-                    $client = $this->client;
-                    /* @var \PDO $client */
-                    $statement = $client->prepare("select * from `versions`");
-                    if ($statement->execute()) {
-                        return $statement->fetchAll(\PDO::FETCH_OBJ);
-                    }
-                } catch (\Exception $e) {
-                    //\Idno\Core\Idno::site()->logging()->error($e->getMessage());
-                    error_log($e->getMessage());
-                }
-
-                return false;
-            }
-
-            /**
              * Optimize tables - this can reduce overall database storage space and query time
              * @return bool
              */
@@ -172,25 +118,6 @@
                 }
 
                 return false;
-            }
-
-            /**
-             * Handle the session in MySQL
-             */
-            function handleSession()
-            {
-                if (version_compare(phpversion(), '5.3', '>')) {
-                    $sessionHandler = new \Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler(\Idno\Core\Idno::site()->db()->getClient(),
-                        array(
-                            'db_table'    => 'session',
-                            'db_id_col'   => 'session_id',
-                            'db_data_col' => 'session_value',
-                            'db_time_col' => 'session_time',
-                        )
-                    );
-
-                    session_set_save_handler($sessionHandler, true);
-                }
             }
 
             /**
@@ -222,26 +149,6 @@
             }
 
             /**
-             * Saves a Known entity to the database, returning the _id
-             * field on success.
-             *
-             * @param Entity $object
-             */
-
-            function saveObject($object)
-            {
-                if ($object instanceof \Idno\Common\Entity) {
-                    if ($collection = $object->getCollection()) {
-                        $array = $object->saveToArray();
-
-                        return $this->saveRecord($collection, $array);
-                    }
-                }
-
-                return false;
-            }
-
-            /**
              * Saves a record to the specified database collection
              *
              * @param string $collection
@@ -269,8 +176,10 @@
                 if (empty($array['owner'])) {
                     $array['owner'] = '';
                 }
+
                 try {
                     $contents = json_encode($array);
+
                 } catch (\Exception $e) {
                     $contents = json_encode([]);
                     \Idno\Core\Idno::site()->logging()->error($e->getMessage());
@@ -375,27 +284,6 @@
             }
 
             /**
-             * Retrieves a Known entity object by its UUID, casting it to the
-             * correct class
-             *
-             * @param string $id
-             * @return \Idno\Common\Entity | false
-             */
-
-            function getObject($uuid)
-            {
-                if ($result = $this->getRecordByUUID($uuid)) {
-                    if ($object = $this->rowToEntity($result)) {
-                        if ($object->canRead()) {
-                            return $object;
-                        }
-                    }
-                }
-
-                return false;
-            }
-
-            /**
              * Retrieves a record from the database by its UUID
              *
              * @param string $id
@@ -466,80 +354,6 @@
                 }
 
                 return false;
-            }
-
-            /**
-             * Retrieve objects of a certain kind that we're allowed to see,
-             * (or excluding kinds that we don't want to see),
-             * in reverse chronological order
-             *
-             * @param string|array $subtypes String or array of subtypes we're allowed to see
-             * @param array $search Any extra search terms in array format (eg array('foo' => 'bar')) (default: empty)
-             * @param array $fields An array of fieldnames to return (leave empty for all; default: all)
-             * @param int $limit Maximum number of records to return (default: 10)
-             * @param int $offset Number of records to skip (default: 0)
-             * @param string $collection Collection to query; default: entities
-             * @param array $readGroups Which ACL groups should we check? (default: everything the user can see)
-             * @return array|false Array of elements or false, depending on success
-             */
-
-            function getObjects($subtypes = '', $search = array(), $fields = array(), $limit = 10, $offset = 0, $collection = 'entities', $readGroups = [])
-            {
-
-                // Initialize query parameters to be an empty array
-                $query_parameters = array();
-
-                // Ensure subtypes are recorded properly
-                // and remove subtypes that have an exclamation mark before them
-                // from consideration
-                if (!empty($subtypes)) {
-                    $not = array();
-                    if (!is_array($subtypes)) {
-                        $subtypes = array($subtypes);
-                    }
-                    foreach ($subtypes as $key => $subtype) {
-                        if (substr($subtype, 0, 1) == '!') {
-                            unset($subtypes[$key]);
-                            $not[] = substr($subtype, 1);
-                        }
-                    }
-                    if (!empty($subtypes)) {
-                        $query_parameters['entity_subtype']['$in'] = $subtypes;
-                    }
-                    if (!empty($not)) {
-                        $query_parameters['entity_subtype']['$not'] = $not;
-                    }
-                }
-
-                // Make sure we're only getting objects that we're allowed to see
-                if (empty($readGroups)) {
-                    $readGroups = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
-                }
-                $query_parameters['access'] = array('$in' => $readGroups);
-
-                // Join the rest of the search query elements to this search
-                $query_parameters = array_merge($query_parameters, $search);
-
-                // Prepare the fields array for searching, if required
-                if (!empty($fields) && is_array($fields)) {
-                    $fields = array_flip($fields);
-                    $fields = array_fill_keys($fields, true);
-                } else {
-                    $fields = array();
-                }
-
-                // Run the query
-                if ($results = $this->getRecords($fields, $query_parameters, $limit, $offset, $collection)) {
-                    $return = array();
-                    foreach ($results as $row) {
-                        $return[] = $this->rowToEntity($row);
-                    }
-
-                    return $return;
-                }
-
-                return array();
-
             }
 
             /**
@@ -642,38 +456,46 @@
                                 $variables[":value{$metadata_joins}"] = $value;
                             }
                         } else {
-                            if (!empty($value['$or'])) {
-                                $subwhere[] = "(" . $this->build_where_from_array($value['$or'], $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
-                            }
                             if (!empty($value['$not'])) {
                                 if (!empty($value['$not']['$in'])) {
-                                    $value['$not'] = array_merge($value['$not'], $value['$not']['$in']);
-                                    unset($value['$not']['$in']);
-                                }
-                                if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner'))) {
-                                    $notstring = "`{$collection}`.`$key` not in(";
-                                    $i         = 0;
-                                    foreach ($value['$not'] as $val) {
-                                        if ($i > 0) $notstring .= ', ';
-                                        $notstring .= ":nonmdvalue{$non_md_variables}";
-                                        $variables[":nonmdvalue{$non_md_variables}"] = $val;
-                                        $non_md_variables++;
-                                        $i++;
+
+                                    if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner'))) {
+                                        $notstring = "`{$collection}`.`$key` not in (";
+                                        $i         = 0;
+                                        foreach ($value['$not']['$in'] as $val) {
+                                            if ($i > 0) $notstring .= ', ';
+                                            $notstring .= ":nonmdvalue{$non_md_variables}";
+                                            $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                            $non_md_variables++;
+                                            $i++;
+                                        }
+                                        $notstring .= ")";
+                                    } else {
+                                        $metadata_joins++;
+                                        $notstring                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}' and md{$metadata_joins}.`value` not in (";
+                                        $variables[":name{$metadata_joins}"] = $key;
+                                        $i                                   = 0;
+                                        foreach ($value['$not']['$in'] as $val) {
+                                            if ($i > 0) $notstring .= ', ';
+                                            $notstring .= ":nonmdvalue{$non_md_variables}";
+                                            $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                            $non_md_variables++;
+                                            $i++;
+                                        }
+                                        $notstring .= "))";
                                     }
-                                    $notstring .= ")";
                                 } else {
-                                    $metadata_joins++;
-                                    $notstring                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}' and md{$metadata_joins}.`value` not in (";
-                                    $variables[":name{$metadata_joins}"] = $key;
-                                    $i                                   = 0;
-                                    foreach ($value['$not'] as $val) {
-                                        if ($i > 0) $notstring .= ', ';
-                                        $notstring .= ":nonmdvalue{$non_md_variables}";
-                                        $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                    if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner'))) {
+                                        $notstring                                   = "`{$collection}`.`$key` != :nonmdvalue{$non_md_variables}";
+                                        $variables[":nonmdvalue{$non_md_variables}"] = $value['$not'];
                                         $non_md_variables++;
-                                        $i++;
+                                    } else {
+                                        $metadata_joins++;
+                                        $notstring = "(md{$metadata_joins}.`name`    = :name{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}' and md{$metadata_joins}.`value` != :nonmdvalue{$non_md_variables})";
+                                        $variables[":name{$metadata_joins}"]         = $key;
+                                        $variables[":nonmdvalue{$non_md_variables}"] = $value['$not'];
+                                        $non_md_variables++;
                                     }
-                                    $notstring .= "))";
                                 }
                                 $subwhere[] = $notstring;
                             }
@@ -704,6 +526,9 @@
                                     $instring .= "))";
                                 }
                                 $subwhere[] = $instring;
+                            }
+                            if ($key == '$or') {
+                                $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
                             }
                             if ($key == '$search') {
                                 if (!empty($value[0])) {
@@ -800,52 +625,6 @@
             }
 
             /**
-             * Count objects of a certain kind that we're allowed to see
-             *
-             * @param string|array $subtypes String or array of subtypes we're allowed to see
-             * @param array $search Any extra search terms in array format (eg array('foo' => 'bar')) (default: empty)
-             * @param string $collection Collection to query; default: entities
-             */
-            function countObjects($subtypes = '', $search = array(), $collection = 'entities')
-            {
-
-                // Initialize query parameters to be an empty array
-                $query_parameters = array();
-
-                // Ensure subtypes are recorded properly
-                // and remove subtypes that have an exclamation mark before them
-                // from consideration
-                if (!empty($subtypes)) {
-                    $not = array();
-                    if (!is_array($subtypes)) {
-                        $subtypes = array($subtypes);
-                    }
-                    foreach ($subtypes as $key => $subtype) {
-                        if (substr($subtype, 0, 1) == '!') {
-                            unset($subtypes[$key]);
-                            $not[] = substr($subtype, 1);
-                        }
-                    }
-                    if (!empty($subtypes)) {
-                        $query_parameters['entity_subtype']['$in'] = $subtypes;
-                    }
-                    if (!empty($not)) {
-                        $query_parameters['entity_subtype']['$not'] = $not;
-                    }
-                }
-
-                // Make sure we're only getting objects that we're allowed to see
-                $readGroups                 = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
-                $query_parameters['access'] = array('$in' => $readGroups);
-
-                // Join the rest of the search query elements to this search
-                $query_parameters = array_merge($query_parameters, $search);
-
-                return $this->countRecords($query_parameters, $collection);
-
-            }
-
-            /**
              * Count the number of records that match the given parameters
              * @param array $parameters
              * @param string $collection The collection to interrogate (default: 'entities')
@@ -889,19 +668,6 @@
             }
 
             /**
-             * Get database errors
-             * @return mixed
-             */
-            function getErrors()
-            {
-                if (!empty($this->client)) {
-                    return $this->client->errorInfo();
-                }
-
-                return false;
-            }
-
-            /**
              * Remove an entity from the database
              * @param string $id
              * @return true|false
@@ -932,36 +698,6 @@
                 return false;
             }
 
-            /**
-             * Retrieve the filesystem associated with the current db, suitable for saving
-             * and retrieving files
-             * @return bool
-             */
-            function getFilesystem()
-            {
-                // We're not returning a filesystem for MySQL
-                return false;
-            }
-
-            /**
-             * Given a text query, return an array suitable for adding into getFromX calls
-             * @param $query
-             * @return array
-             */
-            function createSearchArray($query)
-            {
-                return array('$search' => array($query));
-            }
-
-        }
-
-        /**
-         * Helper function that returns the current database object
-         * @return \Idno\Core\DataConcierge
-         */
-        function db()
-        {
-            return \Idno\Core\Idno::site()->db();
         }
 
     }

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -9,41 +9,8 @@
 
     namespace Idno\Data {
 
-        class Postgres extends \Idno\Core\DataConcierge
+        class Postgres extends AbstractSQL
         {
-            private $dbname;
-            private $dbuser;
-            private $dbpass;
-            private $dbhost;
-            private $dbport;
-
-            function __construct($dbuser = null, $dbpass = null, $dbname = null, $dbhost = null, $dbport = null)
-            {
-
-                $this->dbuser = $dbuser;
-                $this->dbpass = $dbpass;
-                $this->dbname = $dbname;
-                $this->dbhost = $dbhost;
-                $this->dbport = $dbport;
-
-                if (empty($dbuser)) {
-                    $this->dbuser = \Idno\Core\Idno::site()->config()->dbuser;
-                }
-                if (empty($dbpass)) {
-                    $this->dbpass = \Idno\Core\Idno::site()->config()->dbpass;
-                }
-                if (empty($dbname)) {
-                    $this->dbname = \Idno\Core\Idno::site()->config()->dbname;
-                }
-                if (empty($dbhost)) {
-                    $this->dbhost = \Idno\Core\Idno::site()->config()->dbhost;
-                }
-                if (empty($dbport)) {
-                    $this->dbport = \Idno\Core\Idno::site()->config()->dbport;
-                }
-
-                parent::__construct();
-            }
 
             function init()
             {
@@ -104,94 +71,6 @@
                         }
                     }
                 }
-            }
-
-            /**
-             * Retrieve version information from the schema
-             * @return array|bool
-             */
-            function getVersions()
-            {
-                try {
-                    $client = $this->client;
-                    /* @var \PDO $client */
-                    $statement = $client->prepare("select * from versions");
-                    if ($statement->execute()) {
-                        return $statement->fetchAll(\PDO::FETCH_OBJ);
-                    }
-                } catch (\Exception $e) {
-                    //\Idno\Core\Idno::site()->logging()->error($e->getMessage());
-                    error_log($e->getMessage());
-                }
-
-                return false;
-            }
-
-            /**
-             * Handle the session in Postgres
-             */
-            function handleSession()
-            {
-                if (version_compare(phpversion(), '5.3', '>')) {
-                    $sessionHandler = new \Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler(\Idno\Core\Idno::site()->db()->getClient(),
-                        array(
-                            'db_table'    => 'session',
-                            'db_id_col'   => 'session_id',
-                            'db_data_col' => 'session_value',
-                            'db_time_col' => 'session_time',
-                        )
-                    );
-
-                    session_set_save_handler($sessionHandler, true);
-                }
-            }
-
-            /**
-             * Returns an instance of the database reference variable
-             * @return string;
-             */
-            function getDatabase()
-            {
-                return $this->database;
-            }
-
-            /**
-             * Returns an instance of the database client reference variable
-             * @return \PDO
-             */
-            function getClient()
-            {
-                return $this->client;
-            }
-
-            /**
-             * MySQL doesn't need the ID to be processed.
-             * @param $id
-             * @return string
-             */
-            function processID($id)
-            {
-                return $id;
-            }
-
-            /**
-             * Saves a Known entity to the database, returning the _id
-             * field on success.
-             *
-             * @param Entity $object
-             */
-
-            function saveObject($object)
-            {
-                if ($object instanceof \Idno\Common\Entity) {
-                    if ($collection = $object->getCollection()) {
-                        $array = $object->saveToArray();
-
-                        return $this->saveRecord($collection, $array);
-                    }
-                }
-
-                return false;
             }
 
             /**
@@ -311,27 +190,6 @@
             }
 
             /**
-             * Retrieves a Known entity object by its UUID, casting it to the
-             * correct class
-             *
-             * @param string $id
-             * @return \Idno\Common\Entity | false
-             */
-
-            function getObject($uuid)
-            {
-                if ($result = $this->getRecordByUUID($uuid)) {
-                    if ($object = $this->rowToEntity($result)) {
-                        if ($object->canRead()) {
-                            return $object;
-                        }
-                    }
-                }
-
-                return false;
-            }
-
-            /**
              * Retrieves a record from the database by its UUID
              *
              * @param string $id
@@ -402,80 +260,6 @@
                 }
 
                 return false;
-            }
-
-            /**
-             * Retrieve objects of a certain kind that we're allowed to see,
-             * (or excluding kinds that we don't want to see),
-             * in reverse chronological order
-             *
-             * @param string|array $subtypes String or array of subtypes we're allowed to see
-             * @param array $search Any extra search terms in array format (eg array('foo' => 'bar')) (default: empty)
-             * @param array $fields An array of fieldnames to return (leave empty for all; default: all)
-             * @param int $limit Maximum number of records to return (default: 10)
-             * @param int $offset Number of records to skip (default: 0)
-             * @param string $collection Collection to query; default: entities
-             * @param array $readGroups Which ACL groups should we check? (default: everything the user can see)
-             * @return array|false Array of elements or false, depending on success
-             */
-
-            function getObjects($subtypes = '', $search = array(), $fields = array(), $limit = 10, $offset = 0, $collection = 'entities', $readGroups = [])
-            {
-
-                // Initialize query parameters to be an empty array
-                $query_parameters = array();
-
-                // Ensure subtypes are recorded properly
-                // and remove subtypes that have an exclamation mark before them
-                // from consideration
-                if (!empty($subtypes)) {
-                    $not = array();
-                    if (!is_array($subtypes)) {
-                        $subtypes = array($subtypes);
-                    }
-                    foreach ($subtypes as $key => $subtype) {
-                        if (substr($subtype, 0, 1) == '!') {
-                            unset($subtypes[$key]);
-                            $not[] = substr($subtype, 1);
-                        }
-                    }
-                    if (!empty($subtypes)) {
-                        $query_parameters['entity_subtype']['$in'] = $subtypes;
-                    }
-                    if (!empty($not)) {
-                        $query_parameters['entity_subtype']['$not'] = $not;
-                    }
-                }
-
-                // Make sure we're only getting objects that we're allowed to see
-                if (empty($readGroups)) {
-                    $readGroups = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
-                }
-                $query_parameters['access'] = array('$in' => $readGroups);
-
-                // Join the rest of the search query elements to this search
-                $query_parameters = array_merge($query_parameters, $search);
-
-                // Prepare the fields array for searching, if required
-                if (!empty($fields) && is_array($fields)) {
-                    $fields = array_flip($fields);
-                    $fields = array_fill_keys($fields, true);
-                } else {
-                    $fields = array();
-                }
-
-                // Run the query
-                if ($results = $this->getRecords($fields, $query_parameters, $limit, $offset, $collection)) {
-                    $return = array();
-                    foreach ($results as $row) {
-                        $return[] = $this->rowToEntity($row);
-                    }
-
-                    return $return;
-                }
-
-                return array();
-
             }
 
             /**
@@ -580,38 +364,47 @@
                                 $variables[":value{$metadata_joins}"] = $value;
                             }
                         } else {
-                            if (!empty($value['$or'])) {
-                                $subwhere[] = "(" . $this->build_where_from_array($value['$or'], $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
-                            }
                             if (!empty($value['$not'])) {
                                 if (!empty($value['$not']['$in'])) {
-                                    $value['$not'] = array_merge($value['$not'], $value['$not']['$in']);
-                                    unset($value['$not']['$in']);
+                                    if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner'))) {
+                                        $notstring = "{$collection}.$key not in (";
+                                        $i         = 0;
+                                        foreach ($value['$not']['$in'] as $val) {
+                                            if ($i > 0) $notstring .= ', ';
+                                            $notstring .= ":nonmdvalue{$non_md_variables}";
+                                            $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                            $non_md_variables++;
+                                            $i++;
+                                        }
+                                        $notstring .= ")";
+                                    } else {
+                                        $metadata_joins++;
+                                        $notstring                           = "(md{$metadata_joins}.name = :name{$metadata_joins} and md{$metadata_joins}.collection = '{$collection}' and md{$metadata_joins}.value not in (";
+                                        $variables[":name{$metadata_joins}"] = $key;
+                                        $i                                   = 0;
+                                        foreach ($value['$not']['$in'] as $val) {
+                                            if ($i > 0) $notstring .= ', ';
+                                            $notstring .= ":nonmdvalue{$non_md_variables}";
+                                            $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                            $non_md_variables++;
+                                            $i++;
+                                        }
+                                        $notstring .= "))";
+                                    }
                                 }
-                                if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner'))) {
-                                    $notstring = "{$collection}.$key not in(";
-                                    $i         = 0;
-                                    foreach ($value['$not'] as $val) {
-                                        if ($i > 0) $notstring .= ', ';
-                                        $notstring .= ":nonmdvalue{$non_md_variables}";
-                                        $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                // simple $not
+                                else {
+                                    if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner'))) {
+                                        $notstring                                   = "{$collection}.{$key} != :nonmdvalue{$non_md_variables}";
+                                        $variables[":nonmdvalue{$non_md_variables}"] = $value['$not'];
                                         $non_md_variables++;
-                                        $i++;
-                                    }
-                                    $notstring .= ")";
-                                } else {
-                                    $metadata_joins++;
-                                    $notstring                           = "(md{$metadata_joins}.name = :name{$metadata_joins} and md{$metadata_joins}.collection = '{$collection}' and md{$metadata_joins}.value not in (";
-                                    $variables[":name{$metadata_joins}"] = $key;
-                                    $i                                   = 0;
-                                    foreach ($value['$not'] as $val) {
-                                        if ($i > 0) $notstring .= ', ';
-                                        $notstring .= ":nonmdvalue{$non_md_variables}";
-                                        $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                    } else {
+                                        $metadata_joins++;
+                                        $notstring = "(md{$metadata_joins}.`name`    = :name{$metadata_joins} and md{$metadata_joins}.collection = '{$collection}' and md{$metadata_joins}.value != :nonmdvalue{$non_md_variables})";
+                                        $variables[":name{$metadata_joins}"]         = $key;
+                                        $variables[":nonmdvalue{$non_md_variables}"] = $value['$not'];
                                         $non_md_variables++;
-                                        $i++;
                                     }
-                                    $notstring .= "))";
                                 }
                                 $subwhere[] = $notstring;
                             }
@@ -643,6 +436,9 @@
                                 }
                                 $subwhere[] = $instring;
                             }
+                            if ($key == '$or') {
+                                $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
+                            }
                             if ($key == '$search' && !empty($value)) {
                                 $val = $value[0]; // The search query is always in $value position [0] for now
 //                                if (strlen($val) > 5) {
@@ -672,52 +468,6 @@
             function exportRecords($collection = 'entities')
             {
                 // TODO
-            }
-
-            /**
-             * Count objects of a certain kind that we're allowed to see
-             *
-             * @param string|array $subtypes String or array of subtypes we're allowed to see
-             * @param array $search Any extra search terms in array format (eg array('foo' => 'bar')) (default: empty)
-             * @param string $collection Collection to query; default: entities
-             */
-            function countObjects($subtypes = '', $search = array(), $collection = 'entities')
-            {
-
-                // Initialize query parameters to be an empty array
-                $query_parameters = array();
-
-                // Ensure subtypes are recorded properly
-                // and remove subtypes that have an exclamation mark before them
-                // from consideration
-                if (!empty($subtypes)) {
-                    $not = array();
-                    if (!is_array($subtypes)) {
-                        $subtypes = array($subtypes);
-                    }
-                    foreach ($subtypes as $key => $subtype) {
-                        if (substr($subtype, 0, 1) == '!') {
-                            unset($subtypes[$key]);
-                            $not[] = substr($subtype, 1);
-                        }
-                    }
-                    if (!empty($subtypes)) {
-                        $query_parameters['entity_subtype']['$in'] = $subtypes;
-                    }
-                    if (!empty($not)) {
-                        $query_parameters['entity_subtype']['$not'] = $not;
-                    }
-                }
-
-                // Make sure we're only getting objects that we're allowed to see
-                $readGroups                 = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
-                $query_parameters['access'] = array('$in' => $readGroups);
-
-                // Join the rest of the search query elements to this search
-                $query_parameters = array_merge($query_parameters, $search);
-
-                return $this->countRecords($query_parameters, $collection);
-
             }
 
             /**
@@ -764,19 +514,6 @@
             }
 
             /**
-             * Get database errors
-             * @return mixed
-             */
-            function getErrors()
-            {
-                if (!empty($this->client)) {
-                    return $this->client->errorInfo();
-                }
-
-                return false;
-            }
-
-            /**
              * Remove an entity from the database
              * @param string $id
              * @return true|false
@@ -807,36 +544,6 @@
                 return false;
             }
 
-            /**
-             * Retrieve the filesystem associated with the current db, suitable for saving
-             * and retrieving files
-             * @return bool
-             */
-            function getFilesystem()
-            {
-                // We're not returning a filesystem for MySQL
-                return false;
-            }
-
-            /**
-             * Given a text query, return an array suitable for adding into getFromX calls
-             * @param $query
-             * @return array
-             */
-            function createSearchArray($query)
-            {
-                return array('$search' => array($query));
-            }
-
-        }
-
-        /**
-         * Helper function that returns the current database object
-         * @return \Idno\Core\DataConcierge
-         */
-        function db()
-        {
-            return \Idno\Core\Idno::site()->db();
         }
 
     }

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -10,22 +10,8 @@
 
     namespace Idno\Data {
 
-        class Sqlite3 extends \Idno\Core\DataConcierge
+        class Sqlite3 extends AbstractSQL
         {
-
-            private $dbname;
-
-            function __construct($dbname = null)
-            {
-
-                $this->dbname = $dbname;
-
-                if (empty($dbname)) {
-                    $this->dbname = \Idno\Core\Idno::site()->config()->dbname;
-                }
-
-                parent::__construct();
-            }
 
             function init()
             {
@@ -110,53 +96,6 @@
                 }
 
                 return false;
-            }
-
-            /**
-             * Handle the session in Sqlite3
-             */
-            function handleSession()
-            {
-                if (version_compare(phpversion(), '5.3', '>')) {
-                    $sessionHandler = new \Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler(\Idno\Core\Idno::site()->db()->getClient(),
-                        array(
-                            'db_table'    => 'session',
-                            'db_id_col'   => 'session_id',
-                            'db_data_col' => 'session_value',
-                            'db_time_col' => 'session_time',
-                        )
-                    );
-
-                    session_set_save_handler($sessionHandler, true);
-                }
-            }
-
-            /**
-             * Returns an instance of the database reference variable
-             * @return string;
-             */
-            function getDatabase()
-            {
-                return $this->database;
-            }
-
-            /**
-             * Returns an instance of the database client reference variable
-             * @return \PDO
-             */
-            function getClient()
-            {
-                return $this->client;
-            }
-
-            /**
-             * Sqlite3 doesn't need the ID to be processed.
-             * @param $id
-             * @return string
-             */
-            function processID($id)
-            {
-                return $id;
             }
 
             /**
@@ -349,80 +288,6 @@
             }
 
             /**
-             * Retrieve objects of a certain kind that we're allowed to see,
-             * (or excluding kinds that we don't want to see),
-             * in reverse chronological order
-             *
-             * @param string|array $subtypes String or array of subtypes we're allowed to see
-             * @param array $search Any extra search terms in array format (eg array('foo' => 'bar')) (default: empty)
-             * @param array $fields An array of fieldnames to return (leave empty for all; default: all)
-             * @param int $limit Maximum number of records to return (default: 10)
-             * @param int $offset Number of records to skip (default: 0)
-             * @param string $collection Collection to query; default: entities
-             * @param array $readGroups Which ACL groups should we check? (default: everything the user can see)
-             * @return array|false Array of elements or false, depending on success
-             */
-
-            function getObjects($subtypes = '', $search = array(), $fields = array(), $limit = 10, $offset = 0, $collection = 'entities', $readGroups = [])
-            {
-
-                // Initialize query parameters to be an empty array
-                $query_parameters = array();
-
-                // Ensure subtypes are recorded properly
-                // and remove subtypes that have an exclamation mark before them
-                // from consideration
-                if (!empty($subtypes)) {
-                    $not = array();
-                    if (!is_array($subtypes)) {
-                        $subtypes = array($subtypes);
-                    }
-                    foreach ($subtypes as $key => $subtype) {
-                        if (substr($subtype, 0, 1) == '!') {
-                            unset($subtypes[$key]);
-                            $not[] = substr($subtype, 1);
-                        }
-                    }
-                    if (!empty($subtypes)) {
-                        $query_parameters['entity_subtype']['$in'] = $subtypes;
-                    }
-                    if (!empty($not)) {
-                        $query_parameters['entity_subtype']['$not'] = $not;
-                    }
-                }
-
-                // Make sure we're only getting objects that we're allowed to see
-                if (empty($readGroups)) {
-                    $readGroups = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
-                }
-                $query_parameters['access'] = array('$in' => $readGroups);
-
-                // Join the rest of the search query elements to this search
-                $query_parameters = array_merge($query_parameters, $search);
-
-                // Prepare the fields array for searching, if required
-                if (!empty($fields) && is_array($fields)) {
-                    $fields = array_flip($fields);
-                    $fields = array_fill_keys($fields, true);
-                } else {
-                    $fields = array();
-                }
-
-                // Run the query
-                if ($results = $this->getRecords($fields, $query_parameters, $limit, $offset, $collection)) {
-                    $return = array();
-                    foreach ($results as $row) {
-                        $return[] = $this->rowToEntity($row);
-                    }
-
-                    return $return;
-                }
-
-                return array();
-
-            }
-
-            /**
              * Retrieves a set of records from the database with given parameters, in
              * reverse chronological order
              *
@@ -527,38 +392,47 @@
                                 $variables[":value{$metadata_joins}"] = $value;
                             }
                         } else {
-                            if (!empty($value['$or'])) {
-                                $subwhere[] = "(" . $this->build_where_from_array($value['$or'], $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
-                            }
                             if (!empty($value['$not'])) {
                                 if (!empty($value['$not']['$in'])) {
-                                    $value['$not'] = array_merge($value['$not'], $value['$not']['$in']);
-                                    unset($value['$not']['$in']);
+                                    if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner'))) {
+                                        $notstring = "`{$collection}`.`$key` not in(";
+                                        $i         = 0;
+                                        foreach ($value['$not']['$in'] as $val) {
+                                            if ($i > 0) $notstring .= ', ';
+                                            $notstring .= ":nonmdvalue{$non_md_variables}";
+                                            $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                            $non_md_variables++;
+                                            $i++;
+                                        }
+                                        $notstring .= ")";
+                                    } else {
+                                        $metadata_joins++;
+                                        $notstring                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}' and md{$metadata_joins}.`value` not in (";
+                                        $variables[":name{$metadata_joins}"] = $key;
+                                        $i                                   = 0;
+                                        foreach ($value['$not']['$in'] as $val) {
+                                            if ($i > 0) $notstring .= ', ';
+                                            $notstring .= ":nonmdvalue{$non_md_variables}";
+                                            $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                            $non_md_variables++;
+                                            $i++;
+                                        }
+                                        $notstring .= "))";
+                                    }
                                 }
-                                if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner'))) {
-                                    $notstring = "`{$collection}`.`$key` not in(";
-                                    $i         = 0;
-                                    foreach ($value['$not'] as $val) {
-                                        if ($i > 0) $notstring .= ', ';
-                                        $notstring .= ":nonmdvalue{$non_md_variables}";
-                                        $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                // simple $not
+                                else {
+                                    if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner'))) {
+                                        $notstring                                   = "`{$collection}`.`$key` != :nonmdvalue{$non_md_variables}";
+                                        $variables[":nonmdvalue{$non_md_variables}"] = $value['$not'];
                                         $non_md_variables++;
-                                        $i++;
-                                    }
-                                    $notstring .= ")";
-                                } else {
-                                    $metadata_joins++;
-                                    $notstring                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}' and md{$metadata_joins}.`value` not in (";
-                                    $variables[":name{$metadata_joins}"] = $key;
-                                    $i                                   = 0;
-                                    foreach ($value['$not'] as $val) {
-                                        if ($i > 0) $notstring .= ', ';
-                                        $notstring .= ":nonmdvalue{$non_md_variables}";
-                                        $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                    } else {
+                                        $metadata_joins++;
+                                        $notstring = "(md{$metadata_joins}.`name`    = :name{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}' and md{$metadata_joins}.`value` != :nonmdvalue{$non_md_variables})";
+                                        $variables[":name{$metadata_joins}"]         = $key;
+                                        $variables[":nonmdvalue{$non_md_variables}"] = $value['$not'];
                                         $non_md_variables++;
-                                        $i++;
                                     }
-                                    $notstring .= "))";
                                 }
                                 $subwhere[] = $notstring;
                             }
@@ -590,6 +464,9 @@
                                 }
                                 $subwhere[] = $instring;
                             }
+                            if ($key == '$or') {
+                                $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
+                            }
                             if ($key == '$search' && !empty($value)) {
                                 $val = $value[0]; // The search query is always in $value position [0] for now
 //                                if (strlen($val) > 5) {
@@ -609,52 +486,6 @@
                 }
 
                 return $where;
-            }
-
-            /**
-             * Count objects of a certain kind that we're allowed to see
-             *
-             * @param string|array $subtypes String or array of subtypes we're allowed to see
-             * @param array $search Any extra search terms in array format (eg array('foo' => 'bar')) (default: empty)
-             * @param string $collection Collection to query; default: entities
-             */
-            function countObjects($subtypes = '', $search = array(), $collection = 'entities')
-            {
-
-                // Initialize query parameters to be an empty array
-                $query_parameters = array();
-
-                // Ensure subtypes are recorded properly
-                // and remove subtypes that have an exclamation mark before them
-                // from consideration
-                if (!empty($subtypes)) {
-                    $not = array();
-                    if (!is_array($subtypes)) {
-                        $subtypes = array($subtypes);
-                    }
-                    foreach ($subtypes as $key => $subtype) {
-                        if (substr($subtype, 0, 1) == '!') {
-                            unset($subtypes[$key]);
-                            $not[] = substr($subtype, 1);
-                        }
-                    }
-                    if (!empty($subtypes)) {
-                        $query_parameters['entity_subtype']['$in'] = $subtypes;
-                    }
-                    if (!empty($not)) {
-                        $query_parameters['entity_subtype']['$not'] = $not;
-                    }
-                }
-
-                // Make sure we're only getting objects that we're allowed to see
-                $readGroups                 = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
-                $query_parameters['access'] = array('$in' => $readGroups);
-
-                // Join the rest of the search query elements to this search
-                $query_parameters = array_merge($query_parameters, $search);
-
-                return $this->countRecords($query_parameters, $collection);
-
             }
 
             /**
@@ -704,19 +535,6 @@
             }
 
             /**
-             * Get database errors
-             * @return mixed
-             */
-            function getErrors()
-            {
-                if (!empty($this->client)) {
-                    return $this->client->errorInfo();
-                }
-
-                return false;
-            }
-
-            /**
              * Remove an entity from the database
              * @param string $id
              * @return true|false
@@ -747,42 +565,10 @@
                 return false;
             }
 
-            /**
-             * Retrieve the filesystem associated with the current db, suitable for saving
-             * and retrieving files
-             * @return bool
-             */
-            function getFilesystem()
-            {
-                // We're not returning a filesystem for Sqlite3
-                return false;
-            }
-
-            /**
-             * Given a text query, return an array suitable for adding into getFromX calls
-             * @param $query
-             * @return array
-             */
-            function createSearchArray($query)
-            {
-                return array('$search' => array($query));
-            }
-
             public function exportRecords($collection = 'entities')
             {
-
-
                 return false; // TODO
             }
-        }
-
-        /**
-         * Helper function that returns the current database object
-         * @return \Idno\Core\DataConcierge
-         */
-        function db()
-        {
-            return \Idno\Core\Idno::site()->db();
         }
 
     }


### PR DESCRIPTION
- refactor to eliminate duplicate code between Postgres, Mysql, &
  Sqlite implementations
- change logic of build_where_query slightly to support
  `[$not]` and `[$not][$in]` (previously it combined the two cases).
- also check for `$key == '$or'` rather than `!empty($value['$or'])`,
  which I don't think made sense.