### PR TITLE
Closes #1365: Don't remove client cookie when called on API

### DIFF
--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -330,12 +330,14 @@
                 // Really log the user off by destroying the cookie
                 // See https://secure.php.net/manual/en/function.session-destroy.php
                 if (!defined('KNOWN_UNIT_TEST')) {
-                    if (ini_get("session.use_cookies")) {
-                        $params = session_get_cookie_params();
-                        setcookie(session_name(), '', time() - 42000,
-                            $params["path"], $params["domain"],
-                            $params["secure"], $params["httponly"]
-                        );
+                    if (!$this->isAPIRequest()) { // #1365 - we need to destroy the session, but resetting cookie causes problems with the api
+                        if (ini_get("session.use_cookies")) {
+                            $params = session_get_cookie_params();
+                            setcookie(session_name(), '', time() - 42000,
+                                $params["path"], $params["domain"],
+                                $params["secure"], $params["httponly"]
+                            );
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Here's what I fixed or added:

Prevent cookie set on logout for API requests

## Here's why I did it:

This caused issues of headers already being sent when logout called on shutdown hook in api (to avoid XSS issues elsewhere). 

Session is still destroyed, but client cookie reset, while still recommended, is optional, and not really necessary on the API since we no longer require cookies to handle forwarding to newly created objects.

