### PR TITLE
Unicode slug fix

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -627,7 +627,7 @@
                 $slug = preg_replace_callback("/([\p{L}]+)/u", function ($matches) {
                     return rawurlencode(($matches[1]));
                 }, $slug);
-                $slug = preg_replace("/([^A-Za-z0-9\p{L}\-\_ ])/u", '', $slug);
+                $slug = preg_replace("/([^A-Za-z0-9%\p{L}\-\_ ])/u", '', $slug);
                 $slug = preg_replace("/[ ]+/u", ' ', $slug);
                 $slug = implode('-', array_slice(explode(' ', $slug), 0, $max_pieces));
                 $slug = str_replace(' ', '-', $slug);

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -618,7 +618,7 @@
             {
                 $slug = trim($slug);
                 if (is_callable('mb_strtolower')) {
-                    $slug = mb_strtolower($slug);
+                    $slug = mb_strtolower($slug, 'UTF-8');
                 } else {
                     $slug = strtolower($slug);
                 }

--- a/Tests/Common/EntityTest.php
+++ b/Tests/Common/EntityTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Common;
+
+use Idno\Common\Entity;
+
+class EntityTest extends \Tests\KnownTestCase {
+
+    public function testPrepareSlug()
+    {
+        $entity = new Entity();
+        $this->assertEquals(
+            'test-a-simple-title',
+            $entity->prepareSlug('Test a Simple Title'));
+        $this->assertEquals(
+            'true-and-i-dont-really-like-how-there-are-never',
+            $entity->prepareSlug("True and I don't really like how there are never leftovers. But the recipes have been really creative, definitely different stuff (and more complicated) than I would think to cook on my own."));
+        $this->assertEquals(
+            'aus-base-wird-o2---dann-versuchen-wir-mal-den',
+            $entity->prepareSlug('Aus BASE wird O2 - Dann versuchen wir mal, den Kunden über den Tisch zu ziehen'));
+        $this->assertEquals(
+            'liked-a-post-by-ben-werdm%C3%BCller',
+            $entity->prepareSlug('liked a post by Ben Werdmüller'));
+    }
+
+}


### PR DESCRIPTION
## Here's what I fixed or added:

- new unit test for prepareSlug with some simple cases and some umlauts (both inside and outside of the slug length)
- allow % characters when creating the slug; prevents it from converting %C3%BC to C3BC
- specify 'UTF-8' encoding in mb_strtolower

## Here's why I did it:

On some versions of PHP, `mb_strtolower` without a specific converts ü to \343\247, which is some other encoding that breaks everything and erases the slug.

Fixes #1343 