### PR TITLE
remove rel=syndication when rendering syndication links in the h-feed

### DIFF
--- a/templates/default/content/syndication/links.tpl.php
+++ b/templates/default/content/syndication/links.tpl.php
@@ -25,7 +25,12 @@
                         $human_icon = $this->draw('content/syndication/icon/generic');
                     }
 
-                    echo '<a href="' . $element['url'] . '" rel="syndication" class="u-syndication ' . $service . '">' . $human_icon . ' ' . $element['identifier'] . '</a> ';
+                    $rel_syndication = '';
+                    if (\Idno\Core\Idno::site()->currentPage()->isPermalink()) {
+                        $rel_syndication = ' rel="syndication"';
+                    }
+
+                    echo "<a href=\"{$element['url']}\"$rel_syndication class=\"u-syndication $service\">$human_icon {$element['identifier']}</a>";
                 }
             }
 


### PR DESCRIPTION
## Here's what I fixed or added:

remove rel=syndication when rendering syndication links in the h-feed

## Here's why I did it:

rel=syndication is page-scoped so they should only be used when we're on
the post's permalink