### PR TITLE
urlencode the entire slug after dasherizing

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -624,13 +624,11 @@
                 }
                 $slug = strip_tags($slug);
                 $slug = preg_replace('|https?://[a-z\.0-9]+|', '', $slug);
-                $slug = preg_replace_callback("/([\p{L}]+)/u", function ($matches) {
-                    return rawurlencode(($matches[1]));
-                }, $slug);
                 $slug = preg_replace("/([^A-Za-z0-9%\p{L}\-\_ ])/u", '', $slug);
                 $slug = preg_replace("/[ ]+/u", ' ', $slug);
                 $slug = implode('-', array_slice(explode(' ', $slug), 0, $max_pieces));
-                $slug = str_replace(' ', '-', $slug);
+                $slug = rawurlencode($slug);
+
                 $slug = substr($slug, 0, $max_chars);
                 while (substr($slug, -1) == '-') {
                     $slug = substr($slug, 0, strlen($slug) - 1);

--- a/Tests/Common/EntityTest.php
+++ b/Tests/Common/EntityTest.php
@@ -21,6 +21,23 @@ class EntityTest extends \Tests\KnownTestCase {
         $this->assertEquals(
             'liked-a-post-by-ben-werdm%C3%BCller',
             $entity->prepareSlug('liked a post by Ben Werdmüller'));
+        $this->assertEquals(
+            'the-top-1%25-of-the-top-1%25',
+            $entity->prepareSlug('The Top 1% of the Top 1%'));
+        $this->assertEquals(
+            'voil%C3%A0-this-title-has-a-%25-sign-%D0%B4%D0%BE-%D1%81%D0%B2%D0%B8%D0%B4%D0%B0%D0%BD%D0%B8%D1%8F',
+            $entity->prepareSlug('Voilà, this title has a % sign, до свидания'));
+        // titles with many long words may need to be truncated mid-word
+        $this->assertEquals(
+            'thistitleisreallyreallylong-with',
+            $entity->prepareSlug('ThisTitleIsReallyReallyLong WithVeryFewWords', 10, 32));
+        // borrowed this one from @nekr0z
+        $this->assertEquals(
+            '%D0%B4%D0%B0-%D1%8F-%D0%B6-%D0%B4%D0%B0%D0%B2%D0%B5%D1%87%D0%B0-%D0%B2-%D1%81%D0%BF%D0%BE%D1%80%D1%82%D0%BC%D0%B0%D1%81%D1%82%D0%B5%D1%80%D0%B5-%D0%B1%D1%8B%D0%BB',
+            $entity->prepareSlug('Да, я ж давеча в Спортмастере был...'));
+        $this->assertEquals(
+            'make-sure-spaces-are-collapsed-and-tags-are-stripped',
+            $entity->prepareSlug('Make Sure    <b>Spaces</b> are  Collapsed and Tags  Are  <i>Stripped</i>'));
     }
 
 }


### PR DESCRIPTION
## Here's what I fixed or added:


- make sure %'s and other special characters (that aren't \p{L}) are also encoded
- add more cases to the unit test to make sure we're doing what's expected

## Here's why I did it:

This should support both #1343 and #1331.

Previously we tried stripping %'s altogether, which converted unicode characters like %C3%BC to C3BC (which is fine but ugly), and including all %'s which was problematic when there is an actual literal % in the title. 