### PR TITLE
Soft deprecation of PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   
 matrix:
     allow_failures:
-	    - php: 5.4
+        - php: 5.4
         - php: 7.0
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   
 matrix:
     allow_failures:
+	    - php: 5.4
         - php: 7.0
 
 branches:

--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -440,7 +440,7 @@
                             if (class_exists('CURLFile')) {
                                 return new \CURLFile($file, $mime, $name);
                             } else {
-                                throw new \Exception("CURLFile does not exist");
+                                throw new \Exception("Sorry, CURLFile is not supported by your version of PHP");
                             }
                         }
 

--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -84,7 +84,7 @@
                     $basics['status']             = 'Failure';
                     $basics['report']['php-version'] = [
                         'status'  => 'Warning',
-                        'message' => 'You are running Known using a very old version of PHP (' . phpversion() . '), which is no longer supported by the manufacturer. Although Known will currently still run, we\'re likely to start phasing out support, so you should upgrade soon. You may need to ask your server administrator to upgrade PHP for you.'
+                        'message' => 'You are running Known using a very old version of PHP (' . phpversion() . '), which is no longer supported. Although Known will currently still install, some features will not work, so you should upgrade soon. You may need to ask your server administrator to upgrade PHP for you.'
                     ];
                 } else {
                     $basics['report']['php-version'] = [

--- a/Tests/API/UploadTest.php
+++ b/Tests/API/UploadTest.php
@@ -16,7 +16,7 @@ namespace Tests\API {
             $result = \Idno\Core\Webservice::post(\Idno\Core\Idno::site()->config()->url . 'photo/edit', [
                 'title' => 'A Photo upload',
                 'body' => "Uploading a pretty picture via the api",
-                'photo' => "@".dirname(__FILE__)."/".self::$file.";filename=Photo.jpg;type=image/jpeg"
+                'photo' => \Idno\Core\Webservice::fileToCurlFile("@".dirname(__FILE__)."/".self::$file.";filename=Photo.jpg;type=image/jpeg")
             ], [
 				    'Accept: application/json',
                                     'X-KNOWN-USERNAME: ' . $user->handle,

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -4,7 +4,7 @@ Known _requires_ the following server components:
 
 + A Web Server that supports URL rewriting (Apache + mod_rewrite recommended).
 + If you are using Apache, you also need to make sure support for .htaccess is enabled (using [the AllowOverride All directive](https://help.ubuntu.com/community/EnablingUseOfApacheHtaccessFiles)).
-+ PHP 5.4 or above.
++ PHP 5.5 or above.
 + MySQL 5+, MongoDB, Postgres or SQLite3. We recommend MySQL.
 
 Known can either be installed at the root of a domain or subdomain, or in a subdirectory.

--- a/warmup/requirements.php
+++ b/warmup/requirements.php
@@ -27,7 +27,7 @@
                     $text = 'You are running PHP version ' . phpversion() . '.';
                 } else if (version_compare(phpversion(), '5.4') >= 0) {
                     $class = 'warning';
-                    $text = 'You are running Known using a very old version of PHP (' . phpversion() . '), which is no longer supported by the manufacturer. Although Known will currently still run, we\'re likely to start phasing out support, so you should upgrade soon. You may need to ask your server administrator to upgrade PHP for you.';
+                    $text = 'You are running Known using a very old version of PHP (' . phpversion() . '), which is no longer supported. Although Known will currently still install, some features will not work, so you should upgrade soon. You may need to ask your server administrator to upgrade PHP for you.';
                 } else {
                     $class = 'failure';
                     $text = 'You are running PHP version ' . phpversion() . ', which cannot run Known. You may need to ask your server administrator to upgrade PHP for you.';


### PR DESCRIPTION
## Here's what I fixed or added:

* Uses stronger language in PHP 5.4 warning message
* Changing documented minimum requirement to PHP 5.5

## Here's why I did it:

Removal of the @ file shim in 2279f5f488d9d9823e807bd45c19c2a2447d0336 introduced a breaking change in the Webservice interface, this means we can no longer maintain PHP 5.4 support without significant technical debt. 

This patch moves PHP 5.4 to the "breaking" section of the travis build, and softly deprecates 5.4 support in the installer. 5.4 installs will still install (i.e. the installer won't kick you out), but we now state that it's going to be increasingly unsupported and that you should upgrade.

Closes previous tickets and PRs related to this issue.

Refs #1310