### PR TITLE
let plugins store additional properties in posse links

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1081,26 +1081,27 @@
 
             /**
              * Sets the POSSE link for this entity to a particular service
-             * @param $service The name of the service
-             * @param $url The URL of the post
-             * @param $identifier A human-readable account identifier
-             * @param $item_id A Known-readable item identifier
-             * @param $account_id A Known-readable account identifier
+             * @param string $service The name of the service
+             * @param string $url The URL of the post
+             * @param string $identifier A human-readable account identifier
+             * @param string $item_id A Known-readable item identifier
+             * @param string $account_id A Known-readable account identifier
+             * @param array $other_properties (optional) additional properties to store with the link
              * @return bool
              */
-            function setPosseLink($service, $url, $identifier = '', $item_id = '', $account_id = '')
+            function setPosseLink($service, $url, $identifier = '', $item_id = '', $account_id = '', $other_properties=array())
             {
                 if (!empty($service) && !empty($url)) {
                     $posse = $this->posse;
                     if (empty($identifier)) {
                         $identifier = $service;
                     }
-                    $posse[$service][] = array(
+                    $posse[$service][] = array_merge($other_properties, array(
                         'url'        => $url,
                         'identifier' => $identifier,
                         'item_id'    => $item_id,
                         'account_id' => $account_id
-                    );
+                    ));
                     $this->posse       = $posse;
 
                     return true;
@@ -2009,10 +2010,10 @@
                 }
 
                 // Ask whether it's ok to save this annotation (allows filtering)
-                if (!\Idno\Core\Idno::site()->triggerEvent('annotation/save', array('annotation' => $annotation, 'object' => $this))) { 
+                if (!\Idno\Core\Idno::site()->triggerEvent('annotation/save', array('annotation' => $annotation, 'object' => $this))) {
                     return false; // Something prevented the annotation from being saved.
                 }
-                
+
                 $annotations[$subtype][$local_url] = $annotation;
                 $this->annotations                 = $annotations;
                 $this->save();

--- a/Idno/Core/Syndication.php
+++ b/Idno/Core/Syndication.php
@@ -146,19 +146,20 @@
              * Registers an account on a particular service as being available. The service itself must also have been registered.
              * @param string $service The name of the service.
              * @param string $username The username or user identifier on the service.
-             * @param $display_name A human-readable name for this account.
+             * @param string $display_name A human-readable name for this account.
+             * @param array $other_properties An optional list of additional properties to include in the account record
              */
-            function registerServiceAccount($service, $username, $display_name)
+            function registerServiceAccount($service, $username, $display_name, $other_properties=array())
             {
                 $service = strtolower($service);
                 if (!empty($this->accounts[$service])) {
-                    foreach ($this->accounts[$service] as $key => $account) {
+                    foreach ($this->accounts[$service] as $idx => $account) {
                         if ($account['username'] == $username) {
-                            unset($this->accounts[$service][$key]); // Remove existing entry if it exists, so fresher one can be added
+                            unset($this->accounts[$service][$idx]); // Remove existing entry if it exists, so fresher one can be added
                         }
                     }
                 }
-                $this->accounts[$service][] = array('username' => $username, 'name' => $display_name);
+                $this->accounts[$service][] = array_merge($other_properties, ['username' => $username, 'name' => $display_name]);
             }
 
             /**

--- a/templates/default/content/syndication.tpl.php
+++ b/templates/default/content/syndication.tpl.php
@@ -31,11 +31,21 @@
                             }
                             $service_details[$service][] = ['username' => $account['username'], 'name' => $account['name']];
 
-                            $button .= $this->__(array('service' => $service, 'disabled' => $disabled, 'username' => $account['username'], 'name' => $account['name'], 'selected' => \Idno\Core\Idno::site()->triggerEvent('syndication/selected/' . $service, [
-                                'service' => $service,
+                            // give plugins a chance to pre-select a service (e.g. if replying to a tweet, pre-select twitter)
+                            $preselect = \Idno\Core\Idno::site()->triggerEvent('syndication/selected/' . $service, [
+                                'service'  => $service,
                                 'username' => $account['username'],
                                 'reply-to' => \Idno\Core\Idno::site()->currentPage()->getInput('share_url')
-                            ], false)))->draw('content/syndication/account');
+                            ], false);
+
+                            $button .= $this->__([
+                                'service'  => $service,
+                                'disabled' => $disabled,
+                                'username' => $account['username'],
+                                'name'     => $account['name'],
+                                'details'  => $account,
+                                'selected' => $preselect,
+                            ])->draw('content/syndication/account');
                         }
                     } else {
                         $disabled = array_key_exists($service, $posse_links) ? 'disabled' : '';

--- a/templates/default/content/syndication/links.tpl.php
+++ b/templates/default/content/syndication/links.tpl.php
@@ -16,8 +16,11 @@
                 }
 
                 foreach($posse_links as $element) {
-                    $this->username = isset($element['account_id']) ? $element['account_id'] : false;
-                    $human_icon = $this->draw('content/syndication/icon/' . $service);
+                    $human_icon = $this->__([
+                        'username' => isset($element['account_id']) ? $element['account_id'] : false,
+                        'details'  => $element,
+                    ])->draw('content/syndication/icon/' . $service);
+
                     if (empty($human_icon)) {
                         $human_icon = $this->draw('content/syndication/icon/generic');
                     }


### PR DESCRIPTION
## Here's what I fixed or added:

Added parameters so I can stick "additional" properties into serviceAccount definitions and also into posseLinks that have been created.

## Here's why I did it:

 This supports IndieSyndicate which will store a configurable icon and posse-style
for each micropub syndication account.