### PR TITLE
tweak form-group in templates

### DIFF
--- a/IdnoPlugins/Comments/templates/default/comments/public/form.tpl.php
+++ b/IdnoPlugins/Comments/templates/default/comments/public/form.tpl.php
@@ -11,12 +11,19 @@
                 </div>
             </div>
             <div class="col-md-10 idno-comment-container" id="comment-form">
-                <input type="text" name="name" class="form-control" placeholder="Your name" required>
-                <input type="text" name="url" class="form-control" placeholder="Your website address">
-                <input type="text" name="url-2" class="form-control" placeholder="You probably shouldn't fill this in" style="display: none;" >
+                <div class="form-group">
+                    <input type="text" name="name" class="form-control" placeholder="Your name" required>
+                </div>
+                <div class="form-group">
+                    <input type="text" name="url" class="form-control" placeholder="Your website address">
+                </div>
+                <div class="form-group">
+                    <input type="text" name="url-2" class="form-control" placeholder="You probably shouldn't fill this in" style="display: none;" >
+                </div>
                 <div id="extrafield" style="display:none"></div>
-                <textarea name="body" placeholder="Add a comment ..." class="form-control mentionable"></textarea>
-
+                <div class="form-group">
+                    <textarea name="body" placeholder="Add a comment ..." class="form-control mentionable"></textarea>
+                </div>
                 <p style="text-align: right" id="comment-submit">
                     <?= \Idno\Core\Idno::site()->actions()->signForm('annotation/post') ?>
                 </p>

--- a/templates/default/account/login.tpl.php
+++ b/templates/default/account/login.tpl.php
@@ -6,46 +6,37 @@
         <h3 class="text-center">
             Sign in
         </h3>
-        
+
         <div class="col-md-10 col-md-offset-1">
 
-        <form action="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() ?>session/login" method="post">
-            <div class="control-group">
-                <div class="controls">
-                    <input type="text" id="inputEmail" name="email" placeholder="Your email address or username"
-                           class="form-control">
+            <form action="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() ?>session/login" method="post">
+                <div class="form-group">
+                    <input type="text" id="inputEmail" name="email" placeholder="Your email address or username" class="form-control">
                 </div>
-            </div>
-            <div class="control-group">
-                <div class="controls">
+                <div class="form-group">
                     <input type="password" id="inputPassword" name="password" placeholder="Password" class="form-control">
                 </div>
-            </div>
-            <div class="control-group">
-                <div class="controls">
+                <div class="form-group">
                     <button type="submit" class="btn btn-signin">Sign in</button>
                     <input type="hidden" name="fwd" value="<?php
-                        if (!empty($vars['fwd'])) {
-                            echo htmlspecialchars($vars['fwd']);
-                        } else if (!empty($_SERVER['HTTP_REFERER'])) {
-                            echo htmlspecialchars($_SERVER['HTTP_REFERER']);
-                        } else {
-                            echo \Idno\Core\Idno::site()->config()->getDisplayURL();
-                        }?>" />
+                                                           if (!empty($vars['fwd'])) {
+                                                               echo htmlspecialchars($vars['fwd']);
+                                                           } else if (!empty($_SERVER['HTTP_REFERER'])) {
+                                                               echo htmlspecialchars($_SERVER['HTTP_REFERER']);
+                                                           } else {
+                                                               echo \Idno\Core\Idno::site()->config()->getDisplayURL();
+                                                           }?>" />
                 </div>
-            </div>
-            
-              <div class="control-group">
-                <div class="controls">
+
+                <div class="form-group">
                     <?php
-                        if (\Idno\Core\Idno::site()->config()->open_registration == true && \Idno\Core\Idno::site()->config()->canAddUsers()) {
+                    if (\Idno\Core\Idno::site()->config()->open_registration == true && \Idno\Core\Idno::site()->config()->canAddUsers()) {
                     ?>
-                    <a href="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>account/register">New here? Register for an account.</a><br><br>
+                        <a href="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>account/register">New here? Register for an account.</a><br><br>
                     <?php
                         }
                     ?>
                     <a href="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>account/password">Forgot your password?</a>
-                </div>
             </div>
             <?= \Idno\Core\Idno::site()->actions()->signForm('/session/login') ?>
         </form>


### PR DESCRIPTION
## Here's what I fixed or added:

Add form-group divs around elements in the Comments form.

Change control-group to form-group in Login form.

## Here's why I did it:


Bootstrap 3 changed control-group to form-group, this fixes the spacing
between form elements that had been fixed artificially before 1a59ac17a74a21bd3d3c1e903cd60cba391e907c