### PR TITLE
change key $accounts to 'accounts' to fix invalid index error

### DIFF
--- a/Idno/Core/Syndication.php
+++ b/Idno/Core/Syndication.php
@@ -106,7 +106,7 @@
                     $accounts = $this->accounts;
                 }
 
-                $accounts = Idno::site()->triggerEvent('syndication/accounts/get', [$accounts => $accounts], $accounts);
+                $accounts = Idno::site()->triggerEvent('syndication/accounts/get', ['accounts' => $accounts], $accounts);
 
                 return $accounts;
             }


### PR DESCRIPTION
I think this was just a typo in 7457fe846ad1caf993f44ffd5a01b5e01a81cbdc

fixes #1362