### PR TITLE
Closes #1385: Handle "%" encoding in page URLS.

### DIFF
--- a/IdnoPlugins/StaticPages/Main.php
+++ b/IdnoPlugins/StaticPages/Main.php
@@ -26,7 +26,7 @@
                 \Idno\Core\Idno::site()->addPageHandler('/admin/staticpages/reorder/?', 'IdnoPlugins\StaticPages\Pages\Admin\ReorderCategory');
                 \Idno\Core\Idno::site()->addPageHandler('/admin/staticpages/reorder/page/?', 'IdnoPlugins\StaticPages\Pages\Admin\ReorderPage');
 
-                \Idno\Core\Idno::site()->addPageHandler('/pages/([A-Za-z0-9\-\_]+)/?', 'IdnoPlugins\StaticPages\Pages\View');
+                \Idno\Core\Idno::site()->addPageHandler('/pages/([A-Za-z0-9\-\_\%]+)/?', 'IdnoPlugins\StaticPages\Pages\View');
 
                 // This makes sure that the homepage is accessible even when it is overridden.
                 \Idno\Core\Idno::site()->addPageHandler('/content/default/?', 'Idno\Pages\Homepage');


### PR DESCRIPTION
## Here's what I fixed or added:

Added "%" encoded chars on StaticPages page router definition.

## Here's why I did it:

Pages with unicode characters were not being picked up by the page router, which meant there was no current page when the shell was rendered.