### PR TITLE
remove leading / when building checkin.js url

### DIFF
--- a/IdnoPlugins/Checkin/checkin.js
+++ b/IdnoPlugins/Checkin/checkin.js
@@ -24,7 +24,7 @@ $(function () {
 
     function queryLocation(latitude, longitude, cb) {
         $.ajax({
-            url: wwwroot() + '/checkin/callback',
+            url: wwwroot() + 'checkin/callback',
             type: 'post',
             data: { lat: latitude.toString(), long: longitude.toString() }
         }).done(function (data) {


### PR DESCRIPTION
## Here's what I fixed or added:

remove extra / from checkin.js url

## Here's why I did it:

based on https://github.com/idno/Known/issues/1375#issuecomment-200840476 the leading / seems to be causing an error. Since wwwroot() is based on getDisplayURL(), we are safe to assume it will end in a slash and can remove the leading one here

fixes #1375 
(again)