### PR TITLE
log the file:line based on the first stack frame before Logging

### DIFF
--- a/Idno/Core/Logging.php
+++ b/Idno/Core/Logging.php
@@ -94,12 +94,12 @@
                     // Trace for debug (when filtering is set to debug, always add a trace)
                     $trace = "";
                     if ($this->loglevel_filter == LOGLEVEL_DEBUG) {
-                        $backtrace = @debug_backtrace(false, 2);
-                        if ($backtrace) {
-                            // Never show this
-                            $backtrace = $backtrace[0];
-
-                            $trace = " [{$backtrace['file']}:{$backtrace['line']}]";
+                        $backtrace = @debug_backtrace(false, 3);
+                        foreach (array_reverse($backtrace) as $frame) {
+                            if ($frame['class'] !== 'Idno\Core\Logging') {
+                                $trace = " [{$frame['file']}:{$frame['line']}]";
+                                break;
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Here's what I fixed or added:
 
Check the top 3 frames, and take the first one that is not from class
Idno\Core\Logging.

## Here's why I did it:

The addition of warn(), info(), debug(), methods mean that we cannot
count on the 2nd frame always being meaningful.