### PR TITLE
Share: strip all extra text from share_url property

### DIFF
--- a/Idno/Pages/Entity/Share.php
+++ b/Idno/Pages/Entity/Share.php
@@ -20,6 +20,11 @@
                 $title = $this->getInput('share_title', $this->getInput('title'));
                 $type  = $this->getInput('share_type');
 
+                // remove cruft added by mobile apps
+                if (preg_match('~\b(?:f|ht)tps?://[^\s]+\b~i', $url, $matches)) {
+                    $url = $matches[0];
+                }
+
                 $event = new \Idno\Core\Event();
                 $event->setResponse($url);
                 \Idno\Core\Idno::site()->events()->dispatch('url/shorten', $event);


### PR DESCRIPTION
## Here's what I fixed or added:

on the /share page, strip all extra non-URL text from the share_url property

## Here's why I did it:

Support for mobile apps that add extra stuff (title, tagline, via, app name) to the url.

Fixes #1361