### PR TITLE
mf2 markup tweaks

### DIFF
--- a/Idno/Core/Logging.php
+++ b/Idno/Core/Logging.php
@@ -96,7 +96,7 @@
                     if ($this->loglevel_filter == LOGLEVEL_DEBUG) {
                         $backtrace = @debug_backtrace(false, 3);
                         foreach (array_reverse($backtrace) as $frame) {
-                            if ($frame['class'] !== 'Idno\Core\Logging' && isset($frame['file']) && isset($frame['line'])) {
+                            if (isset($frame['class']) && isset($frame['file']) && isset($frame['line']) && $frame['class'] !== 'Idno\Core\Logging') {
                                 $trace = " [{$frame['file']}:{$frame['line']}]";
                                 break;
                             }

--- a/css/default.css
+++ b/css/default.css
@@ -144,7 +144,6 @@ img {
 }
 
 .idno-entry .h-card .p-name {
-    word-break: break-all;
     word-wrap: break-word;
 }
 

--- a/templates/default/entity/FeedItem.tpl.php
+++ b/templates/default/entity/FeedItem.tpl.php
@@ -24,8 +24,6 @@
                 <a href="<?= $item->getAuthorURL() ?>" class="icon-container"><img
                         class="u-logo logo u-photo photo" src="<?= $item->getAuthorPhoto() ?>"/></a>
                 <a class="p-name fn u-url url" href="<?= $item->getAuthorURL() ?>"><?= $item->getAuthorName() ?></a>
-                <a class="u-url" href="<?= $item->getAuthorURL() ?>">
-                    <!-- This is here to force the hand of your MF2 parser --></a>
             </p>
         </div>
         <div class="e-content entry-content">

--- a/templates/default/entity/annotations/replies.tpl.php
+++ b/templates/default/entity/annotations/replies.tpl.php
@@ -13,15 +13,17 @@
             </div>
             <div class="idno-annotation-content col-md-9">
                 <div class="p-summary e-content"><?=$this->autop($this->parseURLs(strip_tags($annotation['content'])));?></div>
-                <div class="h-card">
-                    <p><small><a href="<?=htmlspecialchars($annotation['owner_url'])?>" class="p-author p-name"><?=htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a>,
-                            <a href="<?=$permalink?>"><?=date('M d Y', $annotation['time']);?></a>
-                            on <a href="<?=$permalink?>" class="u-url"><?=parse_url($permalink, PHP_URL_HOST)?></a></small> <img src="<?=$annotation['owner_image']?>" class="u-photo" style="display:none"/></p></small></p>
-                </div>
+                <p><small>
+                    <span class="p-author h-card">
+                        <a class="u-photo" href="<?=$annotation['owner_image']?>"></a>
+                        <a class="p-name u-url" href="<?=htmlspecialchars($annotation['owner_url'])?>"><?=htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a></span>,
+                    <a href="<?=$permalink?>"><?=date('M d Y', $annotation['time']);?></a>
+                    on <a href="<?=$permalink?>" class="u-url"><?=parse_url($permalink, PHP_URL_HOST)?></a>
+                </small></p>
             </div>
             <?php
                 $this->annotation_permalink = $locallink;
-                
+
                 if ($vars['object']->canEditAnnotation($annotation)) {
                     echo $this->draw('content/annotation/edit');
                 }

--- a/templates/default/entity/shell.tpl.php
+++ b/templates/default/entity/shell.tpl.php
@@ -8,9 +8,9 @@
             <div class="row idno-entry idno-entry-<?php
                 if (preg_match('@\\\\([\w]+)$@', get_class($object), $matches)) {
                     echo strtolower($matches[1]);
-                }?>">
+                }?> <?= $object->getMicroformats2ObjectType() ?> idno-<?= $object->getContentTypeCategorySlug() ?> idno-object">
 
-                <div class="col-md-1 col-md-offset-1 owner h-card visible-md visible-lg">
+                <div class="col-md-1 col-md-offset-1 owner p-author h-card visible-md visible-lg">
                     <p>
                         <a href="<?= $owner->getDisplayURL() ?>" class="u-url icon-container">
 	                        <img class="u-photo" src="<?= $owner->getIcon() ?>"/></a><br/>
@@ -19,7 +19,7 @@
                 </div>
 
                 <div
-                    class="col-md-8 <?= $object->getMicroformats2ObjectType() ?> idno-<?= $object->getContentTypeCategorySlug() ?> idno-object idno-content">
+                    class="col-md-8 idno-content">
                     <!--<div class="visible-xs">
                         <p class="p-author author h-card vcard">
                             <a href="<?= $owner->getDisplayURL() ?>" class="icon-container"><img


### PR DESCRIPTION
- move h-entry outside of the h-card in the default theme, so that the author is captured
- narrow h-card in comments so that it only includes the author, and not the permalink url
- remove break-all from css -- causes words to be broken in the middle unnecessarily (like "Kyle Ma\nhan")

fixes #1371 and #1372