### PR TITLE
bugfix: check that ContentType is not false before inspecting it

### DIFF
--- a/Idno/Core/PubSubHubbub.php
+++ b/Idno/Core/PubSubHubbub.php
@@ -250,7 +250,7 @@
                     $homepage_types   = \Idno\Core\Idno::site()->config()->getHomepageContentTypes();
                     $type_in_homepage = false;
                     if ($object instanceof Entity) {
-                        if (in_array($object->getContentType()->getEntityClass(), $homepage_types)) {
+                        if ($object->getContentType() && in_array($object->getContentType()->getEntityClass(), $homepage_types)) {
                             $type_in_homepage = true;
                         }
                     }


### PR DESCRIPTION
## Here's what I fixed or added:

Check that $entity->getContentType() returns something before trying to access it.

## Here's why I did it:

$entity->getContentType() returns false or StaticPage entities.

Fixes #1394 