### PR TITLE
remove urldecode from webmention endpoint

### DIFF
--- a/Idno/Pages/Webmentions/Endpoint.php
+++ b/Idno/Pages/Webmentions/Endpoint.php
@@ -26,9 +26,8 @@
                 // Check that both source and target are non-empty
                 if (!empty($vars['source']) && !empty($vars['target']) && $vars['source'] != $vars['target']) {
 
-                    // Sanitize source and target
-                    $source = urldecode($vars['source']);
-                    $target = urldecode($vars['target']);
+                    $source = $vars['source'];
+                    $target = $vars['target'];
 
                     // Remove anchors from target URL, but save them to '#' input so we can still reference them later
                     if (strpos($target, '#')) {


### PR DESCRIPTION
## Here's what I fixed or added:

remove urldecode calls on received webmentions

## Here's why I did it:


form parameters should already have been decoded; decoding them again
caused an issue where we could not recognize webmentions when the
source has unicode characters in the URL (i.e. it would grep the target content
for the source, but not find it since the %-characters in the source URL
had been converted to their unicode equivalent)

@nekr0z reported this issue to bridgy here: https://github.com/snarfed/bridgy/issues/625