### PR TITLE
skip duplicate notifications for the same source/target

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1969,15 +1969,17 @@
 
                                 if (!empty($notification_template) && !empty($context) && $send_notification) {
                                     $notif = new \Idno\Entities\Notification();
-                                    $notif->setOwner($recipient);
-                                    $notif->setMessage($subject);
-                                    $notif->setMessageTemplate($notification_template);
-                                    $notif->setActor($owner_url);
-                                    $notif->setVerb($context);
-                                    $notif->setObject($annotation);
-                                    $notif->setTarget($this);
-                                    $notif->save();
-                                    $recipient->notify($notif);
+                                    if ($notif->setNotificationKey([$context, $recipient->getUUID(), $annotation_url])) {
+                                        $notif->setOwner($recipient);
+                                        $notif->setMessage($subject);
+                                        $notif->setMessageTemplate($notification_template);
+                                        $notif->setActor($owner_url);
+                                        $notif->setVerb($context);
+                                        $notif->setObject($annotation);
+                                        $notif->setTarget($this);
+                                        $notif->save();
+                                        $recipient->notify($notif);
+                                    }
                                 }
                             }
 

--- a/Idno/Entities/Notification.php
+++ b/Idno/Entities/Notification.php
@@ -12,6 +12,25 @@
         {
 
             /**
+             * Set up a unique key for this notification so we can
+             * avoid sending repeat notifications for the same
+             * thing. e.g., for a webmention, [$source, $target].
+             *
+             * This affects the result of getURL()
+             *
+             * @param array $params
+             * @return true if the notification key represents a
+             * unique notification, false if we've seen this one
+             * before.
+             */
+            function setNotificationKey(array $params)
+            {
+                $this->notificationKey = md5(implode('|', $params));
+                $preexisting = self::getOne(['notificationKey' => $this->notificationKey]);
+                return $preexisting === false;
+            }
+
+            /**
              * The short text message to notify the user with. (eg, a
              * subject line.)
              * @param string $message
@@ -43,7 +62,8 @@
             }
 
             /**
-             * Is this an array {name:..., url:..., image:...}, a UUID, or either?
+             * @param string $actor URL (or UUID if local) of the
+             * person who initiated the action
              */
             function setActor($actor)
             {
@@ -134,6 +154,10 @@
 
                 if (!empty($this->canonical)) {
                     return $this->canonical;
+                }
+
+                if (!empty($this->notificationKey)) {
+                    return \Idno\Core\Idno::site()->config()->getDisplayURL() . 'notification/' . $this->notificationKey;
                 }
 
                 return \Idno\Core\Idno::site()->config()->url . 'view/' . $this->getID();

--- a/Idno/Pages/User/View.php
+++ b/Idno/Pages/User/View.php
@@ -154,15 +154,20 @@
                 $message .= ' on ' . parse_url($mention['permalink'], PHP_URL_HOST);
 
                 $notif = new Notification();
-                $notif->setOwner($user);
-                $notif->setMessage($message);
-                $notif->setMessageTemplate('content/notification/mention');
-                $notif->setActor($sender_url);
-                $notif->setVerb('mention');
-                $notif->setObject($mention);
-                $notif->setTarget($user);
-                $notif->save();
-                $user->notify($notif);
+                if ($notif->setNotificationKey(['mention', $user->getUUID(), $source, $target])) {
+                    $notif->setOwner($user);
+                    $notif->setMessage($message);
+                    $notif->setMessageTemplate('content/notification/mention');
+                    $notif->setActor($sender_url);
+                    $notif->setVerb('mention');
+                    $notif->setObject($mention);
+                    $notif->setTarget($user);
+                    $notif->save();
+                    $user->notify($notif);
+                } else {
+                    \Idno\Core\Idno::site()->logging()->debug("ignoring duplicate notification", ['source' => $source, 'target' => $target, 'user' => $user->getHandle()]);
+                }
+
                 return true;
             }
 

--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -172,8 +172,8 @@
                             $content_value = $content;
                         }
                         if (!empty($posse_link)) {
-                            $posse_service = parse_url($posse_link, PHP_URL_HOST);
-                            $entity->setPosseLink(str_replace('.com', '', $posse_service), $posse_link, '', '');
+                            $posse_service = preg_replace('/^(www\.|m\.)?(.+?)(\.com|\.org|\.net)?$/', '$2', parse_url($posse_link, PHP_URL_HOST));
+                            $entity->setPosseLink($posse_service, $posse_link, '', '');
                         }
                         $hashtags = (empty($hashtags) ? "" : "<p>".$hashtags."</p>");
                         $htmlPhoto    = (empty($htmlPhoto) ? "" : "<p>".$htmlPhoto."</p>");

