### PR TITLE
Journal content type plugin added

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -12,6 +12,7 @@ listings here do not imply endorsement by the Known project team in any way.
 * [Recipe](https://github.com/cleverdevil/Known–Recipes) – Post recipes to your Known site, by [Jonathan LaCour][]
 * [Review](https://github.com/cleverdevil/Known–Reviews) – Post reviews to your Known site, by [Jonathan LaCour][]
 * [Reactions](https://github.com/kylewm/KnownReactions) – Indieweb–style likes and reposts, by [Kyle Mahan][] 
+* [Journal] (https://github.com/tinokremer/KnownJournal) - Post journal entries to your Known site, by [Tino Kremer][]
 
 ### Syndication plugins
 

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -90,6 +90,7 @@ listings here do not imply endorsement by the Known project team in any way.
 [Tim Owens]: http://timowens.io/
 [Tyler Gillies]: http://tylergillies.club/
 [Yann Sallou]: http://winds.fr/
+[Tino Kremer]: https://tinokremer.nl/
 
 ## Submissions
 


### PR DESCRIPTION
## Here's what I fixed or added:
New content type for Known
## Here's why I did it:
Journal content type for Known, post journal entries to your Known site