### PR TITLE
MP Endpoint: delete single quotes in categories (for hashtags)

### DIFF
--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -139,6 +139,7 @@
                         $category = trim($category);
                         if ($category) {
                             if (str_word_count($category) > 1) {
+                                $category = str_replace("'"," ",$category);
                                 $category = ucwords($category);
                                 $category = str_replace(" ","",$category);
                             }


### PR DESCRIPTION
## Here's what I fixed or added:
delete single quotes in categories name
## Here's why I did it:
4sq categories are internationalized and can have single quotes (apostrophe), as this would break the hashtag, we need to delete them.