### PR TITLE
use drawPage rather than draw('shell')

### DIFF
--- a/Idno/Pages/File/Picker.php
+++ b/Idno/Pages/File/Picker.php
@@ -19,7 +19,7 @@
                 $t->title   = 'Image picker';
                 $t->hidenav = true;
                 $t->body    = $t->draw($template);
-                echo $t->draw('shell');
+                $t->drawPage();
             }
 
             function post()


### PR DESCRIPTION
The 'shell' template expects 'messages' to be set, and drawPage sets it.

fixes #1370