### PR TITLE
IndiePub needs to call static function as static

### DIFF
--- a/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
+++ b/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
@@ -15,7 +15,7 @@
                 if (!empty($headers['Authorization'])) {
                     $token = $headers['Authorization'];
                     $token = trim(str_replace('Bearer', '', $token));
-                    $found = findUserForToken($token);
+                    $found = self::findUserForToken($token);
 
                     if (!empty($found)) {
                         $this->setResponse(200);


### PR DESCRIPTION
## Here's what I fixed or added:

Call to findUserForToken() should be static, otherwise it's undefined.

## Here's why I did it:

It should be static.

Possibly related to #1352 
