### PR TITLE
add a Queue interface and default (sync) implementation

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1677,10 +1677,9 @@
                         $this->save();
 
                         if ($return && $this->isReply()) {
-                            $webmentions = new Webmention();
                             if ($reply_urls = $this->getReplyToURLs()) {
                                 foreach ($reply_urls as $reply_url) {
-                                    $webmentions->sendWebmentionPayload($this->getDisplayURL(), $reply_url);
+                                    Webmention::sendWebmentionPayload($this->getDisplayURL(), $reply_url);
                                 }
                             }
                         }

--- a/Idno/Core/EventQueue.php
+++ b/Idno/Core/EventQueue.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Idno\Core;
+
+use Idno\Common\Entity;
+
+/**
+ * Generic interface for queueing events that don't necessarily need
+ * to be done synchronously, like sending or receiving webmentions.
+ */
+abstract class EventQueue extends \Idno\Common\Component
+{
+
+    /**
+     * Enqueue an event for processing.
+     * @param string $queueName the named queue to put this event on (currently unused)
+     * @param string $eventName the name of the event, e.g. "webmention/send"
+     * @param array $eventData the data sent to the event when it is triggered.
+     * @return string an ID that can be used to query the job status
+     */
+    abstract function enqueue($queueName, $eventName, array $eventData);
+
+    /**
+     * Check whether a previously enqueued job has completed.
+     * @param string $jobId the ID of the job returned from enqueue()
+     * @return boolean
+     */
+    abstract function isComplete($jobId);
+
+    /**
+     * Retrieve the result of a completed job by its ID.
+     * @param string $jobId the ID of the job returned from enqueue()
+     * @return mixed
+     */
+    abstract function getResult($jobId);
+
+    /**
+     * Convert a JSON object to a string, replacing any Entity with its UUID.
+     * @param array $args
+     * @return string
+     */
+    function serialize($args)
+    {
+        return json_encode($this->convertEntitiesToUUIDs($args), JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * Convert a string back to a JSON object, restoring Entities from their UUIDs.
+     * @param string $str
+     * @return array
+     */
+    function deserialize($str)
+    {
+        return $this->convertUUIDsToEntities(json_decode($str, true));
+    }
+
+    private function convertEntitiesToUUIDs($args)
+    {
+        $result = [];
+        foreach ($args as $key => $value) {
+            if ($value instanceof Entity) {
+                $value = [
+                    '_class' => $value->getClass(),
+                    'uuid'   => $value->getUUID(),
+                ];
+            } else if (is_array($value)) {
+                $value = $this->convertEntitiesToUUIDs($value);
+            }
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+
+    private function convertUUIDsToEntities($args)
+    {
+        $result = [];
+        foreach ($args as $key => $value) {
+            if (is_array($value)) {
+                if (isset($value['_class'])) {
+                    $class  = $value['_class'];
+                    $entity = $class::getByUUID($value['uuid']);
+                    $value  = $entity;
+                } else {
+                    $value = $this->deserialize($value);
+                }
+            }
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+
+
+}

--- a/Idno/Core/EventQueue.php
+++ b/Idno/Core/EventQueue.php
@@ -54,7 +54,7 @@ abstract class EventQueue extends \Idno\Common\Component
         return $this->convertUUIDsToEntities(json_decode($str, true));
     }
 
-    private function convertEntitiesToUUIDs($args)
+    function convertEntitiesToUUIDs($args)
     {
         $result = [];
         foreach ($args as $key => $value) {
@@ -71,7 +71,7 @@ abstract class EventQueue extends \Idno\Common\Component
         return $result;
     }
 
-    private function convertUUIDsToEntities($args)
+    function convertUUIDsToEntities($args)
     {
         $result = [];
         foreach ($args as $key => $value) {

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -24,6 +24,7 @@
             public $actions;
             public $plugins;
             public $dispatcher;
+            public $queue;
             public $pagehandlers;
             public $public_pages;
             public $syndication;
@@ -48,6 +49,7 @@
             {
                 self::$site       = $this;
                 $this->dispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+                $this->queue      = new SynchronousQueue();
                 $this->config     = new Config();
                 if ($this->config->isDefaultConfig()) {
                     header('Location: ./warmup/');
@@ -245,6 +247,15 @@
             function &events()
             {
                 return $this->dispatcher;
+            }
+
+            /**
+             * Access to the EventQueue for dispatching events
+             * asynchronously
+             */
+            function &queue()
+            {
+                return $this->queue;
             }
 
             /**
@@ -801,7 +812,7 @@
             {
                 return
                     (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
-                    || $_SERVER['SERVER_PORT'] == 443
+                    || (!empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443)
                     || (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https');
             }
 

--- a/Idno/Core/SynchronousQueue.php
+++ b/Idno/Core/SynchronousQueue.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Idno\Core;
+
+class SynchronousQueue extends EventQueue
+{
+
+    private $results = array();
+
+    function enqueue($queueName, $eventName, array $eventData)
+    {
+        $id     = md5(time() . rand(0,9999) . $eventName);
+        $result = Idno::site()->triggerEvent($eventName, $eventData);
+        $this->results[$id] = $result;
+        return $id;
+    }
+
+    function isComplete($id)
+    {
+        return isset($this->resuts[$id]);
+    }
+
+    function getResult($id)
+    {
+        return $this->results[$id];
+    }
+
+}

--- a/Idno/Core/Syndication.php
+++ b/Idno/Core/Syndication.php
@@ -31,12 +31,12 @@
                             if ($selected_services = \Idno\Core\Idno::site()->currentPage()->getInput('syndication')) {
                                 if (!empty($selected_services) && is_array($selected_services)) {
                                     foreach ($selected_services as $selected_service) {
-                                        $event->data()['syndication_account'] = false;
+                                        $eventdata['syndication_account'] = false;
                                         if (in_array($selected_service, $services)) {
-                                            site()->triggerEvent('post/' . $content_type . '/' . $selected_service, $eventdata);
+                                            site()->queue()->enqueue('default', 'post/' . $content_type . '/' . $selected_service, $eventdata);
                                         } else if ($implied_service = $this->getServiceByAccountString($selected_service)) {
                                             $eventdata['syndication_account'] = $this->getAccountFromAccountString($selected_service);
-                                            site()->triggerEvent('post/' . $content_type . '/' . $implied_service, $eventdata);
+                                            site()->queue()->enqueue('default', 'post/' . $content_type . '/' . $implied_service, $eventdata);
                                         }
                                     }
                                 }

--- a/Idno/Core/Webmention.php
+++ b/Idno/Core/Webmention.php
@@ -352,14 +352,24 @@
             {
 
                 // Add webmention headers to the top of the page
-                \Idno\Core\Idno::site()->addEventHook('page/head', function (Event $event) {
-
+                Idno::site()->addEventHook('page/head', function (Event $event) {
                     if (!empty(site()->config()->hub)) {
                         $eventdata = $event->data();
                         header('Link: <' . \Idno\Core\Idno::site()->config()->getURL() . 'webmention/>; rel="http://webmention.org/"', false);
                         header('Link: <' . \Idno\Core\Idno::site()->config()->getURL() . 'webmention/>; rel="webmention"', false);
                     }
+                });
 
+                Idno::site()->addEventHook('webmention/sendall', function (Event $event) {
+                    $data = $event->data();
+                    $result = self::pingMentions($data['source'], $data['text']);
+                    $event->setResponse($result);
+                });
+
+                Idno::site()->addEventHook('webmention/send', function (Event $event) {
+                    $data = $event->data();
+                    $result = self::sendWebmentionPayload($data['source'], $data['target']);
+                    $event->setResponse($result);
                 });
 
             }

--- a/IdnoPlugins/Status/Status.php
+++ b/IdnoPlugins/Status/Status.php
@@ -93,6 +93,7 @@
                     $this->body      = $body;
                     $this->inreplyto = $inreplyto;
                     $this->tags      = $tags;
+                    // TODO fetch syndicated reply targets asynchronously (or maybe on-demand, when syndicating?)
                     if (!empty($inreplyto)) {
                         if (is_array($inreplyto)) {
                             foreach ($inreplyto as $inreplytourl) {
@@ -106,7 +107,10 @@
                     if ($this->publish($new)) {
 
                         if ($this->getAccess() == 'PUBLIC') {
-                            \Idno\Core\Webmention::pingMentions($this->getURL(), \Idno\Core\Idno::site()->template()->parseURLs($this->getDescription()));
+                            \Idno\Core\Idno::site()->queue()->enqueue('default', 'webmention/sendall', [
+                                'source' => $this->getURL(),
+                                'text' => \Idno\Core\Idno::site()->template()->parseURLs($this->getDescription()),
+                            ]);
                         }
 
                         return true;


### PR DESCRIPTION
## Here's what I fixed or added:

Add a Queue interface and default (sync) implementation. Move some events (webmentions, PuSH ping, syndication) to the queue first.

## Here's why I did it:

- allow some events to send to a queue instead of triggering immediately
- EventQueue is super generic to hopefully allow experimentation, avoid
  specifying exactly how a queue dispatcher should work

This PR continues my thought process from #691, I don't necessarily need it merged so much as I wanted to continue the conversation... FWIW, I have a proof of concept plugin that uses Gearman running locally, but it might be a little while before I can release it.