### PR TITLE
AbstractSQL bugfix: $not cannot be side-by-side with a simple = value

### DIFF
--- a/Idno/Data/AbstractSQL.php
+++ b/Idno/Data/AbstractSQL.php
@@ -150,18 +150,20 @@
                             $not[] = substr($subtype, 1);
                         }
                     }
-                    if (!empty($subtypes)) {
-                        if (count($subtypes) === 1) {
-                            $query_parameters['entity_subtype'] = $subtypes[0];
-                        } else {
+                    if (count($subtypes) === 1) {
+                        // no need to check $not if there can only be one subtype
+                        $query_parameters['entity_subtype'] = $subtypes[0];
+                    } else {
+                        if (!empty($subtypes)) {
                             $query_parameters['entity_subtype']['$in'] = $subtypes;
                         }
-                    }
-                    if (!empty($not)) {
-                        if (count($not) === 1) {
-                            $query_parameters['entity_subtype']['$not'] = $not[0];
-                        } else {
-                            $query_parameters['entity_subtype']['$not']['$in'] = $not;
+                        // TODO else if? do we ever need to check both $in and $not $in?
+                        if (!empty($not)) {
+                            if (count($not) === 1) {
+                                $query_parameters['entity_subtype']['$not'] = $not[0];
+                            } else {
+                                $query_parameters['entity_subtype']['$not']['$in'] = $not;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Here's what I fixed or added:

if querying just one subtype, then just set `$search['entity_subtype'] = value`. The `$not` query in this case is redundant and trying to set it was giving a warning message.


## Here's why I did it:

My previous PR introduced this bug. It used to just set `[$in]` and `[$not][$in]` even if there was only one candidate match.