--- a/Tests/Pages/HomepageTest.php
+++ b/Tests/Pages/HomepageTest.php
@@ -20,16 +20,14 @@
 
             }
 
-            private function doWebmentionContent($target)
+            private function doWebmentionContent($source, $target)
             {
                 $notification = false;
                 Idno::site()->addEventHook('notify', function (Event $event) use (&$notification) {
                     $eventdata    = $event->data();
                     $notification = $eventdata['notification'];
-
                 });
 
-                $source = 'http://foo.bar/mention';
                 $sourceContent = <<<EOD
 <div class="h-entry">
   <a class="p-author h-card" href="http://foo.bar">Foo Bar</a>
@@ -54,8 +52,10 @@ EOD;
             {
                 Idno::site()->config->single_user = true;
                 $this->admin(); // make sure there is an admin user
+                // uniquify source to make sure we get the notification
+                $source = 'http://foo.bar/homepage-mention-single-user-'.md5(time() . rand(0,9999));
                 $target = Idno::site()->config()->getDisplayURL();
-                $notification = $this->doWebmentionContent($target);
+                $notification = $this->doWebmentionContent($source, $target);
                 $this->assertTrue($notification !== false);
                 $this->assertEquals('http://foo.bar', $notification['actor']);
                 $this->assertEquals('You were mentioned by Foo Bar on foo.bar', $notification['message']);
@@ -72,8 +72,9 @@ EOD;
             {
                 Idno::site()->config->single_user = true;
                 $this->admin(); // make sure there is an admin user
+                $source = 'http://foo.bar/homepage-mention-single-user-no-slash-'.md5(time() . rand(0,9999));
                 $target = rtrim(Idno::site()->config()->getDisplayURL(), '/');
-                $notification = $this->doWebmentionContent($target);
+                $notification = $this->doWebmentionContent($source, $target);
                 $this->assertTrue($notification !== false);
                 $this->assertEquals('http://foo.bar', $notification['actor']);
                 $this->assertEquals('You were mentioned by Foo Bar on foo.bar', $notification['message']);
@@ -88,8 +89,9 @@ EOD;
             function testWebmentionContentMultiUser()
             {
                 Idno::site()->config->single_user = false;
+                $source = 'http://foo.bar/homepage-mention-multi-user-'.md5(time() . rand(0,9999));
                 $target = Idno::site()->config()->getDisplayURL();
-                $notification = $this->doWebmentionContent($target);
+                $notification = $this->doWebmentionContent($source, $target);
                 $this->assertFalse($notification);
             }
 

--- a/Tests/Pages/User/ViewTest.php
+++ b/Tests/Pages/User/ViewTest.php
@@ -17,7 +17,7 @@
                     $notification = $eventdata['notification'];
                 });
 
-                $source = 'http://karenpage.com/looking-for-information';
+                $source = 'http://karenpage.com/looking-for-information-' . md5(time() . rand(0,9999));
                 $target = $user->getURL();
 
                 $sourceContent = <<<EOD
@@ -42,9 +42,10 @@ EOD;
                 $this->assertEquals('Karen Page', $notification['object']['owner_name']);
                 $this->assertEquals('http://karenpage.com/', $notification['object']['owner_url']);
 
-                return $notification;
-
-
+                // make sure second webmention for the same source does not create another notification
+                $notification = false;
+                $profile->webmentionContent($source, $target, $sourceResp, $sourceMf2);
+                $this->assertFalse($notification);
             }
 
         }


### PR DESCRIPTION
Since we don't store user mentions in the user object,
we need to make sure we're only sending one Notification per
source/target pair (rather than one per webmention)

This checks uniqueness using a "notification key" which is
analogous to the slug of a post, except that the notification
key contains long urls so we take the md5 hash of it.

I'm also sneaking in a change to indiepub that prevents it
from changing "www.instagram.com" to "www.instagram" 
that I forgot to make in a separate branch.

fixes #1381