### PR TITLE
ignore webmentions where the source is a feed

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1612,7 +1612,7 @@
              *
              * @param string $source The source URL
              * @param string $target The target URL (i.e., the page on this site that was pinged)
-             * @param string $source_content The source page's HTML
+             * @param array $source_content The Webservice response from fetching the source page
              * @param array $source_mf2 Parsed Microformats 2 content from $source
              * @return bool Success
              */
@@ -1643,56 +1643,48 @@
                     }
 
                     // And then let's cycle through them!
+                    $hentrys = [];
+                    $hcards  = [];
 
-                    // A first pass for overall owner ...
                     foreach ($source_mf2['items'] as $item) {
-
-                        // Figure out what kind of Microformats 2 item we have
-                        if (!empty($item['type']) && is_array($item['type'])) {
-                            foreach ($item['type'] as $type) {
-
-                                switch ($type) {
-                                    case 'h-card':
-                                        if (!empty($item['properties'])) {
-                                            if (!empty($item['properties']['name'])) $mentions['owner']['name'] = $item['properties']['name'][0];
-                                            if (!empty($item['properties']['url'])) $mentions['owner']['url'] = $item['properties']['url'][0];
-                                            if (!empty($item['properties']['photo'])) {
-                                                //$mentions['owner']['photo'] = $item['properties']['photo'][0];
-
-                                                $tmpfname = tempnam(sys_get_temp_dir(), 'webmention_avatar');
-                                                file_put_contents($tmpfname, \Idno\Core\Webservice::file_get_contents($item['properties']['photo'][0]));
-
-                                                $name = md5($item['properties']['url'][0]);
-
-                                                // TODO: Don't update the cache image for every webmention
-
-                                                if ($icon = \Idno\Entities\File::createThumbnailFromFile($tmpfname, $name, 300)) {
-                                                    $mentions['owner']['photo'] = \Idno\Core\Idno::site()->config()->url . 'file/' . (string)$icon;
-                                                } else if ($icon = \Idno\Entities\File::createFromFile($tmpfname, $name)) {
-                                                    $mentions['owner']['photo'] = \Idno\Core\Idno::site()->config()->url . 'file/' . (string)$icon;
-                                                }
-
-                                                unlink($tmpfname);
-                                            }
-                                        }
-                                        break;
-                                }
-                                if (!empty($mentions['owner'])) {
-                                    break;
-                                }
-
+                        if (isset($item['type'])) {
+                            if (in_array('h-card', $item['type'])) {
+                                $hcards[] = $item;
+                            } else if (in_array('h-entry', $item['type'])) {
+                                $hentrys[] = $item;
                             }
                         }
-
                     }
 
-                    // And now a second pass for per-item owners and mentions ...
-                    foreach ($source_mf2['items'] as $item) {
-                        $mentions = $this->addWebmentionItem($item, $mentions, $source, $target, $title);
-                        if (!empty($item['type']) && is_array($item['type'])) {
+                    // primary h-entry on the page
+                    $primary = false;
+
+                    // if there is only one h-entry on the page, then it's primary
+                    if (count($hentrys) == 1) {
+                        $primary = $hentrys[0];
+                    }
+                    // if there are more entries, then looks like a feed, so we'll ignore it
+                    // ... unless one of the entry's "url" values is the current page
+                    else if (count($hentrys) > 1) {
+                        foreach ($hentrys as $hentry) {
+                            if (!empty($hentry['properties']['url']) && in_array($source, $hentry['properties']['url'])) {
+                                $primary = $hentry;
+                                break;
+                            }
                         }
                     }
-                    if (!empty($mentions['mentions']) && !empty($mentions['owner']) && !empty($mentions['owner']['url'])) {
+
+                    // Convert the h-entry to one or more mentions
+                    if ($primary) {
+                        $mentions = $this->addWebmentionItem($primary, $mentions, $source, $target, $title);
+                    }
+
+                    // If the mention didn't have an author, fill in based on the first top-level h-card
+                    if (empty($mentions['owner']) && $hcards) {
+                        $mentions['owner'] = $this->parseHCard($hcards[0]);
+                    }
+
+                    if (!empty($mentions['mentions']) && !empty($mentions['owner'])) {
                         if (empty($mentions['owner']['photo'])) {
                             $mentions['owner']['photo'] = '';
                         }
@@ -1706,12 +1698,14 @@
                             $mentions['title'] = '';
                         }
                         $this->removeAnnotation($source);
+
                         foreach ($mentions['mentions'] as $mention) {
                             if (!empty($mention['url'])) {
                                 $permalink = $mention['url'][0]; //implode('', $mention['url']);
                             } else {
                                 $permalink = $source;
                             }
+
                             // Special exemption for bridgy
                             if ((strpos($source, 'https://brid-gy.appspot.com/') !== false) && in_array($mention['type'], array('like', 'share', 'rsvp'))) {
                                 $permalink = \Idno\Core\Idno::site()->template()->getURLWithVar('known_from', $source, implode('', $mention['url']));
@@ -1775,36 +1769,16 @@
              */
             function addWebmentionItem($item, $mentions, $source, $target, $title = '')
             {
-                if (!empty($item['properties']['author'])) {
+                // per-entry author
+                if (isset($item['properties']['author'])) {
                     foreach ($item['properties']['author'] as $author) {
-                        if (!empty($author['type'])) {
-                            foreach ($author['type'] as $type) {
-                                if ($type == 'h-card') {
-                                    if (!empty($author['properties']['name'])) $mentions['owner']['name'] = $author['properties']['name'][0];
-                                    if (!empty($author['properties']['url'])) $mentions['owner']['url'] = $author['properties']['url'][0];
-                                    if (!empty($author['properties']['photo'])) {
-                                        //$mentions['owner']['photo'] = $author['properties']['photo'][0];
-
-                                        $tmpfname = tempnam(sys_get_temp_dir(), 'webmention_avatar');
-                                        file_put_contents($tmpfname, \Idno\Core\Webservice::file_get_contents($author['properties']['photo'][0]));
-
-                                        $name = md5($author['properties']['url'][0]);
-
-                                        // TODO: Don't update the cache image for every webmention
-
-                                        if ($icon = \Idno\Entities\File::createThumbnailFromFile($tmpfname, $name, 300)) {
-                                            $mentions['owner']['photo'] = \Idno\Core\Idno::site()->config()->url . 'file/' . (string)$icon;
-                                        } else if ($icon = \Idno\Entities\File::createFromFile($tmpfname, $name)) {
-                                            $mentions['owner']['photo'] = \Idno\Core\Idno::site()->config()->url . 'file/' . (string)$icon;
-                                        }
-
-                                        unlink($tmpfname);
-                                    }
-                                }
-                            }
+                        if (isset($author['type']) && in_array('h-card', $author['type'])) {
+                            $mentions['owner'] = $this->parseHCard($author);
+                            break;
                         }
                     }
                 }
+
                 if (!empty($item['type'])) {
                     if (in_array('h-entry', $item['type'])) {
 
@@ -1887,15 +1861,38 @@
 
                     }
                 }
-                if (in_array('h-feed', $item['type'])) {
-                    if (!empty($item['children'])) {
-                        foreach ($item['children'] as $child) {
-                            $mentions = $this->addWebmentionItem($child, $mentions, $source, $target, $title);
-                        }
-                    }
-                }
 
                 return $mentions;
+            }
+
+            private function parseHCard($hcard)
+            {
+                $owner = [];
+                if (!empty($hcard['properties']['name'])) {
+                    $owner['name'] = $hcard['properties']['name'][0];
+                }
+                if (!empty($hcard['properties']['url'])) {
+                    $owner['url'] = $hcard['properties']['url'][0];
+                }
+                if (!empty($hcard['properties']['photo'])) {
+                    //$owner['photo'] = $hcard['properties']['photo'][0];
+
+                    $tmpfname = tempnam(sys_get_temp_dir(), 'webmention_avatar');
+                    file_put_contents($tmpfname, \Idno\Core\Webservice::file_get_contents($hcard['properties']['photo'][0]));
+
+                    $name = md5($hcard['properties']['url'][0]);
+
+                    // TODO: Don't update the cache image for every webmention
+
+                    if ($icon = \Idno\Entities\File::createThumbnailFromFile($tmpfname, $name, 300)) {
+                        $owner['photo'] = \Idno\Core\Idno::site()->config()->url . 'file/' . (string)$icon;
+                    } else if ($icon = \Idno\Entities\File::createFromFile($tmpfname, $name)) {
+                        $owner['photo'] = \Idno\Core\Idno::site()->config()->url . 'file/' . (string)$icon;
+                    }
+
+                    unlink($tmpfname);
+                }
+                return $owner;
             }
 
             /**

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1621,13 +1621,15 @@
                 if ($source_content['response'] == 410) {
                     $this->removeAnnotation($source);
                     $this->save();
-                } else if (!empty($source_mf2) && !empty($source_mf2['items']) && is_array($source_mf2['items'])) {
+                    return true;
+                }
+                $return = false;
+                if (!empty($source_mf2) && !empty($source_mf2['items']) && is_array($source_mf2['items'])) {
 
                     // At this point, we don't know who owns the page or what the content is.
                     // First, we'll initialize some variables that we're interested in filling.
 
                     $mentions = array('owner' => array(), 'mentions' => array()); // Content owner and usable webmention items
-                    $return   = true; // Return value;
 
                     // Get the page title from the source content
                     $title = $source;
@@ -1685,6 +1687,7 @@
                     }
 
                     if (!empty($mentions['mentions']) && !empty($mentions['owner'])) {
+                        $return = true;
                         if (empty($mentions['owner']['photo'])) {
                             $mentions['owner']['photo'] = '';
                         }
@@ -1716,23 +1719,18 @@
                         }
                         $this->save();
 
-                        if ($return) {
-                            if ($this->isReply()) {
-                                $webmentions = new Webmention();
-                                if ($reply_urls = $this->getReplyToURLs()) {
-                                    foreach ($reply_urls as $reply_url) {
-                                        $webmentions->sendWebmentionPayload($this->getDisplayURL(), $reply_url);
-                                    }
+                        if ($return && $this->isReply()) {
+                            $webmentions = new Webmention();
+                            if ($reply_urls = $this->getReplyToURLs()) {
+                                foreach ($reply_urls as $reply_url) {
+                                    $webmentions->sendWebmentionPayload($this->getDisplayURL(), $reply_url);
                                 }
                             }
                         }
                     }
-
-                    return $return;
                 }
 
-                return true; // There were no IndieWeb webmentions to add
-
+                return $return;
             }
 
             /**

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -168,7 +168,7 @@
                     }
                 }
 
-                if ($_SERVER['REQUEST_METHOD'] != 'GET') {
+                if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] != 'GET') {
                     $body = @file_get_contents('php://input');
                     $body = trim($body);
                     if (!empty($body)) {

--- a/Idno/Pages/Webmentions/Endpoint.php
+++ b/Idno/Pages/Webmentions/Endpoint.php
@@ -60,8 +60,8 @@
                                         $this->setResponse(202); // Webmention received a-ok.
                                         exit;
                                     } else {
-                                        $error      = 'target_not_supported';
-                                        $error_text = 'This is not webmentionable.';
+                                        $error      = 'source_not_supported';
+                                        $error_text = 'Could not interpret source as a comment.';
                                     }
                                 } else {
                                     $error      = 'no_link_found';

--- a/Tests/Common/EntityTest.php
+++ b/Tests/Common/EntityTest.php
@@ -3,8 +3,26 @@
 namespace Tests\Common;
 
 use Idno\Common\Entity;
+use Idno\Core\Idno;
+use Idno\Core\Webservice;
 
 class EntityTest extends \Tests\KnownTestCase {
+
+    public function setUp()
+    {
+        $this->user()->notifications['email'] = 'none';
+        $this->user()->save();
+    }
+
+
+    function tearDown()
+    {
+        if (isset($entity->toDelete)) {
+            foreach ($this->toDelete as $entity) {
+                $entity->delete();
+            }
+        }
+    }
 
     public function testPrepareSlug()
     {
@@ -39,5 +57,211 @@ class EntityTest extends \Tests\KnownTestCase {
             'make-sure-spaces-are-collapsed-and-tags-are-stripped',
             $entity->prepareSlug('Make Sure    <b>Spaces</b> are  Collapsed and Tags  Are  <i>Stripped</i>'));
     }
+
+    /**
+     * Send a simple reply and make sure it gets collected.
+     */
+    function testAddWebmentions_SimpleReply()
+    {
+        $entity = new Entity();
+        $entity->setOwner($this->user());
+        $entity->title = "This will be the target of our webmention";
+        $entity->publish();
+        $this->toDelete[] = $entity;
+
+        $target = $entity->getURL();
+        $source = 'http://example.com/2015/this-is-a-reply';
+        $sourceContent = <<<EOD
+<!DOCTYPE html>
+<html>
+<body class="h-entry">
+  <a class="u-in-reply-to" href="$target">in reply to</a>
+  <span class="p-name e-content">This is a reply</span>
+  <a class="u-url" href="http://example.com/2015/this-is-a-reply">permalink</a>
+  <a class="p-author h-card" href="https://example.com/">Jane Example</a>
+</body>
+</html>
+EOD;
+        $sourceResp = ['response' => 200, 'content' => $sourceContent];
+        $sourceMf2 = (new \Mf2\Parser($sourceContent, $source))->parse();
+        $entity->addWebmentions($source, $target, $sourceResp, $sourceMf2);
+
+        $this->assertArrayHasKey('reply', $entity->getAllAnnotations());
+        $this->assertCount(1, $entity->getAllAnnotations()['reply']);
+
+        $anno = array_values($entity->getAllAnnotations()['reply'])[0];
+
+        $this->assertArrayHasKey('owner_name', $anno);
+        $this->assertEquals('Jane Example', $anno['owner_name']);
+        $this->assertArrayHasKey('permalink', $anno);
+        $this->assertEquals($source, $anno['permalink']);
+    }
+
+    /**
+     * Test some other annotation types
+     */
+    function testAddWebmentions_OtherTypes()
+    {
+        $entity = new Entity();
+        $entity->setOwner($this->user());
+        $entity->title = "This will be the target of our webmention";
+        $entity->publish();
+        $this->toDelete[] = $entity;
+
+        $target = $entity->getURL();
+
+
+        $sources = [
+            'http://joe.example/this-is-a-like' => <<<EOD
+<!DOCTYPE html>
+<html>
+<body>
+<div class="h-entry">
+  <p class="p-name">
+    I liked this other post
+    <a class="u-like-of" href="$target">on example.com</a>
+  </p>
+</div>
+<a class="h-card" href="https://joe.example/">Joe Example</a>
+</body>
+</html>
+EOD
+            ,'http://gary.example/this-is-a-mention' => <<<EOD
+<!DOCTYPE html>
+<html>
+<body>
+<div class="h-entry">
+  <p class="p-name">
+    I just want to mention this post <a href="$target">on example.com</a>
+  </p>
+  <a class="p-author h-card" href="http://gary.example/">Gary Example</a>
+  <a class="u-url" href="http://gary.example/this-is-a-mention"></a>
+</div>
+</body>
+</html>
+EOD
+            ,'http://chelsea.example/chelsea-liked-a-post' => <<<EOD
+<!DOCTYPE html>
+<html>
+<body class="h-entry">
+  <p class="p-name">
+    <a class="p-author h-card" href="https://chelsea.example/">Chelsea Example</a> liked a post
+    <a class="u-like-of" href="$target">on example.com</a>
+  </p>
+</body>
+</html>
+EOD
+        ];
+
+        foreach ($sources as $source => $sourceContent) {
+            $sourceMf2 = (new \Mf2\Parser($sourceContent, $source))->parse();
+            $entity->addWebmentions($source, $target, ['response' => 200, 'content' => $sourceContent], $sourceMf2);
+        }
+
+        $this->assertArrayHasKey('like', $entity->getAllAnnotations());
+        $this->assertCount(2, $entity->getAllAnnotations()['like']);
+
+        $anno = array_values($entity->getAllAnnotations()['like'])[0];
+
+        $this->assertArrayHasKey('owner_name', $anno);
+        $this->assertEquals('Joe Example', $anno['owner_name']);
+        $this->assertArrayHasKey('permalink', $anno);
+        $this->assertEquals('http://joe.example/this-is-a-like', $anno['permalink']);
+
+        $anno = array_values($entity->getAllAnnotations()['like'])[1];
+
+        $this->assertArrayHasKey('owner_name', $anno);
+        $this->assertEquals('Chelsea Example', $anno['owner_name']);
+        $this->assertArrayHasKey('permalink', $anno);
+        $this->assertEquals('http://chelsea.example/chelsea-liked-a-post', $anno['permalink']);
+
+        $this->assertArrayHasKey('mention', $entity->getAllAnnotations());
+
+        $anno = array_values($entity->getAllAnnotations()['mention'])[0];
+
+        $this->assertArrayHasKey('owner_name', $anno);
+        $this->assertEquals('Gary Example', $anno['owner_name']);
+        $this->assertArrayHasKey('permalink', $anno);
+        $this->assertEquals('http://gary.example/this-is-a-mention', $anno['permalink']);
+
+    }
+
+
+    /**
+     * When we get a webmention where the source is a feed, make
+     * sure we handle it gracefully.
+     */
+    function testAddWebmentions_RemoteFeed()
+    {
+        $entity = new Entity();
+        $entity->setOwner($this->user());
+        $entity->title = "This post will be the webmention target";
+        $entity->publish();
+        $this->toDelete[] = $entity;
+
+        $target = $entity->getURL();
+        $source = 'http://example.com/';
+        $sourceContent = <<<EOD
+<!DOCTYPE html>
+<html>
+<body>
+  <div class="h-entry">
+    <a class="p-author h-card" href="https://example.com/">Jane Example</a>
+    <span class="p-name e-content">This is just nonsense</span>
+    <a class="u-url" href="http://example.com/2015/this-is-just-nonsense">permalink</a>
+  </div>
+  <div class="h-entry">
+    <a class="u-in-reply-to" href="$target">in reply to</a>
+    <a class="p-author h-card" href="https://example.com/">Jane Example</a>
+    <span class="p-name e-content">This is a reply</span>
+    <a class="u-url" href="http://example.com/2015/this-is-a-reply">permalink</a>
+  </div>
+  <div class="h-entry">
+    <a class="p-author h-card" href="https://example.com/">Jane Example</a>
+    <span class="p-name e-content">This is probably really serious</span>
+    <a class="u-url" href="http://example.com/2015/this-is-probably-really-serious">permalink</a>
+  </div>
+</body>
+</html>
+EOD;
+
+        $sourceResp = ['response' => 200, 'content' => $sourceContent];
+        $sourceMf2 = (new \Mf2\Parser($sourceContent, $source))->parse();
+        $entity->addWebmentions($source, $target, $sourceResp, $sourceMf2);
+
+        $this->assertEmpty($entity->getAllAnnotations());
+    }
+
+    /**
+     * A particularly knotty case when we get a webmention from *our
+     * own* feed. It looks valid because it includes a link, but it's
+     * not really.
+     */
+    function testAddWebmentions_LocalFeed()
+    {
+        for ($i = 0 ; $i < 5 ; $i++) {
+            $entity = new Entity();
+            $entity->setOwner($this->user());
+            $entity->title = "This post will be the webmention target";
+            $entity->publish();
+            $entities[] = $entity;
+            $this->toDelete[] = $entity;
+        }
+
+        // take one from the middle
+        $entity = $entities[2];
+
+        $source = \Idno\Core\Idno::site()->config()->url;
+        $target = $entity->getURL();
+
+        // render the homepage feed
+        $sourceResp = Webservice::get($source);
+        $sourceContent = $sourceResp['content'];
+        $sourceMf2 = (new \Mf2\Parser($sourceContent, $source))->parse();
+        $entity->addWebmentions($source, $target, $sourceResp, $sourceMf2);
+
+        $this->assertEmpty($entity->getAllAnnotations());
+    }
+
 
 }


### PR DESCRIPTION
## Here's what I fixed or added:

- add unit tests for `Entity::addWebmentions`
- examine incoming webmention source to see if it looks like a feed (has > 1 h-entry)
- discard webmentions from pages that look like feeds
- refactored Entity::addWebmentionItem to remove duplicate code for parsing h-cards

## Here's why I did it:

If you send a webmention to yourself wtih `source=http://yoursite.com/` and `target=http://yoursite.com/2016/a-permalink`, it currently sends yourself a reply from every post on the feed to that target, which looks crazy (see #1358 for screenshots)

fixes #1358