### PR TITLE
Adds WebserviceFile curl wrapper

### DIFF
--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -44,28 +44,20 @@
                 switch (strtolower($verb)) {
                     case 'post':
 
-                        // Check for old style @file uploads and try and convert them
-                        /*
+                        // Check for WebserviceFile and convert to CURL Parameters
                         if (!empty($params) && is_array($params)) {
                             foreach ($params as $k => $v) {
-                                if ($v[0] == '@') {
+                                
+                                if ($v instanceof \Idno\Core\WebserviceFile) { 
+                                    
                                     try {
-
-                                        $cfile = self::fileToCurlFile($v);
-                                        if ($cfile) {
-                                            $params[$k] = $cfile;
-                                            curl_setopt($curl_handle, CURLOPT_SAFE_UPLOAD, true);
-                                        }
-
+                                        $params[$k] = $v->getCurlParameters();
                                     } catch (\Exception $ex) {
                                         \Idno\Core\Idno::site()->logging->error("Error sending $verb to $endpoint", ['error' => $ex]);
-                                        if (defined('CURLOPT_SAFE_UPLOAD')) { // 5.4 compat
-                                            curl_setopt($curl_handle, CURLOPT_SAFE_UPLOAD, false);
-                                        }
                                     }
                                 }
                             }
-                        }*/
+                        }
 
                         curl_setopt($curl_handle, CURLOPT_POST, 1);
                         curl_setopt($curl_handle, CURLOPT_POSTFIELDS, $params);
@@ -407,48 +399,6 @@
                 return self::$lastResponse;
             }
 
-            /**
-             * Converts an "@" formatted file string into a CurlFile
-             * @param type $fileuploadstring
-             * @return CURLFile|false
-             */
-            static function fileToCurlFile($fileuploadstring) {
-                if ($fileuploadstring[0] == '@') {
-                    $bits = explode(';', $fileuploadstring);
-
-                    $file = $name = $mime = null;
-
-                    foreach ($bits as $bit) {
-                        // File
-                        if ($bit[0] == '@') {
-                            $file = trim($bit, '@ ;');
-                        }
-                        if (strpos($bit, 'filename')!==false) {
-                            $tmp = explode('=', $bit);
-                            $name = trim($tmp[1], ' ;');
-                        }
-                        if (strpos($bit, 'type')!==false) {
-                            $tmp = explode('=', $bit);
-                            $mime = trim($tmp[1], ' ;');
-                        }
-
-                    }
-
-                    if ($file) {
-
-                        if (file_exists($file)) {
-                            if (class_exists('CURLFile')) {
-                                return new \CURLFile($file, $mime, $name);
-                            } else {
-                                throw new \Exception("CURLFile does not exist");
-                            }
-                        }
-
-                    }
-                }
-
-                return false;
-            }
         }
 
     }

--- a/Idno/Core/WebserviceFile.php
+++ b/Idno/Core/WebserviceFile.php
@@ -21,6 +21,10 @@ namespace Idno\Core {
             $this->name = $name;
         }
 
+        /**
+         * Return curl parameters supported by your system.
+         * @return \CURLFile|string
+         */
         function getCurlParameters() {
 
             if (class_exists('CURLFile')) {

--- a/Idno/Core/WebserviceFile.php
+++ b/Idno/Core/WebserviceFile.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Utility wrapper around files
+ *
+ * @package idno
+ * @subpackage core
+ */
+
+namespace Idno\Core {
+
+    class WebserviceFile {
+
+        private $file;
+        private $name;
+        private $mime;
+
+        function __construct($file, $mime, $name) {
+            $this->file = $file;
+            $this->mime = $mime;
+            $this->name = $name;
+        }
+
+        function getCurlParameters() {
+
+            if (class_exists('CURLFile')) {
+                return new \CURLFile($this->file, $this->mime, $this->name);
+            } else {
+                return "@{$this->file};filename={$this->name};type={$this->mime}";
+            }
+        }
+
+        /**
+         * Converts an "@" formatted file string into a WebserviceFile
+         * @param type $fileuploadstring
+         * @return WebserviceFile|false
+         */
+        static function createFromCurlString($fileuploadstring) {
+            if ($fileuploadstring[0] == '@') {
+                $bits = explode(';', $fileuploadstring);
+
+                $file = $name = $mime = null;
+
+                foreach ($bits as $bit) {
+                    // File
+                    if ($bit[0] == '@') {
+                        $file = trim($bit, '@ ;');
+                    }
+                    if (strpos($bit, 'filename') !== false) {
+                        $tmp = explode('=', $bit);
+                        $name = trim($tmp[1], ' ;');
+                    }
+                    if (strpos($bit, 'type') !== false) {
+                        $tmp = explode('=', $bit);
+                        $mime = trim($tmp[1], ' ;');
+                    }
+                }
+
+                if ($file) {
+
+                    if (file_exists($file)) {
+                        return new WebserviceFile($file, $mime, $name);
+                    }
+                }
+            }
+
+            return false;
+        }
+
+    }
+
+}

--- a/Tests/API/UploadTest.php
+++ b/Tests/API/UploadTest.php
@@ -16,7 +16,7 @@ namespace Tests\API {
             $result = \Idno\Core\Webservice::post(\Idno\Core\Idno::site()->config()->url . 'photo/edit', [
                 'title' => 'A Photo upload',
                 'body' => "Uploading a pretty picture via the api",
-                'photo' => "@".dirname(__FILE__)."/".self::$file.";filename=Photo.jpg;type=image/jpeg"
+                'photo' => \Idno\Core\WebserviceFile::createFromCurlString("@".dirname(__FILE__)."/".self::$file.";filename=Photo.jpg;type=image/jpeg")
             ], [
 				    'Accept: application/json',
                                     'X-KNOWN-USERNAME: ' . $user->handle,
@@ -26,7 +26,7 @@ namespace Tests\API {
             print_r($result);
             $content = json_decode($result['content']);
             $response = $result['response'];
-            
+          
             $this->assertTrue(empty($result['error']));
             $this->assertTrue(!empty($content));
             $this->assertTrue(!empty($content->location));


### PR DESCRIPTION
## Here's what I fixed or added:

As per @kylewm's suggestion, introducing a webservice file wrapper around the various curl file formats

## Here's why I did it:

Removing the previous shim broke the build for > PHP 5.4, and while I think binning 5.4 is the longterm goal (#1313) this is a good solution to this specific issue.

Closes: #1310
Closes: #1312