### PR TITLE
remove DreamHost from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@
 A fully-managed hosted service is provided at <https://withknown.com/>. It is always kept up to date with the latest
 version of Known.
 
-Exclusive web hosting sponsor:
-
-[![DreamHost](https://withknown.com/img/sponsor_dh_small.jpg)](http://dreamhost.com/redir.cgi?promo=known595&url=promo/hosting595/&utm_source=known&utm_medium=banner&utm_content=sponsorshared595&utm_campaign=shared)
-
-We've tested DreamHost's hosting platform and highly recommend it for supporting your Known site.
-
 ###Installing
 
 Known is under active development and requires PHP 5.4+ with selected extensions, together with a supported database backend.


### PR DESCRIPTION
## Here's what I fixed or added:
remove DreamHost from README

## Here's why I did it:

Following 62e9e853c418b55b6cfc400e3527010e9325d87e Dreamhost is no longer a sponsor