### PR TITLE
MP Endpoint: rollback $photo

### DIFF
--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -174,7 +174,7 @@
                         $hashtags = (empty($hashtags) ? "" : "<p>".$hashtags."</p>");
                         $htmlPhoto    = (empty($htmlPhoto) ? "" : "<p>".$htmlPhoto."</p>");
                         $this->setInput('title', $name);
-                        $this->setInput('body', $photo.$content_value.$hashtags);
+                        $this->setInput('body', $htmlPhoto.$content_value.$hashtags);
                         $this->setInput('inreplyto', $in_reply_to);
                         $this->setInput('like-of', $like_of);
                         $this->setInput('repost-of', $repost_of);

--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -117,7 +117,7 @@
                                $photo = \Idno\Core\Idno::site()->config()->url . 'file/' . $id;
                            }
                            if (!empty($photo)) {
-                               $photo = '<p><img style="display: block; margin-left: auto; margin-right: auto;" src="' . $photo . '" alt="' . $place_name . '"  /></p>';
+                               $htmlPhoto = '<p><img style="display: block; margin-left: auto; margin-right: auto;" src="' . $photo . '" alt="' . $place_name . '"  /></p>';
                            }
                       }
                     if ($type == 'photo' && empty($name) && !empty($content)) {
@@ -134,6 +134,7 @@
 
                 // setting all categories as hashtags into content field
                 if (is_array($categories)) {
+                    $hashtags = "";
                     foreach ($categories as $category) {
                         $category = trim($category);
                         if ($category) {
@@ -171,7 +172,7 @@
                             $entity->setPosseLink(str_replace('.com', '', $posse_service), $posse_link, '', '');
                         }
                         $hashtags = (empty($hashtags) ? "" : "<p>".$hashtags."</p>");
-                        $photo    = (empty($photo) ? "" : "<p>".$photo."</p>");
+                        $htmlPhoto    = (empty($htmlPhoto) ? "" : "<p>".$htmlPhoto."</p>");
                         $this->setInput('title', $name);
                         $this->setInput('body', $photo.$content_value.$hashtags);
                         $this->setInput('inreplyto', $in_reply_to);


### PR DESCRIPTION
## Here's what I fixed or added:
renamed $photo variable
## Here's why I did it:
$photo is used to create a photo entity and should then not be added to the $content
