### PR TITLE
DataConcierge: use strict comparisons (===) when checking keys

### DIFF
--- a/Idno/Data/AbstractSQL.php
+++ b/Idno/Data/AbstractSQL.php
@@ -145,7 +145,7 @@
                         $subtypes = array($subtypes);
                     }
                     foreach ($subtypes as $key => $subtype) {
-                        if (substr($subtype, 0, 1) == '!') {
+                        if (substr($subtype, 0, 1) === '!') {
                             unset($subtypes[$key]);
                             $not[] = substr($subtype, 1);
                         }
@@ -222,7 +222,7 @@
                         $subtypes = array($subtypes);
                     }
                     foreach ($subtypes as $key => $subtype) {
-                        if (substr($subtype, 0, 1) == '!') {
+                        if (substr($subtype, 0, 1) === '!') {
                             unset($subtypes[$key]);
                             $not[] = substr($subtype, 1);
                         }

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -56,7 +56,7 @@
             {
                 if ($versions = $this->getVersions()) {
                     foreach ($versions as $version) {
-                        if ($version->label == 'schema') {
+                        if ($version->label === 'schema') {
                             $basedate          = $newdate = (int)$version->value;
                             $upgrade_sql_files = array();
                             $schema_dir        = dirname(dirname(dirname(__FILE__))) . '/schemas/mysql/';
@@ -442,7 +442,7 @@
                         if (!is_array($value)) {
                             if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner', 'created'))) {
                                 $subwhere[] = "(`{$collection}`.`{$key}` = :nonmdvalue{$non_md_variables})";
-                                if ($key == 'created') {
+                                if ($key === 'created') {
                                     if (!is_int($value)) {
                                         $value = strtotime($value);
                                     }
@@ -527,10 +527,10 @@
                                 }
                                 $subwhere[] = $instring;
                             }
-                            if ($key == '$or') {
+                            if ($key === '$or') {
                                 $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
                             }
-                            if ($key == '$search') {
+                            if ($key === '$search') {
                                 if (!empty($value[0])) {
                                     $val = $value[0]; // The search query is always in $value position [0] for now
                                     if (strlen($val) > 5 && !Idno::site()->config()->bypass_fulltext_search) {

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -62,7 +62,7 @@
             {
                 if ($versions = $this->getVersions()) {
                     foreach ($versions as $version) {
-                        if ($version->label == 'schema') {
+                        if ($version->label === 'schema') {
                             $basedate          = $newdate = (int)$version->value;
                             $upgrade_sql_files = array();
                             $schema_dir        = dirname(dirname(dirname(__FILE__))) . '/schemas/mysql/';
@@ -350,7 +350,7 @@
                         if (!is_array($value)) {
                             if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner', 'created'))) {
                                 $subwhere[] = "({$collection}.{$key} = :nonmdvalue{$non_md_variables})";
-                                if ($key == 'created') {
+                                if ($key === 'created') {
                                     if (!is_int($value)) {
                                         $value = strtotime($value);
                                     }
@@ -436,10 +436,10 @@
                                 }
                                 $subwhere[] = $instring;
                             }
-                            if ($key == '$or') {
+                            if ($key === '$or') {
                                 $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
                             }
-                            if ($key == '$search' && !empty($value)) {
+                            if ($key === '$search' && !empty($value)) {
                                 $val = $value[0]; // The search query is always in $value position [0] for now
 //                                if (strlen($val) > 5) {
 //                                    $subwhere[]                                  = "match (search) against (:nonmdvalue{$non_md_variables})";

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -67,7 +67,7 @@
             {
                 if ($versions = $this->getVersions()) {
                     foreach ($versions as $version) {
-                        if ($version->label == 'schema') {
+                        if ($version->label === 'schema') {
                             $basedate          = $newdate = (int)$version->value;
                             $upgrade_sql_files = array();
                             $schema_dir        = dirname(dirname(dirname(__FILE__))) . '/schemas/sqllite3/';
@@ -378,7 +378,7 @@
                         if (!is_array($value)) {
                             if (in_array($key, array('uuid', '_id', 'entity_subtype', 'owner', 'created'))) {
                                 $subwhere[] = "(`{$collection}`.`{$key}` = :nonmdvalue{$non_md_variables})";
-                                if ($key == 'created') {
+                                if ($key === 'created') {
                                     if (!is_int($value)) {
                                         $value = strtotime($value);
                                     }
@@ -464,10 +464,10 @@
                                 }
                                 $subwhere[] = $instring;
                             }
-                            if ($key == '$or') {
+                            if ($key === '$or') {
                                 $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
                             }
-                            if ($key == '$search' && !empty($value)) {
+                            if ($key === '$search' && !empty($value)) {
                                 $val = $value[0]; // The search query is always in $value position [0] for now
 //                                if (strlen($val) > 5) {
 //                                    $subwhere[]                                  = " srch.search match :nonmdvalue{$non_md_variables} ";


### PR DESCRIPTION
## Here's what I fixed or added:

use strict comparisons (===) when checking keys in `build_query_from_array`

## Here's why I did it:

I ran into a case where the input for build_query had numeric keys,
and `$key == '$or'` is TRUE when $key = 0. Better in these cases to use
strict equality.