### PR TITLE
Fixing assets take 3

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -73,6 +73,9 @@
                 });
 
                 \Idno\Core\Idno::site()->embedded();
+                
+                // Trigger an event when a page is initialised, and currentPage is available
+                \Idno\Core\Idno::site()->triggerEvent('page/ready');
             }
 
             /**

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -886,7 +886,7 @@
             function isAcceptedContentType($contentType)
             {
 
-                if ($headers = $this->getallheaders()) {
+                if ($headers = self::getallheaders()) {
                     if (!empty($headers['Accept'])) {
                         if (substr_count($headers['Accept'], $contentType)) return true;
                     }
@@ -900,7 +900,7 @@
              * getallheaders function
              * @return array
              */
-            function getallheaders()
+            static function getallheaders()
             {
                 if (function_exists('getallheaders')) {
                     return getallheaders();
@@ -1005,7 +1005,7 @@
              */
             public function lastModifiedGatekeeper($timestamp)
             {
-                $headers = $this->getallheaders();
+                $headers = self::getallheaders();
                 if (isset($headers['If-Modified-Since'])) {
                     if (strtotime($headers['If-Modified-Since']) <= $timestamp) {
                         //header('HTTP/1.1 304 Not Modified');

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -19,7 +19,7 @@
 
         use Idno\Entities\User;
 
-        class Page extends \Idno\Common\Component
+        abstract class Page extends \Idno\Common\Component
         {
 
             // Property that defines whether this page may forward to

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -576,7 +576,7 @@
                     return $this->currentPage;
                 }
 
-                return new Page();
+                return false;
             }
 
             /**

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -401,7 +401,7 @@
 
                     $this->setIsAPIRequest(true);
 
-                    $t = \Idno\Core\Idno::site()->currentPage()->getInput('_t');
+                    $t = \Idno\Common\Page::getInput('_t');
                     if (empty($t)) {
                         \Idno\Core\Idno::site()->template()->setTemplateType('json');
                     }

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -401,7 +401,7 @@
 
                     $this->setIsAPIRequest(true);
 
-                    $t = \Idno\Common\Page::getInput('_t');
+                    $t = \Idno\Core\Input::getInput('_t');
                     if (empty($t)) {
                         \Idno\Core\Idno::site()->template()->setTemplateType('json');
                     }

--- a/IdnoPlugins/IndiePub/Main.php
+++ b/IdnoPlugins/IndiePub/Main.php
@@ -41,7 +41,7 @@
             private static function authenticate()
             {
                 $access_token = \Idno\Core\Input::getInput('access_token');
-                $headers = \Idno\Core\Idno::site()->currentPage()->getallheaders();
+                $headers = \Idno\Common\Page::getallheaders();
                 if (!empty($headers['Authorization'])) {
                     $token = $headers['Authorization'];
                     $token = trim(str_replace('Bearer', '', $token));

--- a/IdnoPlugins/IndiePub/Main.php
+++ b/IdnoPlugins/IndiePub/Main.php
@@ -40,12 +40,12 @@
              */
             private static function authenticate()
             {
-                $access_token = \Idno\Core\Idno::site()->currentPage()->getInput('access_token');
+                $access_token = \Idno\Core\Input::getInput('access_token');
                 $headers = \Idno\Core\Idno::site()->currentPage()->getallheaders();
                 if (!empty($headers['Authorization'])) {
                     $token = $headers['Authorization'];
                     $token = trim(str_replace('Bearer', '', $token));
-                } else if ($token = \Idno\Core\Idno::site()->currentPage()->getInput('access_token')) {
+                } else if ($token = \Idno\Core\Input::getInput('access_token')) {
                     $token = trim($token);
                 }
 

--- a/IdnoPlugins/IndiePub/Pages/IndieAuth/Auth.php
+++ b/IdnoPlugins/IndiePub/Pages/IndieAuth/Auth.php
@@ -17,7 +17,7 @@
                     exit;
                 }
 
-                $headers      = $this->getallheaders();
+                $headers      = self::getallheaders();
                 $me           = $this->getInput('me');
                 $client_id    = $this->getInput('client_id');
                 $redirect_uri = $this->getInput('redirect_uri');

--- a/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
+++ b/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
@@ -15,7 +15,7 @@
                 if (!empty($headers['Authorization'])) {
                     $token = $headers['Authorization'];
                     $token = trim(str_replace('Bearer', '', $token));
-                    $found = findUserForToken($token);
+                    $found = self::findUserForToken($token);
 
                     if (!empty($found)) {
                         $this->setResponse(200);

--- a/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
+++ b/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
@@ -11,7 +11,7 @@
             // GET requests verify a token
             function get($params = array())
             {
-                $headers = $this->getallheaders();
+                $headers = self::getallheaders();
                 if (!empty($headers['Authorization'])) {
                     $token = $headers['Authorization'];
                     $token = trim(str_replace('Bearer', '', $token));


### PR DESCRIPTION
## Here's what I fixed or added:

* Page() is now abstract
* currentPage() no longer returns a Mayfly object
* Introduces a page/ready event call once the system is booted and page object is ready.

## Here's why I did it:

Assets were being set, but silently clobbered when the "real" page is booted. This relates to a number of issues we've encountered before, e.g. #235 

Closes #1303 