### PR TITLE
auto-linking: strip more trailing punctuation

### DIFF
--- a/Tests/Core/TemplateTest.php
+++ b/Tests/Core/TemplateTest.php
@@ -1,0 +1,35 @@
+<?php
+
+    namespace Tests\Core {
+
+        use Idno\Core\Template;
+
+        class TemplateTest extends \Tests\KnownTestCase {
+
+            function testParseURLs()
+            {
+                // adapted test cases from brevity (Known requires the http(s) prefix)
+                $testcases = [
+                    [
+                        "expected" => "This links to a weird domain <a href=\"http://deals.blackfriday\">http:/<wbr />/<wbr />deals.blackfriday</a>.",
+                        "text"     => "This links to a weird domain http://deals.blackfriday."
+                    ], [
+                        "expected" => "<a href=\"http://starts.with.a.link\">http:/<wbr />/<wbr />starts.with.a.link</a> and ends with <a href=\"https://kylewm.com/about#me\">HTML</a>.",
+                        "text"     => "http://starts.with.a.link and ends with <a href=\"https://kylewm.com/about#me\">HTML</a>."
+                    ], [
+                        "expected" => "a matched parenthesis: <a href=\"http://wikipedia.org/Python_(programming_language)\">http:/<wbr />/<wbr />wikipedia.org/<wbr />Python_(programming_language)</a> and (an unmatched parenthesis <a href=\"https://en.wikipedia.org/wiki/Guido_van_Rossum\">https:/<wbr />/<wbr />en.wikipedia.org/<wbr />wiki/<wbr />Guido_van_Rossum</a>)",
+                        "text"     => "a matched parenthesis: http://wikipedia.org/Python_(programming_language) and (an unmatched parenthesis https://en.wikipedia.org/wiki/Guido_van_Rossum)"
+                    ],
+                ];
+
+                $t = new Template();
+
+                foreach ($testcases as $testcase) {
+                    $this->assertEquals($testcase['expected'], $t->parseURLs($testcase['text']));
+                }
+
+            }
+
+        }
+
+    }


### PR DESCRIPTION
## Here's what I fixed or added:

- Add ; : and ? to the trailing punctuation marks that are stripped
- Conditionally allow a trailing ) only if there is a matching ( earlier in the URL

## Here's why I did it:

Better display of https://kylewm.com/2016/04/where-do-these-people-come-from-sumantmannei-don-t-think-his-making-a-statement-would-have-changed-anything-e9b31598e378joxoiqdn6-are-they-just