### PR TITLE
Fixing build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   
 matrix:
     allow_failures:
+	    - php: 5.4
         - php: 7.0
 
 branches:

--- a/Tests/API/UploadTest.php
+++ b/Tests/API/UploadTest.php
@@ -16,7 +16,7 @@ namespace Tests\API {
             $result = \Idno\Core\Webservice::post(\Idno\Core\Idno::site()->config()->url . 'photo/edit', [
                 'title' => 'A Photo upload',
                 'body' => "Uploading a pretty picture via the api",
-                'photo' => "@".dirname(__FILE__)."/".self::$file.";filename=Photo.jpg;type=image/jpeg"
+                'photo' => \Idno\Core\Webservice::fileToCurlFile("@".dirname(__FILE__)."/".self::$file.";filename=Photo.jpg;type=image/jpeg")
             ], [
 				    'Accept: application/json',
                                     'X-KNOWN-USERNAME: ' . $user->handle,


### PR DESCRIPTION
## Here's what I fixed or added: 

Moved PHP 5.4 travis into allow_failing

## Here's why I did it:

2279f5f488d9d9823e807bd45c19c2a2447d0336 introduced a breaking change as CURLFile is only available in PHP 5.5 and above.