### PR TITLE
bugfix: 500 error on page not found

### DIFF
--- a/Tests/Pages/HomepageTest.php
+++ b/Tests/Pages/HomepageTest.php
@@ -4,6 +4,7 @@
 
         use Idno\Core\Idno;
         use Idno\Core\Event;
+        use Idno\Core\Webservice;
 
         class HomepageTest extends \Tests\KnownTestCase {
 
@@ -17,7 +18,12 @@
 
                 // Make sure it's actually Known we're talking to
                 $this->assertContains('X-Powered-By: https://withknown.com', $http_response_header);
+            }
 
+            function test404Page()
+            {
+                $result = Webservice::get(Idno::site()->config()->getURL() . 'this-resource-does-not-exist');
+                $this->assertEquals(404, $result['response']);
             }
 
             private function doWebmentionContent($target)

--- a/index.php
+++ b/index.php
@@ -45,11 +45,10 @@
     \Idno\Core\PageHandler::hook('404', function ($params = array()) {
         http_response_code(404);
         $t = \Idno\Core\Idno::site()->template();
-        
+
         // Take over page detection
         \Idno\Core\Idno::site()->template()->autodetectTemplateType();
-        
-        $t->__(array('body' => $t->draw('pages/404'), 'title' => 'Not found!'))->drawPage();
-        exit;
-    });
+
+        (new \Idno\Pages\Homepage())->noContent();
+     });
     \Idno\Core\PageHandler::serve($routes);


### PR DESCRIPTION
## Here's what I fixed or added:

Instead of rendering 404 directly, create a Homepage instance and call
noContent on it.

## Here's why I did it:

Recent changes to avoid creating a default Page meant that
currentPage() returned false for 404 routes, which resulted in
errors rendering the template.
