### PR TITLE
fallback to flat author properties only if there is not top level hcard

### DIFF
--- a/Idno/Core/Webmention.php
+++ b/Idno/Core/Webmention.php
@@ -196,18 +196,6 @@
                             return $author;
                         }
                     }
-                    // look for an author name or url
-                    foreach ($item['properties']['author'] as $author) {
-                        if (is_string($author)) {
-                            if (filter_var($author, FILTER_VALIDATE_URL)) {
-                                return ['type'       => ['h-card'],
-                                        'properties' => ['url' => [$author]]];
-                            } else {
-                                return ['type'       => ['h-card'],
-                                        'properties' => ['name' => [$author]]];
-                            }
-                        }
-                    }
                 }
 
                 // fallback to top-level hcard if there is 1 and only 1
@@ -221,6 +209,21 @@
 
                 if (count($hcards) === 1) {
                     return $hcards[0];
+                }
+
+                if ($item && isset($item['properties']['author'])) {
+                    // look for an author name or url
+                    foreach ($item['properties']['author'] as $author) {
+                        if (is_string($author)) {
+                            if (filter_var($author, FILTER_VALIDATE_URL)) {
+                                return ['type'       => ['h-card'],
+                                        'properties' => ['url' => [$author]]];
+                            } else {
+                                return ['type'       => ['h-card'],
+                                        'properties' => ['name' => [$author]]];
+                            }
+                        }
+                    }
                 }
 
                 return false;


### PR DESCRIPTION
## Here's what I fixed or added:

When parsing webmentions, do not let flat/simple "author" properties prevent us from searching the rest of the page for the full author "h-card". Only fall back to the flat properties if we can't find an h-card at all.

## Here's why I did it:

quick fix for #1397 ... does not get us any closer to implementing /authorship as written, but should cover most of the real world use cases.