### PR TITLE
improve UI when replying to an original that is syndicated to Twitter

### DIFF
--- a/Tests/Core/WebmentionTest.php
+++ b/Tests/Core/WebmentionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+    namespace Tests\Core {
+
+        use Idno\Core\Webmention;
+
+        class WebmentionTest extends \Tests\KnownTestCase {
+
+            function testAddSyndicatedReplyTargets()
+            {
+                // test u-syndication
+                $doc = <<<EOD
+<div class="h-entry">
+  <span class="p-name e-content">This is a post</span>
+  <a class="u-url" href="http://foo.bar/post">permalink</a>
+  <a class="u-syndication" href="https://twitter.com/foobar/12345">on Twitter</a>
+  <a class="u-syndication" href="https://www.facebook.com/foobar/posts/12345">on Facebook</a>
+</div>
+EOD;
+
+                $result = Webmention::addSyndicatedReplyTargets('http://foo.bar/post', [], ['response' => 200, 'content' => $doc]);
+                $this->assertEquals(['https://twitter.com/foobar/12345', 'https://www.facebook.com/foobar/posts/12345'], $result);
+
+                // test rel-syndication
+                $doc = <<<EOD
+<head>
+  <link rel="syndication" href="https://twitter.com/foobar/12345" />
+  <link rel="syndication" href="https://www.facebook.com/foobar/posts/12345" />
+</head>
+<body>
+  <div class="h-entry">
+    <span class="p-name e-content">This is a post</span>
+    <a class="u-url" href="http://foo.bar/post">permalink</a>
+  </div>
+</body>
+EOD;
+
+                $result = Webmention::addSyndicatedReplyTargets('http://foo.bar/post', [], ['response' => 200, 'content' => $doc]);
+                $this->assertEquals(['https://twitter.com/foobar/12345', 'https://www.facebook.com/foobar/posts/12345'], $result);
+            }
+
+        }
+
+    }

--- a/external/mf2/.gitignore
+++ b/external/mf2/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/nbproject
+composer.phar
+/vendor/
+/tmp
+.idea/
+/bin/test

--- a/external/mf2/.travis.yml
+++ b/external/mf2/.travis.yml
@@ -1,0 +1,8 @@
+language: php
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - nightly
+before_script: composer install

--- a/external/mf2/LICENSE.md
+++ b/external/mf2/LICENSE.md
@@ -1,0 +1,36 @@
+# Creative Commons Legal Code
+
+## CC0 1.0 Universal
+
+http://creativecommons.org/publicdomain/zero/1.0
+
+Official translations of this legal tool are available> CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER.
+
+### _Statement of Purpose_
+
+The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related Rights (defined below) upon the creator and subsequent owner(s) (each and all, an "owner") of an original work of authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the purpose of contributing to a commons of creative, cultural and scientific works ("Commons") that the public can reliably and without fear of later claims of infringement build upon, modify, incorporate in other works, reuse and redistribute as freely as possible in any form whatsoever and for any purposes, including without limitation commercial purposes. These owners may contribute to the Commons to promote the ideal of a free culture and the further production of creative, cultural and scientific works, or to gain reputation or greater distribution for their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation of additional consideration or compensation, the person associating CC0 with a Work (the "Affirmer"), to the extent that he or she is an owner of Copyright and Related Rights in the Work, voluntarily elects to apply CC0 to the Work and publicly distribute the Work under its terms, with knowledge of his or her Copyright and Related Rights in the Work and the meaning and intended legal effect of CC0 on those rights.
+
+**1. Copyright and Related Rights.** A Work made available under CC0 may be protected by copyright and related or neighboring rights ("Copyright and Related Rights"). Copyright and Related Rights include, but are not limited to, the following:
+
+1.  the right to reproduce, adapt, distribute, perform, display, communicate, and translate a Work;
+2.  moral rights retained by the original author(s) and/or performer(s);
+3.  publicity and privacy rights pertaining to a person's image or likeness depicted in a Work;
+4.  rights protecting against unfair competition in regards to a Work, subject to the limitations in paragraph 4(a), below;
+5.  rights protecting the extraction, dissemination, use and reuse of data in a Work;
+6.  database rights (such as those arising under Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, and under any national implementation thereof, including any amended or successor version of such directive); and
+7.  other similar, equivalent or corresponding rights throughout the world based on applicable law or treaty, and any national implementations thereof.
+
+**2. Waiver.** To the greatest extent permitted by, but not in contravention of, applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and unconditionally waives, abandons, and surrenders all of Affirmer's Copyright and Related Rights and associated claims and causes of action, whether now known or unknown (including existing as well as future claims and causes of action), in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each member of the public at large and to the detriment of Affirmer's heirs and successors, fully intending that such Waiver shall not be subject to revocation, rescission, cancellation, termination, or any other legal or equitable action to disrupt the quiet enjoyment of the Work by the public as contemplated by Affirmer's express Statement of Purpose.
+
+**3. Public License Fallback.** Should any part of the Waiver for any reason be judged legally invalid or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent permitted taking into account Affirmer's express Statement of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby grants to each affected person a royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and unconditional license to exercise Affirmer's Copyright and Related Rights in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "License"). The License shall be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of the License for any reason be judged legally invalid or ineffective under applicable law, such partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and causes of action with respect to the Work, in either case contrary to Affirmer's express Statement of Purpose.
+
+**4. Limitations and Disclaimers.**
+
+1.  No trademark or patent rights held by Affirmer are waived, abandoned, surrendered, licensed or otherwise affected by this document.
+2.  Affirmer offers the Work as-is and makes no representations or warranties of any kind concerning the Work, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non infringement, or the absence of latent or other defects, accuracy, or the present or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
+3.  Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
+4.  Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.

--- a/external/mf2/Mf2/Parser.php
+++ b/external/mf2/Mf2/Parser.php
@@ -9,20 +9,21 @@ use DOMNode;
 use DOMNodeList;
 use Exception;
 use SplObjectStorage;
+use stdClass;
 
 /**
  * Parse Microformats2
- * 
+ *
  * Functional shortcut for the commonest cases of parsing microformats2 from HTML.
- * 
+ *
  * Example usage:
- * 
+ *
  *     use Mf2;
  *     $output = Mf2\parse('<span class="h-card">Barnaby Walters</span>');
  *     echo json_encode($output, JSON_PRETTY_PRINT);
- * 
+ *
  * Produces:
- * 
+ *
  *     {
  *      "items": [
  *       {
@@ -34,7 +35,7 @@ use SplObjectStorage;
  *      ],
  *      "rels": {}
  *     }
- * 
+ *
  * @param string|DOMDocument $input The HTML string or DOMDocument object to parse
  * @param string $url The URL the input document was found at, for relative URL resolution
  * @param bool $convertClassic whether or not to convert classic microformats
@@ -46,9 +47,47 @@ function parse($input, $url = null, $convertClassic = true) {
 }
 
 /**
+ * Fetch microformats2
+ *
+ * Given a URL, fetches it (following up to 5 redirects) and, if the content-type appears to be HTML, returns the parsed
+ * microformats2 array structure.
+ *
+ * Not that even if the response code was a 4XX or 5XX error, if the content-type is HTML-like then it will be parsed
+ * all the same, as there are legitimate cases where error pages might contain useful microformats (for example a deleted
+ * h-entry resulting in a 410 Gone page with a stub h-entry explaining the reason for deletion). Look in $curlInfo['http_code']
+ * for the actual value.
+ *
+ * @param string $url The URL to fetch
+ * @param bool $convertClassic (optional, default true) whether or not to convert classic microformats
+ * @param &array $curlInfo (optional) the results of curl_getinfo will be placed in this variable for debugging
+ * @return array|null canonical microformats2 array structure on success, null on failure
+ */
+function fetch($url, $convertClassic = true, &$curlInfo=null) {
+	$ch = curl_init();
+	curl_setopt($ch, CURLOPT_URL, $url);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+	curl_setopt($ch, CURLOPT_HEADER, 0);
+	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+	curl_setopt($ch, CURLOPT_MAXREDIRS, 5);
+	$html = curl_exec($ch);
+	$info = $curlInfo = curl_getinfo($ch);
+	curl_close($ch);
+
+	if (strpos(strtolower($info['content_type']), 'html') === false) {
+		// The content was not delivered as HTML, do not attempt to parse it.
+		return null;
+	}
+
+	# ensure the final URL is used to resolve relative URLs
+	$url = $info['url'];
+
+	return parse($html, $url, $convertClassic);
+}
+
+/**
  * Unicode to HTML Entities
  * @param string $input String containing characters to convert into HTML entities
- * @return string 
+ * @return string
  */
 function unicodeToHtmlEntities($input) {
 	return mb_convert_encoding($input, 'HTML-ENTITIES', mb_detect_encoding($input));
@@ -56,10 +95,10 @@ function unicodeToHtmlEntities($input) {
 
 /**
  * Collapse Whitespace
- * 
+ *
  * Collapses any sequences of whitespace within a string into a single space
  * character.
- * 
+ *
  * @deprecated since v0.2.3
  * @param string $str
  * @return string
@@ -77,20 +116,23 @@ function unicodeTrim($str) {
 
 /**
  * Microformat Name From Class string
- * 
- * Given the value of @class, get the relevant mf classnames (e.g. h-card, 
+ *
+ * Given the value of @class, get the relevant mf classnames (e.g. h-card,
  * p-name).
- * 
+ *
  * @param string $class A space delimited list of classnames
  * @param string $prefix The prefix to look for
  * @return string|array The prefixed name of the first microfomats class found or false
  */
-function mfNamesFromClass($class, $prefix = 'h-') {
+function mfNamesFromClass($class, $prefix='h-') {
+	$class = str_replace(array(' ', '	', "\n"), ' ', $class);
 	$classes = explode(' ', $class);
 	$matches = array();
 
 	foreach ($classes as $classname) {
-		if (stristr(' ' . $classname, ' ' . $prefix) !== false) {
+		$compare_classname = ' ' . $classname;
+		$compare_prefix = ' ' . $prefix;
+		if (strstr($compare_classname, $compare_prefix) !== false && ($compare_classname != $compare_prefix)) {
 			$matches[] = ($prefix === 'h-') ? $classname : substr($classname, strlen($prefix));
 		}
 	}
@@ -100,29 +142,38 @@ function mfNamesFromClass($class, $prefix = 'h-') {
 
 /**
  * Get Nested µf Property Name From Class
- * 
- * Returns all the p-, u-, dt- or e- prefixed classnames it finds in a 
+ *
+ * Returns all the p-, u-, dt- or e- prefixed classnames it finds in a
  * space-separated string.
- * 
+ *
  * @param string $class
- * @return string|null
+ * @return array
  */
 function nestedMfPropertyNamesFromClass($class) {
-	$prefixes = array(' p-', ' u-', ' dt-', ' e-');
+	$prefixes = array('p-', 'u-', 'dt-', 'e-');
+	$propertyNames = array();
 
+	$class = str_replace(array(' ', '	', "\n"), ' ', $class);
 	foreach (explode(' ', $class) as $classname) {
 		foreach ($prefixes as $prefix) {
-			if (stristr(' ' . $classname, $prefix))
-				return mfNamesFromClass($classname, ltrim($prefix));
+			// Check if $classname is a valid property classname for $prefix.
+			if (mb_substr($classname, 0, mb_strlen($prefix)) == $prefix && $classname != $prefix) {
+				$propertyName = mb_substr($classname, mb_strlen($prefix));
+				$propertyNames[$propertyName][] = $prefix;
+			}
 		}
 	}
+	
+	foreach ($propertyNames as $property => $prefixes) {
+		$propertyNames[$property] = array_unique($prefixes);
+	}
 
-	return null;
+	return $propertyNames;
 }
 
 /**
  * Wraps mfNamesFromClass to handle an element as input (common)
- * 
+ *
  * @param DOMElement $e The element to get the classname for
  * @param string $prefix The prefix to look for
  * @return mixed See return value of mf2\Parser::mfNameFromClass()
@@ -141,12 +192,68 @@ function nestedMfPropertyNamesFromElement(\DOMElement $e) {
 }
 
 /**
+ * Converts various time formats to HH:MM
+ * @param string $time The time to convert
+ * @return string
+ */
+function convertTimeFormat($time) {
+	$hh = $mm = $ss = '';
+	preg_match('/(\d{1,2}):?(\d{2})?:?(\d{2})?(a\.?m\.?|p\.?m\.?)?/i', $time, $matches);
+
+	// If no am/pm is specified:
+	if (empty($matches[4])) {
+		return $time;
+	} else {
+		// Otherwise, am/pm is specified.
+		$meridiem = strtolower(str_replace('.', '', $matches[4]));
+
+		// Hours.
+		$hh = $matches[1];
+
+		// Add 12 to hours if pm applies.
+		if ($meridiem == 'pm' && ($hh < 12)) {
+			$hh += 12;
+		}
+
+		$hh = str_pad($hh, 2, '0', STR_PAD_LEFT);
+
+		// Minutes.
+		$mm = (empty($matches[2]) ) ? '00' : $matches[2];
+
+		// Seconds, only if supplied.
+		if (!empty($matches[3])) {
+			$ss = $matches[3];
+		}
+
+		if (empty($ss)) {
+			return sprintf('%s:%s', $hh, $mm);
+		}
+		else {
+			return sprintf('%s:%s:%s', $hh, $mm, $ss);
+		}
+	}
+}
+
+function applySrcsetUrlTransformation($srcset, $transformation) {
+	return implode(', ', array_filter(array_map(function ($srcsetPart) use ($transformation) {
+		$parts = explode(" \t\n\r\0\x0B", trim($srcsetPart), 2);
+		$parts[0] = rtrim($parts[0]);
+
+		if (empty($parts[0])) { return false; }
+
+		$parts[0] = call_user_func($transformation, $parts[0]);
+
+		return $parts[0] . (empty($parts[1]) ? '' : ' ' . $parts[1]);
+	}, explode(',', trim($srcset)))));
+}
+
+/**
  * Microformats2 Parser
- * 
+ *
  * A class which holds state for parsing microformats2 from HTML.
- * 
+ *
  * Example usage:
- * 
+ *
  *     use Mf2;
  *     $parser = new Mf2\Parser('<p class="h-card">Barnaby Walters</p>');
  *     $output = $parser->parse();
@@ -157,20 +264,23 @@ class Parser {
 
 	/** @var DOMXPath object which can be used to query over any fragment*/
 	public $xpath;
-	
+
 	/** @var DOMDocument */
 	public $doc;
-	
+
 	/** @var SplObjectStorage */
 	protected $parsed;
 
+	public $jsonMode;
+
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param DOMDocument|string $input The data to parse. A string of HTML or a DOMDocument
 	 * @param string $url The URL of the parsed document, for relative URL resolution
+	 * @param boolean $jsonMode Whether or not to use a stdClass instance for an empty `rels` dictionary. This breaks PHP looping over rels, but allows the output to be correctly serialized as JSON.
 	 */
-	public function __construct($input, $url = null) {
+	public function __construct($input, $url = null, $jsonMode = false) {
 		libxml_use_internal_errors(true);
 		if (is_string($input)) {
 			$doc = new DOMDocument();
@@ -181,120 +291,240 @@ class Parser {
 			$doc = new DOMDocument();
 			@$doc->loadHTML('');
 		}
-		
+
 		$this->xpath = new DOMXPath($doc);
-		
+
 		$baseurl = $url;
 		foreach ($this->xpath->query('//base[@href]') as $base) {
 			$baseElementUrl = $base->getAttribute('href');
-			
+
 			if (parse_url($baseElementUrl, PHP_URL_SCHEME) === null) {
 				/* The base element URL is relative to the document URL.
 				 *
 				 * :/
 				 *
 				 * Perhaps the author was high? */
-				
+
 				$baseurl = resolveUrl($url, $baseElementUrl);
 			} else {
 				$baseurl = $baseElementUrl;
 			}
 			break;
 		}
-		
+
+		// Ignore <template> elements as per the HTML5 spec
+		foreach ($this->xpath->query('//template') as $templateEl) {
+			$templateEl->parentNode->removeChild($templateEl);
+		}
+
 		$this->baseurl = $baseurl;
 		$this->doc = $doc;
 		$this->parsed = new SplObjectStorage();
+		$this->jsonMode = $jsonMode;
 	}
-	
+
 	private function elementPrefixParsed(\DOMElement $e, $prefix) {
 		if (!$this->parsed->contains($e))
 			$this->parsed->attach($e, array());
-		
+
 		$prefixes = $this->parsed[$e];
 		$prefixes[] = $prefix;
 		$this->parsed[$e] = $prefixes;
 	}
-	
+
 	private function isElementParsed(\DOMElement $e, $prefix) {
 		if (!$this->parsed->contains($e))
 			return false;
-		
+
 		$prefixes = $this->parsed[$e];
-		
+
 		if (!in_array($prefix, $prefixes))
 			return false;
-		
+
 		return true;
 	}
-	
+
+	private function resolveChildUrls(DOMElement $el) {
+		$hyperlinkChildren = $this->xpath->query('.//*[@src or @href or @data]', $el);
+
+		foreach ($hyperlinkChildren as $child) {
+			if ($child->hasAttribute('href'))
+				$child->setAttribute('href', $this->resolveUrl($child->getAttribute('href')));
+			if ($child->hasAttribute('src'))
+				$child->setAttribute('src', $this->resolveUrl($child->getAttribute('src')));
+			if ($child->hasAttribute('srcset'))
+				$child->setAttribute('srcset', applySrcsetUrlTransformation($child->getAttribute('href'), [$this, 'resolveUrl']));
+			if ($child->hasAttribute('data'))
+				$child->setAttribute('data', $this->resolveUrl($child->getAttribute('data')));
+		}
+	}
+
+	public function textContent(DOMElement $el) {
+		$excludeTags = array('noframe', 'noscript', 'script', 'style', 'frames', 'frameset');
+		
+		if (isset($el->tagName) and in_array(strtolower($el->tagName), $excludeTags)) {
+			return '';
+		}
+		
+		$this->resolveChildUrls($el);
+
+		$clonedEl = $el->cloneNode(true);
+
+		foreach ($this->xpath->query('.//img', $clonedEl) as $imgEl) {
+			$newNode = $this->doc->createTextNode($imgEl->getAttribute($imgEl->hasAttribute('alt') ? 'alt' : 'src'));
+			$imgEl->parentNode->replaceChild($newNode, $imgEl);
+		}
+		
+		foreach ($excludeTags as $tagName) {
+			foreach ($this->xpath->query(".//{$tagName}", $clonedEl) as $elToRemove) {
+				$elToRemove->parentNode->removeChild($elToRemove);
+			}
+		}
+
+		return $this->innerText($clonedEl);
+	}
+
+	/**
+	 * This method attempts to return a better 'innerText' representation than DOMNode::textContent
+	 *
+	 * @param DOMElement|DOMText $el
+	 * @param bool $implied when parsing for implied name for h-*, rules may be slightly different
+	 * @see: https://github.com/glennjones/microformat-shiv/blob/dev/lib/text.js
+	 */
+	public function innerText($el, $implied=false) {
+		$out = '';
+
+		$blockLevelTags = array('h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'hr', 'pre', 'table',
+			'address', 'article', 'aside', 'blockquote', 'caption', 'col', 'colgroup', 'dd', 'div', 
+			'dt', 'dir', 'fieldset', 'figcaption', 'figure', 'footer', 'form',  'header', 'hgroup', 'hr', 
+			'li', 'map', 'menu', 'nav', 'optgroup', 'option', 'section', 'tbody', 'testarea', 
+			'tfoot', 'th', 'thead', 'tr', 'td', 'ul', 'ol', 'dl', 'details');
+
+		$excludeTags = array('noframe', 'noscript', 'script', 'style', 'frames', 'frameset');
+		
+		// PHP DOMDocument doesn’t correctly handle whitespace around elements it doesn’t recognise.
+		$unsupportedTags = array('data');
+		
+		if (isset($el->tagName)) {
+			if (in_array(strtolower($el->tagName), $excludeTags)) {
+				return $out;
+			} else if ($el->tagName == 'img') {
+				if ($el->getAttribute('alt') !== '') {
+					return $el->getAttribute('alt');
+				} else if (!$implied && $el->getAttribute('src') !== '') {
+					return $this->resolveUrl($el->getAttribute('src'));
+				}
+			} else if ($el->tagName == 'area' and $el->getAttribute('alt') !== '') {
+				return $el->getAttribute('alt');
+			} else if ($el->tagName == 'abbr' and $el->getAttribute('title') !== '') {
+				return $el->getAttribute('title');
+			}
+		}
+
+		// if node is a text node get its text
+		if (isset($el->nodeType) && $el->nodeType === 3) {
+			$out .= $el->textContent;
+		}
+
+		// get the text of the child nodes
+		if ($el->childNodes && $el->childNodes->length > 0) {
+			for ($j = 0; $j < $el->childNodes->length; $j++) {
+				$text = $this->innerText($el->childNodes->item($j), $implied);
+				if (!is_null($text)) {
+					$out .= $text;
+				}
+			}
+		}
+
+		if (isset($el->tagName)) {
+			// if its a block level tag add an additional space at the end
+			if (in_array(strtolower($el->tagName), $blockLevelTags)) {
+				$out .= ' ';
+			} elseif ($implied and in_array(strtolower($el->tagName), $unsupportedTags)) {
+				$out .= ' ';
+			} else if (strtolower($el->tagName) == 'br') {
+				// else if its a br, replace with newline 
+				$out .= "\n";
+			}
+		} 
+
+		return ($out === '') ? NULL : $out;
+	}
+
 	// TODO: figure out if this has problems with sms: and geo: URLs
 	public function resolveUrl($url) {
-		// If the URL is seriously malformed it’s probably beyond the scope of this 
+		// If the URL is seriously malformed it’s probably beyond the scope of this
 		// parser to try to do anything with it.
-		if (parse_url($url) === false)
+		if (parse_url($url) === false) {
 			return $url;
-		
+		}
+
+		// per issue #40 valid URLs could have a space on either side
+		$url = trim($url);
+
 		$scheme = parse_url($url, PHP_URL_SCHEME);
-		
+
 		if (empty($scheme) and !empty($this->baseurl)) {
 			return resolveUrl($this->baseurl, $url);
 		} else {
 			return $url;
 		}
 	}
-	
+
 	// Parsing Functions
-	
+
 	/**
-	 * Parse value-class/value-title on an element, joining with $separator if 
+	 * Parse value-class/value-title on an element, joining with $separator if
 	 * there are multiple.
-	 * 
+	 *
 	 * @param \DOMElement $e
 	 * @param string $separator = '' if multiple value-title elements, join with this string
 	 * @return string|null the parsed value or null if value-class or -title aren’t in use
 	 */
 	public function parseValueClassTitle(\DOMElement $e, $separator = '') {
 		$valueClassElements = $this->xpath->query('./*[contains(concat(" ", @class, " "), " value ")]', $e);
-		
+
 		if ($valueClassElements->length !== 0) {
 			// Process value-class stuff
 			$val = '';
 			foreach ($valueClassElements as $el) {
-				$val .= $el->textContent;
+				$val .= $this->textContent($el);
 			}
-			
+
 			return unicodeTrim($val);
 		}
-		
+
 		$valueTitleElements = $this->xpath->query('./*[contains(concat(" ", @class, " "), " value-title ")]', $e);
-		
+
 		if ($valueTitleElements->length !== 0) {
 			// Process value-title stuff
 			$val = '';
 			foreach ($valueTitleElements as $el) {
 				$val .= $el->getAttribute('title');
 			}
-			
+
 			return unicodeTrim($val);
 		}
-		
+
 		// No value-title or -class in this element
 		return null;
 	}
-	
+
 	/**
-	 * Given an element with class="p-*", get it’s value
-	 * 
+	 * Given an element with class="p-*", get its value
+	 *
 	 * @param DOMElement $p The element to parse
 	 * @return string The plaintext value of $p, dependant on type
 	 * @todo Make this adhere to value-class
 	 */
 	public function parseP(\DOMElement $p) {
 		$classTitle = $this->parseValueClassTitle($p, ' ');
-		
-		if ($classTitle !== null)
+
+		if ($classTitle !== null) {
 			return $classTitle;
+		}
+
+		$this->resolveChildUrls($p);
 		
 		if ($p->tagName == 'img' and $p->getAttribute('alt') !== '') {
 			$pValue = $p->getAttribute('alt');
@@ -305,15 +535,15 @@ class Parser {
 		} elseif (in_array($p->tagName, array('data', 'input')) and $p->getAttribute('value') !== '') {
 			$pValue = $p->getAttribute('value');
 		} else {
-			$pValue = unicodeTrim($p->textContent);
+			$pValue = unicodeTrim($this->innerText($p));
 		}
-		
+
 		return $pValue;
 	}
 
 	/**
 	 * Given an element with class="u-*", get the value of the URL
-	 * 
+	 *
 	 * @param DOMElement $u The element to parse
 	 * @return string The plaintext value of $u, dependant on type
 	 * @todo make this adhere to value-class
@@ -321,18 +551,18 @@ class Parser {
 	public function parseU(\DOMElement $u) {
 		if (($u->tagName == 'a' or $u->tagName == 'area') and $u->getAttribute('href') !== null) {
 			$uValue = $u->getAttribute('href');
-		} elseif ($u->tagName == 'img' and $u->getAttribute('src') !== null) {
+		} elseif (in_array($u->tagName, array('img', 'audio', 'video', 'source')) and $u->getAttribute('src') !== null) {
 			$uValue = $u->getAttribute('src');
 		} elseif ($u->tagName == 'object' and $u->getAttribute('data') !== null) {
 			$uValue = $u->getAttribute('data');
 		}
-		
+
 		if (isset($uValue)) {
 			return $this->resolveUrl($uValue);
 		}
-		
+
 		$classTitle = $this->parseValueClassTitle($u);
-		
+
 		if ($classTitle !== null) {
 			return $classTitle;
 		} elseif ($u->tagName == 'abbr' and $u->getAttribute('title') !== null) {
@@ -340,25 +570,26 @@ class Parser {
 		} elseif (in_array($u->tagName, array('data', 'input')) and $u->getAttribute('value') !== null) {
 			return $u->getAttribute('value');
 		} else {
-			return unicodeTrim($u->textContent);
+			return unicodeTrim($this->textContent($u));
 		}
 	}
 
 	/**
 	 * Given an element with class="dt-*", get the value of the datetime as a php date object
-	 * 
+	 *
 	 * @param DOMElement $dt The element to parse
+	 * @param array $dates Array of dates processed so far
 	 * @return string The datetime string found
 	 */
-	public function parseDT(\DOMElement $dt) {
+	public function parseDT(\DOMElement $dt, &$dates = array()) {
 		// Check for value-class pattern
 		$valueClassChildren = $this->xpath->query('./*[contains(concat(" ", @class, " "), " value ") or contains(concat(" ", @class, " "), " value-title ")]', $dt);
 		$dtValue = false;
-		
+
 		if ($valueClassChildren->length > 0) {
 			// They’re using value-class
 			$dateParts = array();
-			
+
 			foreach ($valueClassChildren as $e) {
 				if (strstr(' ' . $e->getAttribute('class') . ' ', ' value-title ')) {
 					$title = $e->getAttribute('title');
@@ -401,19 +632,35 @@ class Parser {
 			foreach ($dateParts as $part) {
 				// Is this part a full ISO8601 datetime?
 				if (preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?(?:Z?[+|-]\d{2}:?\d{2})?$/', $part)) {
-					// Break completely, we’ve got our value
+					// Break completely, we’ve got our value.
 					$dtValue = $part;
 					break;
 				} else {
-					// Is the current part a valid time(+TZ?) AND no other time reprentation has been found?
+					// Is the current part a valid time(+TZ?) AND no other time representation has been found?
 					if ((preg_match('/\d{1,2}:\d{1,2}(Z?[+|-]\d{2}:?\d{2})?/', $part) or preg_match('/\d{1,2}[a|p]m/', $part)) and empty($timePart)) {
 						$timePart = $part;
 					} elseif (preg_match('/\d{4}-\d{2}-\d{2}/', $part) and empty($datePart)) {
-						// Is the current part a valid date AND no other date reprentation has been found?
+						// Is the current part a valid date AND no other date representation has been found?
 						$datePart = $part;
 					}
-					
-					$dtValue = rtrim($datePart, 'T') . 'T' . unicodeTrim($timePart, 'T');
+
+					if ( !empty($datePart) && !in_array($datePart, $dates) ) {
+						$dates[] = $datePart;
+					}
+
+					$dtValue = '';
+
+					if ( empty($datePart) && !empty($timePart) ) {
+						$timePart = convertTimeFormat($timePart);
+						$dtValue = unicodeTrim($timePart, 'T');
+					}
+					else if ( !empty($datePart) && empty($timePart) ) {
+						$dtValue = rtrim($datePart, 'T');
+					}
+					else {
+						$timePart = convertTimeFormat($timePart);
+						$dtValue = rtrim($datePart, 'T') . 'T' . unicodeTrim($timePart, 'T');
+					}
 				}
 			}
 		} else {
@@ -431,7 +678,7 @@ class Parser {
 				if (!empty($value))
 					$dtValue = $value;
 				else
-					$dtValue = $dt->nodeValue;
+					$dtValue = $this->textContent($dt);
 			} elseif ($dt->tagName == 'abbr') {
 				// Use @title, otherwise innertext
 				// Is it an entire dt?
@@ -439,7 +686,7 @@ class Parser {
 				if (!empty($title))
 					$dtValue = $title;
 				else
-					$dtValue = $dt->nodeValue;
+					$dtValue = $this->textContent($dt);
 			} elseif ($dt->tagName == 'del' or $dt->tagName == 'ins' or $dt->tagName == 'time') {
 				// Use @datetime if available, otherwise innertext
 				// Is it an entire dt?
@@ -447,10 +694,23 @@ class Parser {
 				if (!empty($dtAttr))
 					$dtValue = $dtAttr;
 				else
-					$dtValue = $dt->nodeValue;
+					$dtValue = $this->textContent($dt);
 			} else {
-				$dtValue = $dt->nodeValue;
+				$dtValue = $this->textContent($dt);
 			}
+
+			if (preg_match('/(\d{4}-\d{2}-\d{2})/', $dtValue, $matches)) {
+				$dates[] = $matches[0];
+			}
+		}
+
+		/**
+		 * if $dtValue is only a time and there are recently parsed dates,
+		 * form the full date-time using the most recently parsed dt- value
+		 */
+		if ((preg_match('/^\d{1,2}:\d{1,2}(Z?[+|-]\d{2}:?\d{2})?/', $dtValue) or preg_match('/^\d{1,2}[a|p]m/', $dtValue)) && !empty($dates)) {
+			$dtValue = convertTimeFormat($dtValue);
+			$dtValue = end($dates) . 'T' . unicodeTrim($dtValue, 'T');
 		}
 
 		return $dtValue;
@@ -461,42 +721,39 @@ class Parser {
 	 *
 	 * 	@param DOMElement $e The element to parse
 	 * 	@return string $e’s innerHTML
-	 * 
+	 *
 	 * @todo need to mark this element as e- parsed so it doesn’t get parsed as it’s parent’s e-* too
 	 */
 	public function parseE(\DOMElement $e) {
 		$classTitle = $this->parseValueClassTitle($e);
-		
+
 		if ($classTitle !== null)
 			return $classTitle;
-		
+
 		// Expand relative URLs within children of this element
 		// TODO: as it is this is not relative to only children, make this .// and rerun tests
-		$hyperlinkChildren = $this->xpath->query('//*[@src or @href or @data]', $e);
-		
-		foreach ($hyperlinkChildren as $child) {
-			if ($child->hasAttribute('href'))
-				$child->setAttribute('href', $this->resolveUrl($child->getAttribute('href')));
-			if ($child->hasAttribute('src'))
-				$child->setAttribute('src', $this->resolveUrl($child->getAttribute('src')));
-			if ($child->hasAttribute('data'))
-				$child->setAttribute('data', $this->resolveUrl($child->getAttribute('data')));
-		}
-		
+		$this->resolveChildUrls($e);
+
 		$html = '';
 		foreach ($e->childNodes as $node) {
 			$html .= $node->C14N();
 		}
-		
+
 		return array(
 			'html' => $html,
-			'value' => unicodeTrim($e->textContent)
+			'value' => unicodeTrim($this->innerText($e))
 		);
+	}
+
+	private function removeTags(\DOMElement &$e, $tagName) {
+		while(($r = $e->getElementsByTagName($tagName)) && $r->length) {
+			$r->item(0)->parentNode->removeChild($r->item(0));
+		}
 	}
 
 	/**
 	 * Recursively parse microformats
-	 * 
+	 *
 	 * @param DOMElement $e The element to parse
 	 * @return array A representation of the values contained within microformat $e
 	 */
@@ -511,31 +768,45 @@ class Parser {
 		// Initalise var to store the representation in
 		$return = array();
 		$children = array();
+		$dates = array();
 
 		// Handle nested microformats (h-*)
 		foreach ($this->xpath->query('.//*[contains(concat(" ", @class)," h-")]', $e) as $subMF) {
 			// Parse
 			$result = $this->parseH($subMF);
-			
+
 			// If result was already parsed, skip it
 			if (null === $result)
 				continue;
 			
+			// In most cases, the value attribute of the nested microformat should be the p- parsed value of the elemnt.
+			// The only times this is different is when the microformat is nested under certain prefixes, which are handled below.
 			$result['value'] = $this->parseP($subMF);
 
 			// Does this µf have any property names other than h-*?
 			$properties = nestedMfPropertyNamesFromElement($subMF);
-			
+
 			if (!empty($properties)) {
 				// Yes! It’s a nested property µf
-				foreach ($properties as $property) {
-					$return[$property][] = $result;
+				foreach ($properties as $property => $prefixes) {
+					// Note: handling microformat nesting under multiple conflicting prefixes is not currently specified by the mf2 parsing spec.
+					$prefixSpecificResult = $result;
+					if (in_array('p-', $prefixes)) {
+						$prefixSpecificResult['value'] = $prefixSpecificResult['properties']['name'][0];
+					} elseif (in_array('e-', $prefixes)) {
+						$eParsedResult = $this->parseE($subMF);
+						$prefixSpecificResult['html'] = $eParsedResult['html'];
+						$prefixSpecificResult['value'] = $eParsedResult['value'];
+					} elseif (in_array('u-', $prefixes)) {
+						$prefixSpecificResult['value'] = (empty($result['properties']['url'])) ? $this->parseU($subMF) : reset($result['properties']['url']);
+					}
+					$return[$property][] = $prefixSpecificResult;
 				}
 			} else {
 				// No, it’s a child µf
 				$children[] = $result;
 			}
-			
+
 			// Make sure this sub-mf won’t get parsed as a µf or property
 			// TODO: Determine if clearing this is required?
 			$this->elementPrefixParsed($subMF, 'h');
@@ -545,19 +816,24 @@ class Parser {
 			$this->elementPrefixParsed($subMF, 'e');
 		}
 
+		if($e->tagName == 'area') {
+			$coords = $e->getAttribute('coords');
+			$shape = $e->getAttribute('shape');
+		}
+
 		// Handle p-*
 		foreach ($this->xpath->query('.//*[contains(concat(" ", @class) ," p-")]', $e) as $p) {
 			if ($this->isElementParsed($p, 'p'))
 				continue;
 
 			$pValue = $this->parseP($p);
-			
+
 			// Add the value to the array for it’s p- properties
 			foreach (mfNamesFromElement($p, 'p-') as $propName) {
 				if (!empty($propName))
 					$return[$propName][] = $pValue;
 			}
-			
+
 			// Make sure this sub-mf won’t get parsed as a top level mf
 			$this->elementPrefixParsed($p, 'p');
 		}
@@ -566,32 +842,32 @@ class Parser {
 		foreach ($this->xpath->query('.//*[contains(concat(" ",  @class)," u-")]', $e) as $u) {
 			if ($this->isElementParsed($u, 'u'))
 				continue;
-			
+
 			$uValue = $this->parseU($u);
-			
+
 			// Add the value to the array for it’s property types
 			foreach (mfNamesFromElement($u, 'u-') as $propName) {
 				$return[$propName][] = $uValue;
 			}
-			
+
 			// Make sure this sub-mf won’t get parsed as a top level mf
 			$this->elementPrefixParsed($u, 'u');
 		}
-		
+
 		// Handle dt-*
 		foreach ($this->xpath->query('.//*[contains(concat(" ", @class), " dt-")]', $e) as $dt) {
 			if ($this->isElementParsed($dt, 'dt'))
 				continue;
-			
-			$dtValue = $this->parseDT($dt);
-			
+
+			$dtValue = $this->parseDT($dt, $dates);
+
 			if ($dtValue) {
 				// Add the value to the array for dt- properties
 				foreach (mfNamesFromElement($dt, 'dt-') as $propName) {
 					$return[$propName][] = $dtValue;
 				}
 			}
-			
+
 			// Make sure this sub-mf won’t get parsed as a top level mf
 			$this->elementPrefixParsed($dt, 'dt');
 		}
@@ -618,25 +894,45 @@ class Parser {
 		if (!array_key_exists('name', $return)) {
 			try {
 				// Look for img @alt
-				if ($e->tagName == 'img' and $e->getAttribute('alt') != '')
+				if (($e->tagName == 'img' or $e->tagName == 'area') and $e->getAttribute('alt') != '')
 					throw new Exception($e->getAttribute('alt'));
-				
+
 				if ($e->tagName == 'abbr' and $e->hasAttribute('title'))
 					throw new Exception($e->getAttribute('title'));
-				
+
 				// Look for nested img @alt
 				foreach ($this->xpath->query('./img[count(preceding-sibling::*)+count(following-sibling::*)=0]', $e) as $em) {
-					if ($em->getAttribute('alt') != '')
+					$emNames = mfNamesFromElement($em, 'h-');
+					if (empty($emNames) && $em->getAttribute('alt') != '') {
 						throw new Exception($em->getAttribute('alt'));
+					}
+				}
+
+				// Look for nested area @alt
+				foreach ($this->xpath->query('./area[count(preceding-sibling::*)+count(following-sibling::*)=0]', $e) as $em) {
+					$emNames = mfNamesFromElement($em, 'h-');
+					if (empty($emNames) && $em->getAttribute('alt') != '') {
+						throw new Exception($em->getAttribute('alt'));
+					}
 				}
 
 				// Look for double nested img @alt
 				foreach ($this->xpath->query('./*[count(preceding-sibling::*)+count(following-sibling::*)=0]/img[count(preceding-sibling::*)+count(following-sibling::*)=0]', $e) as $em) {
-					if ($em->getAttribute('alt') != '')
+					$emNames = mfNamesFromElement($em, 'h-');
+					if (empty($emNames) && $em->getAttribute('alt') != '') {
 						throw new Exception($em->getAttribute('alt'));
+					}
 				}
 
-				throw new Exception($e->nodeValue);
+				// Look for double nested img @alt
+				foreach ($this->xpath->query('./*[count(preceding-sibling::*)+count(following-sibling::*)=0]/area[count(preceding-sibling::*)+count(following-sibling::*)=0]', $e) as $em) {
+					$emNames = mfNamesFromElement($em, 'h-');
+					if (empty($emNames) && $em->getAttribute('alt') != '') {
+						throw new Exception($em->getAttribute('alt'));
+					}
+				}
+
+				throw new Exception($this->innerText($e, true));
 			} catch (Exception $exc) {
 				$return['name'][] = unicodeTrim($exc->getMessage());
 			}
@@ -668,47 +964,77 @@ class Parser {
 		// Check for u-url
 		if (!array_key_exists('url', $return)) {
 			// Look for img @src
-			if ($e->tagName == 'a')
+			if ($e->tagName == 'a' or $e->tagName == 'area')
 				$url = $e->getAttribute('href');
-			
-			// Look for nested img @src
+
+			// Look for nested a @href
 			foreach ($this->xpath->query('./a[count(preceding-sibling::a)+count(following-sibling::a)=0]', $e) as $em) {
-				$url = $em->getAttribute('href');
-				break;
+				$emNames = mfNamesFromElement($em, 'h-');
+				if (empty($emNames)) {
+					$url = $em->getAttribute('href');
+					break;
+				}
 			}
-			
+
+			// Look for nested area @src
+			foreach ($this->xpath->query('./area[count(preceding-sibling::area)+count(following-sibling::area)=0]', $e) as $em) {
+				$emNames = mfNamesFromElement($em, 'h-');
+				if (empty($emNames)) {
+					$url = $em->getAttribute('href');
+					break;
+				}
+			}
+
 			if (!empty($url))
 				$return['url'][] = $this->resolveUrl($url);
 		}
 
 		// Make sure things are in alphabetical order
 		sort($mfTypes);
-		
+
 		// Phew. Return the final result.
 		$parsed = array(
 			'type' => $mfTypes,
 			'properties' => $return
 		);
-		if (!empty($children))
+
+		if (!empty($shape)) {
+			$parsed['shape'] = $shape;
+		}
+
+		if (!empty($coords)) {
+			$parsed['coords'] = $coords;
+		}
+
+		if (!empty($children)) {
 			$parsed['children'] = array_values(array_filter($children));
+		}
 		return $parsed;
 	}
-	
+
+	/**
+	 * Parse Rels and Alternatives
+	 *
+	 * Returns [$rels, $alternatives]. If the $rels value is to be empty, i.e. there are no links on the page
+	 * with a rel value *not* containing `alternate`, then the type of $rels depends on $this->jsonMode. If set
+	 * to true, it will be a stdClass instance, optimising for JSON serialisation. Otherwise (the default case),
+	 * it will be an empty array.
+	 */
 	public function parseRelsAndAlternates() {
 		$rels = array();
 		$alternates = array();
-		
+
 		// Iterate through all a, area and link elements with rel attributes
 		foreach ($this->xpath->query('//*[@rel and @href]') as $hyperlink) {
 			if ($hyperlink->getAttribute('rel') == '')
 				continue;
-			
+
 			// Resolve the href
 			$href = $this->resolveUrl($hyperlink->getAttribute('href'));
-			
+
 			// Split up the rel into space-separated values
 			$linkRels = array_filter(explode(' ', $hyperlink->getAttribute('rel')));
-			
+
 			// If alternate in rels, create alternate structure, append
 			if (in_array('alternate', $linkRels)) {
 				$alt = array(
@@ -717,10 +1043,19 @@ class Parser {
 				);
 				if ($hyperlink->hasAttribute('media'))
 					$alt['media'] = $hyperlink->getAttribute('media');
-				
+
 				if ($hyperlink->hasAttribute('hreflang'))
 					$alt['hreflang'] = $hyperlink->getAttribute('hreflang');
-				
+
+				if ($hyperlink->hasAttribute('title'))
+					$alt['title'] = $hyperlink->getAttribute('title');
+
+				if ($hyperlink->hasAttribute('type'))
+					$alt['type'] = $hyperlink->getAttribute('type');
+
+				if ($hyperlink->nodeValue)
+					$alt['text'] = $hyperlink->nodeValue;
+
 				$alternates[] = $alt;
 			} else {
 				foreach ($linkRels as $rel) {
@@ -728,37 +1063,38 @@ class Parser {
 				}
 			}
 		}
-		
-		if (count($rels) === 0)
-			$rels = new \stdclass;
-		
+
+		if (empty($rels) and $this->jsonMode) {
+			$rels = new stdClass();
+		}
+
 		return array($rels, $alternates);
 	}
-	
+
 	/**
 	 * Kicks off the parsing routine
-	 * 
+	 *
 	 * If `$htmlSafe` is set, any angle brackets in the results from non e-* properties
 	 * will be HTML-encoded, bringing all output to the same level of encoding.
-	 * 
+	 *
 	 * If a DOMElement is set as the $context, only descendants of that element will
 	 * be parsed for microformats.
-	 * 
+	 *
 	 * @param bool $htmlSafe whether or not to html-encode non e-* properties. Defaults to false
 	 * @param DOMElement $context optionally an element from which to parse microformats
 	 * @return array An array containing all the µfs found in the current document
 	 */
 	public function parse($convertClassic = true, DOMElement $context = null) {
 		$mfs = array();
-		
+
 		if ($convertClassic) {
 			$this->convertLegacy();
 		}
-		
+
 		$mfElements = null === $context
 			? $this->xpath->query('//*[contains(concat(" ",	@class), " h-")]')
 			: $this->xpath->query('.//*[contains(concat(" ",	@class), " h-")]', $context);
-		
+
 		// Parser microformats
 		foreach ($mfElements as $node) {
 			// For each microformat
@@ -767,64 +1103,64 @@ class Parser {
 			// Add the value to the array for this property type
 			$mfs[] = $result;
 		}
-		
+
 		// Parse rels
 		list($rels, $alternates) = $this->parseRelsAndAlternates();
-		
+
 		$top = array(
 			'items' => array_values(array_filter($mfs)),
 			'rels' => $rels
 		);
-		
+
 		if (count($alternates))
 			$top['alternates'] = $alternates;
-		
+
 		return $top;
 	}
-	
+
 	/**
 	 * Parse From ID
-	 * 
+	 *
 	 * Given an ID, parse all microformats which are children of the element with
 	 * that ID.
-	 * 
+	 *
 	 * Note that rel values are still document-wide.
-	 * 
-	 * If an element with the ID is not found, an empty skeleton mf2 array structure 
+	 *
+	 * If an element with the ID is not found, an empty skeleton mf2 array structure
 	 * will be returned.
-	 * 
+	 *
 	 * @param string $id
 	 * @param bool $htmlSafe = false whether or not to HTML-encode angle brackets in non e-* properties
 	 * @return array
 	 */
 	public function parseFromId($id, $convertClassic=true) {
 		$matches = $this->xpath->query("//*[@id='{$id}']");
-		
+
 		if (empty($matches))
 			return array('items' => array(), 'rels' => array(), 'alternates' => array());
-		
+
 		return $this->parse($convertClassic, $matches->item(0));
 	}
 
 	/**
 	 * Convert Legacy Classnames
-	 * 
+	 *
 	 * Adds microformats2 classnames into a document containing only legacy
 	 * semantic classnames.
-	 * 
+	 *
 	 * @return Parser $this
 	 */
 	public function convertLegacy() {
 		$doc = $this->doc;
 		$xp = new DOMXPath($doc);
-		
+
 		// replace all roots
 		foreach ($this->classicRootMap as $old => $new) {
 			foreach ($xp->query('//*[contains(concat(" ", @class, " "), " ' . $old . ' ") and not(contains(concat(" ", @class, " "), " ' . $new . ' "))]') as $el) {
 				$el->setAttribute('class', $el->getAttribute('class') . ' ' . $new);
 			}
 		}
-		
+
 		foreach ($this->classicPropertyMap as $oldRoot => $properties) {
 			$newRoot = $this->classicRootMap[$oldRoot];
 			foreach ($properties as $old => $new) {
@@ -833,16 +1169,16 @@ class Parser {
 				}
 			}
 		}
-		
+
 		return $this;
 	}
-	
+
 	/**
 	 * XPath Query
-	 * 
+	 *
 	 * Runs an XPath query over the current document. Works in exactly the same
 	 * way as DOMXPath::query.
-	 * 
+	 *
 	 * @param string $expression
 	 * @param DOMNode $context
 	 * @return DOMNodeList
@@ -850,7 +1186,7 @@ class Parser {
 	public function query($expression, $context = null) {
 		return $this->xpath->query($expression, $context);
 	}
-	
+
 	/**
 	 * Classic Root Classname map
 	 */
@@ -860,10 +1196,11 @@ class Parser {
 		'hentry' => 'h-entry',
 		'hrecipe' => 'h-recipe',
 		'hresume' => 'h-resume',
-		'hevent' => 'h-event',
-		'hreview' => 'h-review'
+		'vevent' => 'h-event',
+		'hreview' => 'h-review',
+		'hproduct' => 'h-product'
 	);
-	
+
 	public $classicPropertyMap = array(
 		'vcard' => array(
 			'fn' => 'p-name',
@@ -930,12 +1267,12 @@ class Parser {
 			'skill' => 'p-skill',
 			'affiliation' => 'p-affiliation h-card',
 		),
-		'hevent' => array(
+		'vevent' => array(
 			'dtstart' => 'dt-start',
 			'dtend' => 'dt-end',
 			'duration' => 'dt-duration',
 			'description' => 'p-description',
-			'summary' => 'p-summary',
+			'summary' => 'p-name',
 			'description' => 'p-description',
 			'url' => 'u-url',
 			'category' => 'p-category',
@@ -953,6 +1290,17 @@ class Parser {
 			'best' => 'p-best',
 			'worst' => 'p-worst',
 			'description' => 'p-description'
+		),
+		'hproduct' => array(
+			'fn' => 'p-name',
+			'photo' => 'u-photo',
+			'brand' => 'p-brand',
+			'category' => 'p-category',
+			'description' => 'p-description',
+			'identifier' => 'u-identifier',
+			'url' => 'u-url',
+			'review' => 'p-review h-review',
+			'price' => 'p-price'
 		)
 	);
 }
@@ -979,6 +1327,8 @@ function parseUriToComponents($uri) {
 		if(array_key_exists('user', $u) || array_key_exists('pass', $u))
 			$result['authority'] .= '@';
 		$result['authority'] .= $u['host'];
+		if(array_key_exists('port', $u))
+			$result['authority'] .= ':' . $u['port'];
 	}
 
 	if(array_key_exists('path', $u))
@@ -1079,7 +1429,7 @@ function resolveUrl($baseURI, $referenceURI) {
 # 5.2.3 Merge Paths
 function mergePaths($base, $reference) {
 	# If the base URI has a defined authority component and an empty
-	#    path, 
+	# path,
 	if($base['authority'] && $base['path'] == null) {
 		# then return a string consisting of "/" concatenated with the
 		# reference's path; otherwise,
@@ -1087,13 +1437,13 @@ function mergePaths($base, $reference) {
 	} else {
 		if(($pos=strrpos($base['path'], '/')) !== false) {
 			# return a string consisting of the reference's path component
-			#    appended to all but the last segment of the base URI's path (i.e.,
-			#    excluding any characters after the right-most "/" in the base URI
-			#    path,
+			# appended to all but the last segment of the base URI's path (i.e.,
+			# excluding any characters after the right-most "/" in the base URI
+			# path,
 			$merged = substr($base['path'], 0, $pos + 1) . $reference['path'];
 		} else {
-			#    or excluding the entire base URI path if it does not contain
-			#    any "/" characters).
+			# or excluding the entire base URI path if it does not contain
+			# any "/" characters).
 			$merged = $base['path'];
 		}
 	}

--- a/external/mf2/composer.lock
+++ b/external/mf2/composer.lock
@@ -1,32 +1,31 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "daebdde620bccf210f307d06d0558409",
-    "packages": [
-
-    ],
+    "hash": "4ddb858a7bdae5163307bd104589bd95",
+    "packages": [],
     "packages-dev": [
         {
             "name": "phpunit/php-code-coverage",
-            "version": "1.2.13",
+            "version": "1.2.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "466e7cd2554b4e264c9e3f31216d25ac0e5f3d94"
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/466e7cd2554b4e264c9e3f31216d25ac0e5f3d94",
-                "reference": "466e7cd2554b4e264c9e3f31216d25ac0e5f3d94",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "phpunit/php-file-iterator": ">=1.3.0@stable",
-                "phpunit/php-text-template": ">=1.1.1@stable",
-                "phpunit/php-token-stream": ">=1.1.3@stable"
+                "phpunit/php-text-template": ">=1.2.0@stable",
+                "phpunit/php-token-stream": ">=1.1.3,<1.3.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "3.7.*@dev"
@@ -67,35 +66,37 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2013-09-10 08:14:32"
+            "time": "2014-09-02 10:13:14"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.3.4",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
+                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
-                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a923bb15680d0089e2316f7a4af8f437046e96bb",
+                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
-                    "File/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -112,20 +113,20 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2013-10-10 15:34:57"
+            "time": "2015-04-02 05:19:05"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "1.1.4",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5180896f51c5b3648ac946b05f9ec02be78a0b23"
+                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5180896f51c5b3648ac946b05f9ec02be78a0b23",
-                "reference": "5180896f51c5b3648ac946b05f9ec02be78a0b23",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
                 "shasum": ""
             },
             "require": {
@@ -156,7 +157,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2012-10-31 18:15:28"
+            "time": "2014-01-30 17:20:04"
         },
         {
             "name": "phpunit/php-timer",
@@ -204,16 +205,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "5220af2a7929aa35cf663d97c89ad3d50cf5fa3e"
+                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/5220af2a7929aa35cf663d97c89ad3d50cf5fa3e",
-                "reference": "5220af2a7929aa35cf663d97c89ad3d50cf5fa3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/ad4e1e23ae01b483c16f600ff1bebec184588e32",
+                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32",
                 "shasum": ""
             },
             "require": {
@@ -250,43 +251,42 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2013-09-13 04:58:23"
+            "time": "2014-03-03 05:10:30"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "3.7.28",
+            "version": "3.7.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3b97c8492bcafbabe6b6fbd2ab35f2f04d932a8d"
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3b97c8492bcafbabe6b6fbd2ab35f2f04d932a8d",
-                "reference": "3b97c8492bcafbabe6b6fbd2ab35f2f04d932a8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38709dc22d519a3d1be46849868aa2ddf822bcf6",
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
                 "ext-dom": "*",
+                "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "php": ">=5.3.3",
-                "phpunit/php-code-coverage": "~1.2.1",
-                "phpunit/php-file-iterator": ">=1.3.1",
-                "phpunit/php-text-template": ">=1.1.1",
-                "phpunit/php-timer": ">=1.0.4",
-                "phpunit/phpunit-mock-objects": "~1.2.0",
+                "phpunit/php-code-coverage": "~1.2",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.1",
+                "phpunit/php-timer": "~1.0",
+                "phpunit/phpunit-mock-objects": "~1.2",
                 "symfony/yaml": "~2.0"
             },
             "require-dev": {
-                "pear-pear/pear": "1.9.4"
+                "pear-pear.php.net/pear": "1.9.4"
             },
             "suggest": {
-                "ext-json": "*",
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "phpunit/php-invoker": ">=1.1.0,<1.2.0"
+                "phpunit/php-invoker": "~1.1"
             },
             "bin": [
                 "composer/bin/phpunit"
@@ -324,7 +324,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2013-10-17 07:27:40"
+            "time": "2014-10-17 09:04:17"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -377,26 +377,29 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.3.6",
+            "version": "v2.6.6",
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "6bb881b948368482e1abf1a75c08bcf88a1c5fc3"
+                "reference": "174f009ed36379a801109955fc5a71a49fe62dd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/6bb881b948368482e1abf1a75c08bcf88a1c5fc3",
-                "reference": "6bb881b948368482e1abf1a75c08bcf88a1c5fc3",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/174f009ed36379a801109955fc5a71a49fe62dd4",
+                "reference": "174f009ed36379a801109955fc5a71a49fe62dd4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -410,30 +413,26 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
                     "name": "Symfony Community",
                     "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2013-09-22 18:04:39"
+            "time": "2015-03-30 15:54:10"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.3.0"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }

--- a/external/mf2/phpunit.xml
+++ b/external/mf2/phpunit.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
-<phpunit bootstrap="tests/mf2/bootstrap.php">
+<phpunit bootstrap="tests/Mf2/bootstrap.php">
 	<testsuites>
 		<testsuite name="php-mf2">
-			<directory suffix="Test.php">tests/mf2</directory>
+			<directory suffix="Test.php">tests/Mf2</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/external/mf2/tests/Mf2/ClassicMicroformatsTest.php
+++ b/external/mf2/tests/Mf2/ClassicMicroformatsTest.php
@@ -25,14 +25,14 @@ class ClassicMicroformatsTest extends PHPUnit_Framework_TestCase {
 	public function testParsesClassicHcard() {
 		$input = '<div class="vcard"><span class="fn n">Barnaby Walters</span> is a person.</div>';
 		$expected = '{"items": [{"type": ["h-card"], "properties": {"name": ["Barnaby Walters"]}}], "rels": {}}';
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$this->assertJsonStringEqualsJsonString(json_encode($parser->parse()), $expected);
 	}
 	
 	public function testParsesClassicHEntry() {
 		$input = '<div class="hentry"><h1 class="entry-title">microformats2 Is Great</h1> <p class="entry-summary">yes yes it is.</p></div>';
 		$expected = '{"items": [{"type": ["h-entry"], "properties": {"name": ["microformats2 Is Great"], "summary": ["yes yes it is."]}}], "rels": {}}';
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$this->assertJsonStringEqualsJsonString(json_encode($parser->parse()), $expected);
 	}
 	
@@ -106,9 +106,69 @@ EOT;
 	
 	public function testParsesSnarfedOrgArticleCorrectly() {
 		$input = file_get_contents(__DIR__ . '/snarfed.org.html');
-		/*$parser = new Parser($input, 'http://snarfed.org/2013-10-23_oauth-dropins');
-		$result = $parser->parse();/**/
 		$result = Mf2\parse($input, 'http://snarfed.org/2013-10-23_oauth-dropins');
-		print_r($result);
 	}
+
+	public function testParsesHProduct() {
+		$input = <<<'EOT'
+<xml id="skufilterbrowse" class="slide">
+<productcatalog><labels><label key="skuset.deliverypolicyurl">Delivery policy content URL</label><label key="price.save">Save</label><label key="skuset.seemoredetails">See more details</label><label key="price.additionaloffers">Additional Offers</label><label key="price.freeitem">Includes Free Item*</label><label key="price.instsaving">Instant Savings</label><label key="skuset.eddieseedetails">See details </label><label key="price.rebateurl">RebateURL</label><label key="skuset.freedelivery">FREE SHIPPING, plus 5% back for Rewards Members</label><label key="price.printableCoupons">Click here for Printable Coupon</label><label key="price.value">Value</label><label key="skuset.eddieshipdetails">Estimated to arrive no later than </label><label key="price.qty">Qty.</label><label key="price.chooseyouritems">Choose your Items</label><label key="price.true">true</label><label key="skuset.clearancemessage">&lt;strong&gt;CLEARANCE ITEM:&lt;/strong&gt; </label><label key="price.ERF">Eco Fee</label><label key="skuset.viewlargerimage">View larger</label><label key="common.next">Next</label><label key="price.addtocart">Add to Cart</label><label key="common.reviews">reviews</label><label key="common.previous">Previous</label><label key="skuset.instockonline">In Stock Online</label><label key="price.priceafterrebate">Price &lt;strong&gt;after&lt;/strong&gt; rebate</label><label key="btn.bopis">PICK UP TODAY</label><label key="common.share">SHARE</label><label key="skuset.freedeliverytostore">FREE Shipping to store</label><label key="erf.popup.label">Environmental fee notice:</label><label key="price.details">Details</label><label key="common.stars">stars</label><label key="skuset.learnmore1">Learn more.</label><label key="common.share.twitter">Share on Twitter</label><label key="price.instorespecial">Available In Store Only</label><label key="price.priceincart">See Price in Cart</label><label key="skuset.giftcards">Orders containing this item are not eligible for Gift cards or certain other methods of payment.</label><label key="skuset.mysoftwaredownloads">"My Software Downloads"</label><label key="price.bmsmerf">Buy More Save More prices do not include eco fee.</label><label key="price.now">Now</label><label key="price.collapse">Collapse</label><label key="classpage.getstarted">Get Started</label><label key="skuset.printpage">Print this page</label><label key="price.learnmore">Learn More</label><label key="common.item">Item</label><label key="common.icon.path">/sbdpas/img/ico/</label><label key="skuset.selectcomponent">Select another component below</label><label key="skuset.freeshippingentireorder">Item qualifies entire order for free delivery</label><label key="skuset.eddieincart">in cart. </label><label key="common.selected">selected</label><label key="price.priceaftersavings">Price &lt;strong&gt;after&lt;/strong&gt; savings</label><label key="skuset.inktoner">Ink and toner</label><label key="classpage.comingsoon">Coming Soon</label><label key="price.before">Before</label><label key="price.was">Was</label><label key="skuset.viewfulldetails">View Full Details</label><label key="skuset.expdelivery">Expected Delivery:</label><label key="common.share.pinterest">Share on Pinterest</label><label key="skuset.deliveryonly">Online Only</label><label key="common.share.email">Email it</label><label key="price.seedetails">See Details</label><label key="skuset.expdelpopup">/sbd/content/help-center/shipping-and-delivery.html</label><label key="skuset.softwaredownload">Software Download</label><label key="erf.popup.url">/sbd/content/help/environmental_fee_popup.html</label><label key="price.finalprice">Final Price</label><label key="common.share.facebook">Share on Facebook</label><label key="skuset.eddiesaveproduct">on this product! </label><label key="skuset.suppliedandshippedby">Supplied and Shipped by</label><label key="common.addtofavorites">Add to Favorites</label><label key="skuset.esdnotepart1">Note: Shortly after purchase you will be able to access your Software Downloads in the </label><label key="skuset.esdnotepart2">section of your staples.com&#174; account. It's easy and secure!</label><label key="skuset.software1">/sbd/cre/marketing/technology-research-centers/software/software-downloads.html#z_faq</label><label key="price.instantcoupon">Instant Coupon</label><label key="skuset.eddieshipdetails1">to </label><label key="price.pricebefore">Price &lt;strong&gt;before&lt;/strong&gt;</label><label key="skuset.eddieoffer">Offer valid for 20 minutes. </label><label key="price.price">Price</label><label key="common.model">Model</label><label key="skuset.supplierhover">We have partnered with this trusted supplier to offer you a wider assortment of products and brands for all of your business needs, with the same great level of service you can expect from Staples.com.</label><label key="skuset.forceshiptostore">Item can be shipped only to a retail store location. </label><label key="price.rebate">Rebate</label><label key="price.bmsm">Buy More Save More</label><label key="common.print">print</label><label key="skuset.viewvideo">View video</label><label key="skuset.instoreavailability">Check in Store Availability</label><label key="price.aslowas">As low as</label><label key="price.reg">Reg</label><label key="price.free">FREE</label><label key="erf.message">Provincial recycling or deposit fees may be applicable upon checkout.</label><label key="skuset.eddiesave">Save an extra </label><label key="skuset.deferredfinancemessage">Special Financing Available </label><label key="price.promotions">Promotions</label><label key="price.availableinstore">Available In-Store Only</label><label key="skuset.outofstock">Currently Out of Stock.</label><label key="price.totalsavings">Total Savings</label><label key="price.beforePresentation">Before continuing, please select an item</label></labels>
+
+<product bss="ON" envfeeflag="0" comingsoonflag="0" price="18.35" name="Swingline® 747® Classic Desktop Staplers" bopispilot="true" mss="ON" zipcode="01701" comp="0" presnvalue="Select an Item" snum="SS264184" leadtimedescription="1 - 30 Business Days" expandedpromo="0" alttext="Swingline® 747® Classic Desktop Staplers" prdtypeid="0" presntype="D" review="4.5" class="hproduct" type="skuset" skubopswitch="ON" id="609548" bopisenableflag="0"><descs><desc typeid="2">All-steel construction with non-skid rubber base</desc><desc typeid="2">Spring-loaded inner channel prevents jams</desc><desc typeid="2">Available in black, burgundy and beige &lt;br /&gt; &lt;li&gt;Staples up to 20 sheets&lt;/li&gt;</desc><desc typeid="38">Select an Item</desc><desc typeid="39">All-steel construction with non-skid rubber base</desc><desc typeid="39">Spring-loaded inner channel prevents jams</desc><desc typeid="39">Available in black, burgundy and beige &lt;br /&gt; &lt;li&gt;Staples up to 20 sheets&lt;/li&gt;</desc><desc class="fn">Swingline® 747® Classic Desktop Staplers</desc></descs><price is="18.35" uom="Each"></price><span class="price">18.35</span><span class="currency">USD</span><imgs><pic class="photo" id="1">http://www.staples-3p.com/s7/is/image/Staples/s0021414_sc7?$std$</pic><pic altimg="Y" id="2">http://www.staples-3p.com/s7/is/image/Staples/s0021414_sc7?$thb$</pic><pic id="6">http://www.staples-3p.com/s7/is/image/Staples/s0021414</pic></imgs><producturl class="url">/Swingline-747-Classic-Desktop-Staplers/product_SS264184</producturl><review rating="4.5" count="99" css="45"></review><delivery shiptostore="true" free="false" instore="2" forceshiptostore="false"></delivery></product>
+
+<product bss="ON" envfeeflag="0" comingsoonflag="0" price="18.35" name="Swingline® 747® Classic Desktop Full Strip Stapler, 20 Sheet Capacity, Black" bopispilot="true" mss="ON" zipcode="01701" comp="1" snum="264184" leadtimedescription="1 Business Day" expandedpromo="0" alttext="Swingline® 747® Classic Desktop Full Strip Stapler, 20 Sheet Capacity, Black" prdtypeid="0" review="4.5" class="hproduct" mnum="S7074771G" type="sku" skubopswitch="ON" id="609315" bopisenableflag="1"><descs><desc typeid="2">All-steel construction with non-skid rubber base</desc><desc typeid="2">Full strip</desc><desc typeid="2">Staples up to 20 sheets</desc><desc typeid="19">Each</desc><desc typeid="39">All-steel construction with non-skid rubber base</desc><desc typeid="39">Full strip</desc><desc typeid="39">Staples up to 20 sheets</desc><desc class="fn">Swingline® 747® Classic Desktop Full Strip Stapler, 20 Sheet Capacity, Black</desc></descs><price is="18.35" uom="Each"></price><span class="price">18.35</span><span class="currency">USD</span><imgs><pic class="photo" id="1">http://www.staples-3p.com/s7/is/image/Staples/s0021412_sc7?$std$</pic><pic altimg="Y" id="2">http://www.staples-3p.com/s7/is/image/Staples/s0021412_sc7?$thb$</pic><pic id="6">http://www.staples-3p.com/s7/is/image/Staples/s0021412</pic><pic id="120"></pic></imgs><producturl class="url">/Swingline-747-Classic-Desktop-Full-Strip-Stapler-20-Sheet-Capacity-Black/product_264184</producturl><review rating="4.5" count="99" css="45"></review><delivery shiptostore="true" free="false" instore="1" forceshiptostore="false"></delivery></product>
+
+<product bss="ON" envfeeflag="0" comingsoonflag="0" price="19.59" name="Swingline® 747® Classic Desktop Stapler, Burgundy" bopispilot="true" mss="ON" zipcode="01701" comp="1" snum="413732" leadtimedescription="1 Business Day" expandedpromo="0" alttext="Swingline® 747® Classic Desktop Stapler, Burgundy" prdtypeid="0" review="3.5" class="hproduct" mnum="74718/74782" type="sku" skubopswitch="ON" id="1460639" bopisenableflag="0"><descs><desc typeid="2">All-steel construction with non-skid rubber base</desc><desc typeid="2">Spring-loaded inner channel prevents jams</desc><desc typeid="2">Burgundy &lt;br /&gt; &lt;li&gt;Staples up to 20 sheets&lt;/li&gt;</desc><desc typeid="19">Each</desc><desc typeid="39">All-steel construction with non-skid rubber base</desc><desc typeid="39">Spring-loaded inner channel prevents jams</desc><desc typeid="39">Burgundy &lt;br /&gt; &lt;li&gt;Staples up to 20 sheets&lt;/li&gt;</desc><desc class="fn">Swingline® 747® Classic Desktop Stapler, Burgundy</desc></descs><price is="19.59" uom="Each"></price><span class="price">19.59</span><span class="currency">USD</span><imgs><pic class="photo" id="1">http://www.staples-3p.com/s7/is/image/Staples/m000240695_sc7?$std$</pic><pic altimg="Y" id="2">http://www.staples-3p.com/s7/is/image/Staples/m000240695_sc7?$thb$</pic><pic id="6">http://www.staples-3p.com/s7/is/image/Staples/m000240695</pic></imgs><producturl class="url">/Swingline-747-Classic-Desktop-Stapler-Burgundy/product_413732</producturl><review rating="3.5" count="7" css="35"></review><delivery shiptostore="true" free="false" instore="2" forceshiptostore="false"></delivery></product>
+
+<product bss="ON" envfeeflag="0" comingsoonflag="0" price="39.49" name="Swingline® 747® Rio Red Stapler, 20 Sheet Capacity" bopispilot="true" mss="ON" zipcode="01701" comp="1" brandname="Swingline" snum="562485" leadtimedescription="1 - 4 Business Days" expandedpromo="0" alttext="Swingline® 747® Rio Red Stapler, 20 Sheet Capacity" prdtypeid="0" review="4.5" class="hproduct" mnum="74736" type="sku" skubopswitch="ON" id="1093798" bopisenableflag="0"><descs><desc typeid="2">20 sheet capacity with Swingline S.F.® 4® Staples</desc><desc typeid="2">Durable metal construction</desc><desc typeid="2">Stapler opens for tacking ability</desc><desc typeid="19">Each</desc><desc typeid="39">20 sheet capacity with Swingline S.F.® 4® Staples</desc><desc typeid="39">Durable metal construction</desc><desc typeid="39">Stapler opens for tacking ability</desc><desc class="fn">Swingline® 747® Rio Red Stapler, 20 Sheet Capacity</desc></descs><price is="39.49" uom="Each"></price><span class="price">39.49</span><span class="currency">USD</span><imgs><pic class="photo" id="1">http://www.staples-3p.com/s7/is/image/Staples/s0446269_sc7?$std$</pic><pic altimg="Y" id="2">http://www.staples-3p.com/s7/is/image/Staples/s0446269_sc7?$thb$</pic><pic id="6">http://www.staples-3p.com/s7/is/image/Staples/s0446269</pic></imgs><producturl class="url">/Swingline-747-Rio-Red-Stapler-20-Sheet-Capacity/product_562485</producturl><review rating="4.5" count="76" css="45"></review><delivery shiptostore="true" free="true" instore="2" forceshiptostore="false"></delivery></product>
+</productcatalog>
+</xml>
+EOT;
+
+		$result = Mf2\parse($input, 'http://www.staples.com/Swingline-747-Rio-Red-Stapler-20-Sheet-Capacity/product_562485');
+		$this->assertCount(4, $result['items']);
+	}
+
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/81
+	 */
+	public function test_vevent() {
+		$input = <<< EOT
+<div class="vevent">
+<h3 class="summary">XYZ Project Review</h3>
+<p class="description">Project XYZ Review Meeting</p>
+<p> <a class="url" href="http://example.com/xyz-meeting">http://example.com/xyz-meeting</a> </p>
+<p>To be held on 
+ <span class="dtstart">
+  <abbr class="value" title="1998-03-12">the 12th of March</abbr> 
+  from <span class="value">8:30am</span> <abbr class="value" title="-0500">EST</abbr>
+ </span> until 
+ <span class="dtend">
+  <span class="value">9:30am</span> <abbr class="value" title="-0500">EST</abbr>
+ </span>
+</p>
+<p>Location: <span class="location">1CP Conference Room 4350</span></p>
+<small>Booked by: <span class="uid">guid-1.host1.com</span> on 
+ <span class="dtstamp">
+  <abbr class="value" title="1998-03-09">the 9th</abbr> at <span class="value">6:00pm</span>
+ </span>
+</small>
+</div>
+EOT;
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('name', $output['items'][0]['properties']);
+		$this->assertArrayHasKey('description', $output['items'][0]['properties']);
+		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
+		$this->assertArrayHasKey('start', $output['items'][0]['properties']);
+		$this->assertArrayHasKey('end', $output['items'][0]['properties']);
+
+		$this->assertEquals('XYZ Project Review', $output['items'][0]['properties']['name'][0]);
+		$this->assertEquals('Project XYZ Review Meeting', $output['items'][0]['properties']['description'][0]);
+		$this->assertEquals('http://example.com/xyz-meeting', $output['items'][0]['properties']['url'][0]);
+		$this->assertEquals('1998-03-12T08:30', $output['items'][0]['properties']['start'][0]);
+		$this->assertEquals('1998-03-12T09:30', $output['items'][0]['properties']['end'][0]);
+	}
+
 }

--- a/external/mf2/tests/Mf2/CombinedMicroformatsTest.php
+++ b/external/mf2/tests/Mf2/CombinedMicroformatsTest.php
@@ -3,6 +3,7 @@
 namespace Mf2\Parser\Test;
 
 use Mf2\Parser;
+use Mf2;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -24,46 +25,42 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testHEventLocationHCard() {
 		$input = '<div class="h-event">
-  <a class="p-name u-url" href="http://indiewebcamp.com/2012">
+	<a class="p-name u-url" href="http://indiewebcamp.com/2012">
 	IndieWebCamp 2012
-  </a>
-  from <time class="dt-start">2012-06-30</time> 
-  to <time class="dt-end">2012-07-01</time> at 
-  <span class="p-location h-card">
+	</a>
+	from <time class="dt-start">2012-06-30</time> 
+	to <time class="dt-end">2012-07-01</time> at 
+	<span class="p-location h-card">
 	<a class="p-name p-org u-url" href="http://geoloqi.com/">
-	  Geoloqi
-	</a>, 
-	<span class="p-street-address">920 SW 3rd Ave. Suite 400</span>, 
-	<span class="p-locality">Portland</span>, 
-	<abbr class="p-region" title="Oregon">OR</abbr>
+	Geoloqi</a>, <span class="p-street-address">920 SW 3rd Ave. Suite 400</span>, <span class="p-locality">Portland</span>, <abbr class="p-region" title="Oregon">OR</abbr>
   </span>
 </div>';
 		$expected = '{
 	"rels": {},
-  "items": [{ 
-	"type": ["h-event"],
-	"properties": {
-	  "name": ["IndieWebCamp 2012"],
-	  "url": ["http://indiewebcamp.com/2012"],
-	  "start": ["2012-06-30"],
-	  "end": ["2012-07-01"],
-	  "location": [{
-		"value": "Geoloqi, 920 SW 3rd Ave. Suite 400, Portland, OR",
-		"type": ["h-card"],
+	"items": [{ 
+		"type": ["h-event"],
 		"properties": {
-		  "name": ["Geoloqi"],
-		  "org": ["Geoloqi"],
-		  "url": ["http://geoloqi.com/"],
-		  "street-address": ["920 SW 3rd Ave. Suite 400"],
-		  "locality": ["Portland"],
-		  "region": ["Oregon"]
+			"name": ["IndieWebCamp 2012"],
+			"url": ["http://indiewebcamp.com/2012"],
+			"start": ["2012-06-30"],
+			"end": ["2012-07-01"],
+			"location": [{
+				"value": "Geoloqi",
+				"type": ["h-card"],
+				"properties": {
+					"name": ["Geoloqi"],
+					"org": ["Geoloqi"],
+					"url": ["http://geoloqi.com/"],
+					"street-address": ["920 SW 3rd Ave. Suite 400"],
+					"locality": ["Portland"],
+					"region": ["Oregon"]
+				}
+			}]
 		}
-	  }]
-	}
-  }]
+	}]
 }';
 
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$parser->stringDateTimes = true;
 		$output = $parser->parse();
 		
@@ -92,7 +89,7 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
   }]
 }';
 
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$parser->stringDateTimes = true;
 		$output = $parser->parse();
 
@@ -130,7 +127,7 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
   }]
 }';
 
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$parser->stringDateTimes = true;
 		$output = $parser->parse();
 
@@ -168,10 +165,8 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
   }]
 }';
 
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$output = $parser->parse();
-
-		print_r($output);
 		
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);
 	}
@@ -181,34 +176,127 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testHCardChildHCard() {
 		$input = '<div class="h-card">
-  <a class="p-name u-url"
-	 href="http://blog.lizardwrangler.com/">
-	 Mitchell Baker</a> 
-  (<a class="h-card h-org" href="http://mozilla.org/">
-	  Mozilla Foundation</a>)
+	<a class="p-name u-url"
+	href="http://blog.lizardwrangler.com/">
+	Mitchell Baker</a> 
+	(<a class="h-card h-org" href="http://mozilla.org/">
+	Mozilla Foundation</a>)
 </div>';
 		$expected = '{
 	"rels": {},
   "items": [{ 
-	"type": ["h-card"],
-	"properties": {
-	  "name": ["Mitchell Baker"],
-	  "url": ["http://blog.lizardwrangler.com/"]
-	},
-	"children": [{
-	  "type": ["h-card","h-org"],
-	  "properties": {
-		"name": ["Mozilla Foundation"],
-		"url": ["http://mozilla.org/"]
-	  }
+		"type": ["h-card"],
+		"properties": {
+			"name": ["Mitchell Baker"],
+			"url": ["http://blog.lizardwrangler.com/"]
+		},
+		"children": [{
+			"type": ["h-card","h-org"],
+			"properties": {
+				"name": ["Mozilla Foundation"],
+				"url": ["http://mozilla.org/"]
+			},
+			"value": "Mozilla Foundation"
+		}]
 	}]
-  }]
 }';
 
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$output = $parser->parse();
 		
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);
 	}
+	
+	/**
+	 * Regression test for https://github.com/indieweb/php-mf2/issues/42
+	 * 
+	 * This was occurring because mfPropertyNamesFromClass was only ever returning the first property name
+	 * rather than all of them.
+	 */
+	public function testNestedMicroformatUnderMultipleProperties() {
+		$input = '<article class="h-entry"><div class="p-like-of p-in-reply-to h-cite"></div></article>';
+		$mf = Mf2\parse($input);
+		
+		$this->assertCount(1, $mf['items'][0]['properties']['like-of']);
+		$this->assertCount(1, $mf['items'][0]['properties']['in-reply-to']);
+	}
+	
+	/**
+	 * Test microformats nested under e-* property classnames retain html: key in structure
+	 * 
+	 * @see https://github.com/indieweb/php-mf2/issues/64
+	 */
+	public function testMicroformatsNestedUnderEPropertyClassnamesRetainHtmlKey() {
+		$input = '<div class="h-entry"><div class="h-card e-content"><p>Hello</p></div></div>';
+		$mf = Mf2\parse($input);
+		
+		$this->assertEquals($mf['items'][0]['properties']['content'][0]['html'], '<p>Hello</p>');
+	}
+	
+	/**
+	 * Test microformats nested under u-* property classnames derive value: key from parsing as u-*
+	 */
+	public function testMicroformatsNestedUnderUPropertyClassnamesDeriveValueCorrectly() {
+		$input = '<div class="h-entry"><img class="u-url h-card" alt="This should not be the value" src="This should be the value" /></div>';
+		$mf = Mf2\parse($input);
+		
+		$this->assertEquals($mf['items'][0]['properties']['url'][0]['value'], 'This should be the value');
+	}
 
+	public function testMicroformatsNestedUnderUPropertyClassnamesDeriveValueFromURL() {
+		$input = '<div class="h-entry">
+		  <h1 class="p-name">Name</h1>
+		  <p class="e-content">Hello World</p>
+		  <ul>
+		    <li class="u-comment h-cite">
+		    	<a class="u-author h-card" href="http://jane.example.com/">Jane Bloggs</a>
+		    	<p class="p-content p-name">lol</p>
+		    	<a class="u-url" href="http://example.org/post1234"><time class="dt-published">2015-07-12 12:03</time></a>
+		    </li>
+		  </ul>
+		</div>';
+		$expected = '{
+		  "items": [{
+    	  "type": ["h-entry"],
+	      "properties": {
+	        "name": ["Name"],
+	        "content": [{
+	          "html": "Hello World",
+	          "value": "Hello World"
+	        }],
+	        "comment": [{
+            "type": ["h-cite"],
+            "properties": {
+              "author": [{
+                "type": ["h-card"],
+                "properties": {
+                  "name": ["Jane Bloggs"],
+                  "url": ["http:\/\/jane.example.com\/"]
+                },
+                "value": "http:\/\/jane.example.com\/"
+              }],
+              "content": ["lol"],
+              "name": ["lol"],
+              "url": ["http:\/\/example.org\/post1234"],
+              "published": ["2015-07-12 12:03"]
+            },
+            "value": "http:\/\/example.org\/post1234"
+          }]
+	      }
+	    }],
+	    "rels":[]
+	  }';
+	  	$mf = Mf2\parse($input);
+
+		$this->assertJsonStringEqualsJsonString(json_encode($mf), $expected);
+		$this->assertEquals($mf['items'][0]['properties']['comment'][0]['value'], 'http://example.org/post1234');
+		$this->assertEquals($mf['items'][0]['properties']['comment'][0]['properties']['author'][0]['value'], 'http://jane.example.com/');
+	}
+	
+	public function testMicroformatsNestedUnderPPropertyClassnamesDeriveValueFromFirstPName() {
+		$input = '<div class="h-entry"><div class="p-author h-card">This post was written by <span class="p-name">Zoe</span>.</div></div>';
+		$mf = Mf2\parse($input);
+		
+		$this->assertEquals($mf['items'][0]['properties']['author'][0]['value'], 'Zoe');
+	}
 }

--- a/external/mf2/tests/Mf2/MicroformatsWikiExamplesTest.php
+++ b/external/mf2/tests/Mf2/MicroformatsWikiExamplesTest.php
@@ -32,7 +32,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 	"items": []
 }';
 		
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$output = $parser->parse();
 		
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);
@@ -45,7 +45,8 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 	"items": []
 }';
 		
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
+		$parser->jsonMode = true;
 		$output = $parser->parse();
 		
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);
@@ -65,7 +66,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 	}
   }]
 }';
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$output = $parser->parse();
 
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);
@@ -86,7 +87,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 	}
   }]
 }';
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$output = $parser->parse();
 
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);
@@ -107,7 +108,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 	"photo": ["http://example.org/pic.jpg"]
   }
 }]}';
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$output = $parser->parse();
 
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);
@@ -132,7 +133,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 	"photo": ["https://s3.amazonaws.com/twitter_production/profile_images/53307499/180px-Rohit-sq_bigger.jpg"]
   }
 }]}';
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$output = $parser->parse();
 
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);
@@ -179,7 +180,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 	}
   }]
 }';
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$output = $parser->parse();
 
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);

--- a/external/mf2/tests/Mf2/ParseDTTest.php
+++ b/external/mf2/tests/Mf2/ParseDTTest.php
@@ -135,7 +135,7 @@ class ParseDTTest extends PHPUnit_Framework_TestCase {
 	 * @group valueClass
 	 */
 	public function testAbbrYYYY_MM_DD__HH_MM() {
-		$input = '<div class="h-event"><span class="dt-start"><abbr class="value" title="2012-10-07">some day</a> at <span class="value">21:18</span></span></div>';
+		$input = '<div class="h-event"><span class="dt-start"><abbr class="value" title="2012-10-07">some day</abbr> at <span class="value">21:18</span></span></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
@@ -155,4 +155,107 @@ class ParseDTTest extends PHPUnit_Framework_TestCase {
 		$this->assertArrayHasKey('start', $output['items'][0]['properties']);
 		$this->assertEquals('2012-10-07T21:00', $output['items'][0]['properties']['start'][0]);
 	}
+
+	/**
+	 * @group parseDT
+	 * @group valueClass
+	 */
+	public function testYYYY_MM_DD__HH_MMpm() {
+		$input = '<div class="h-event"><span class="dt-start"><span class="value">2012-10-07</span> at <span class="value">9:00pm</span></span></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('start', $output['items'][0]['properties']);
+		$this->assertEquals('2012-10-07T21:00', $output['items'][0]['properties']['start'][0]);
+	}
+
+	/**
+	 * @group parseDT
+	 * @group valueClass
+	 */
+	public function testYYYY_MM_DD__HH_MM_SSpm() {
+		$input = '<div class="h-event"><span class="dt-start"><span class="value">2012-10-07</span> at <span class="value">9:00:00pm</span></span></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('start', $output['items'][0]['properties']);
+		$this->assertEquals('2012-10-07T21:00:00', $output['items'][0]['properties']['start'][0]);
+	}
+
+	/**
+	 * This test name refers to the value-class used within the dt-end.
+	 * @group parseDT
+	 * @group valueClass
+	 */
+	public function testImpliedDTEndWithValueClass() {
+		$input = '<div class="h-event"> <span class="dt-start"><span class="value">2014-06-04</span> at <span class="value">18:30</span> <span class="dt-end"><span class="value">19:30</span></span></span> </div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('start', $output['items'][0]['properties']);
+		$this->assertArrayHasKey('end', $output['items'][0]['properties']);
+		$this->assertEquals('2014-06-04T18:30', $output['items'][0]['properties']['start'][0]);
+		$this->assertEquals('2014-06-04T19:30', $output['items'][0]['properties']['end'][0]);
+	}
+
+	/**
+	 * This test name refers to the lack of value-class within the dt-end.
+	 * @group parseDT
+	 * @group valueClass
+	 */
+	public function testImpliedDTEndWithoutValueClass() {
+		$input = '<div class="h-event"> <span class="dt-start"><span class="value">2014-06-05</span> at <span class="value">18:31</span> <span class="dt-end">19:31</span></span> </div>';
+
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('start', $output['items'][0]['properties']);
+		$this->assertArrayHasKey('end', $output['items'][0]['properties']);
+		$this->assertEquals('2014-06-05T18:31', $output['items'][0]['properties']['start'][0]);
+		$this->assertEquals('2014-06-05T19:31', $output['items'][0]['properties']['end'][0]);
+	}
+
+	/**
+	 * @see https://github.com/indieweb/php-mf2/pull/46
+	 * @group parseDT
+	 * @group valueClass
+	 */
+	public function testImpliedDTEndUsingNonValueClassDTStart() {
+		$input = '<div class="h-event"> <time class="dt-start">2014-06-05T18:31</time> until <span class="dt-end">19:31</span></span> </div>';
+
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('start', $output['items'][0]['properties']);
+		$this->assertArrayHasKey('end', $output['items'][0]['properties']);
+		$this->assertEquals('2014-06-05T18:31', $output['items'][0]['properties']['start'][0]);
+		$this->assertEquals('2014-06-05T19:31', $output['items'][0]['properties']['end'][0]);
+	}
+
+	/**
+	 * @group parseDT
+	 * @group valueClass
+	 */
+	public function testDTStartOnly() {
+		$input = '<div class="h-event"> <span class="dt-start"><span class="value">2014-06-06</span> at <span class="value">18:32</span> </span> </div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('start', $output['items'][0]['properties']);
+		$this->assertEquals('2014-06-06T18:32', $output['items'][0]['properties']['start'][0]);
+	}
+
+	/**
+	 * @group parseDT
+	 * @group valueClass
+	 */
+	public function testDTStartDateOnly() {
+		$input = '<div class="h-event"> <span class="dt-start"><span class="value">2014-06-07</span> </span> </div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('start', $output['items'][0]['properties']);
+		$this->assertEquals('2014-06-07', $output['items'][0]['properties']['start'][0]);
+	}
+
 }

--- a/external/mf2/tests/Mf2/ParseImpliedTest.php
+++ b/external/mf2/tests/Mf2/ParseImpliedTest.php
@@ -160,7 +160,7 @@ class ParseImpliedTest extends PHPUnit_Framework_TestCase {
 	}]
 }';
 		
-		$parser = new Parser($input);
+		$parser = new Parser($input, '', true);
 		$output = $parser->parse();
 		
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);

--- a/external/mf2/tests/Mf2/ParsePTest.php
+++ b/external/mf2/tests/Mf2/ParsePTest.php
@@ -86,4 +86,33 @@ class ParsePTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://example.com', $result['items'][0]['properties']['url'][0]);
 	}
 
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/53
+	 * @see http://microformats.org/wiki/microformats2-parsing#parsing_an_e-_property
+	 */
+	public function testConvertsNestedImgElementToAltOrSrc() {
+		$input = <<<EOT
+<div class="h-entry">
+	<p class="p-name">The day I saw a <img alt="five legged elephant" src="/photos/five-legged-elephant.jpg" /></p>
+	<p class="p-summary">Blah blah <img src="/photos/five-legged-elephant.jpg" /></p>
+</div>
+EOT;
+		$result = Mf2\parse($input, 'http://waterpigs.co.uk/articles/five-legged-elephant');
+		$this->assertEquals('The day I saw a five legged elephant', $result['items'][0]['properties']['name'][0]);
+		$this->assertEquals('Blah blah http://waterpigs.co.uk/photos/five-legged-elephant.jpg', $result['items'][0]['properties']['summary'][0]);
+	}
+
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/69
+	 */
+	public function testBrWhitespaceIssue69() {
+		$input = '<div class="h-card"><p class="p-adr"><span class="p-street-address">Street Name 9</span><br/><span class="p-locality">12345 NY, USA</span></p></div>';
+		$result = Mf2\parse($input);
+
+		$this->assertEquals('Street Name 9' . "\n" . '12345 NY, USA', $result['items'][0]['properties']['adr'][0]);
+		$this->assertEquals('Street Name 9', $result['items'][0]['properties']['street-address'][0]);
+		$this->assertEquals('12345 NY, USA', $result['items'][0]['properties']['locality'][0]);
+		$this->assertEquals('Street Name 9' . "\n" . '12345 NY, USA', $result['items'][0]['properties']['name'][0]);
+	}
+
 }

--- a/external/mf2/tests/Mf2/ParseUTest.php
+++ b/external/mf2/tests/Mf2/ParseUTest.php
@@ -136,4 +136,56 @@ class ParseUTest extends PHPUnit_Framework_TestCase {
 		$result = Mf2\parse($input);
 		$this->assertEquals('http://example.com/right', $result['items'][0]['properties']['url'][0]);
 	}
+
+	/**
+	 * @group parseU
+	 */
+	public function testParseUHandlesAudio() {
+		$input = '<div class="h-entry"><audio class="u-audio" src="http://example.com/audio.mp3"></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('audio', $output['items'][0]['properties']);
+		$this->assertEquals('http://example.com/audio.mp3', $output['items'][0]['properties']['audio'][0]);
+	}
+
+	/**
+	 * @group parseU
+	 */
+	public function testParseUHandlesVideo() {
+		$input = '<div class="h-entry"><video class="u-video" src="http://example.com/video.mp4"></video></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
+		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
+	}
+
+
+	/**
+	 * @group parseU
+	 */
+	public function testParseUHandlesSource() {
+		$input = '<div class="h-entry"><video><source class="u-video" src="http://example.com/video.mp4" type="video/mp4"><source class="u-video" src="http://example.com/video.ogg" type="video/ogg"></video></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
+		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
+		$this->assertEquals('http://example.com/video.ogg', $output['items'][0]['properties']['video'][1]);
+	}
+
+	/**
+	 * @group parseU
+	 */
+	public function testParseUWithSpaces() {
+		$input = '<div class="h-card"><a class="u-url" href=" http://example.com ">Awesome example website</a></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+		
+		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
+		$this->assertEquals('http://example.com', $output['items'][0]['properties']['url'][0]);
+	}
+	
+
 }

--- a/external/mf2/tests/Mf2/ParserTest.php
+++ b/external/mf2/tests/Mf2/ParserTest.php
@@ -8,10 +8,10 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * Parser Test
- * 
+ *
  * Contains tests for internal parsing functions and stuff which doesn’t go anywhere else, i.e.
  * isn’t related to a particular property as such.
- * 
+ *
  * Stuff for parsing E goes in here until there is enough of it to go elsewhere (like, never?)
  */
 class ParserTest extends PHPUnit_Framework_TestCase {
@@ -19,42 +19,64 @@ class ParserTest extends PHPUnit_Framework_TestCase {
 	public function setUp() {
 		date_default_timezone_set('Europe/London');
 	}
-	
+
 	public function testUnicodeTrim() {
 		$this->assertEquals('thing', Mf2\unicodeTrim('  thing  '));
 		$this->assertEquals('thing', Mf2\unicodeTrim('			thing			'));
 		$this->assertEquals('thing', Mf2\unicodeTrim(mb_convert_encoding(' &nbsp; thing &nbsp; ', 'UTF-8', 'HTML-ENTITIES') ));
 	}
-	
+
 	public function testMicroformatNameFromClassReturnsFullRootName() {
 		$expected = array('h-card');
 		$actual = Mf2\mfNamesFromClass('someclass h-card someotherclass', 'h-');
 
-		$this->assertEquals($actual, $expected);
+		$this->assertEquals($expected, $actual);
 	}
 
 	public function testMicroformatNameFromClassHandlesMultipleHNames() {
 		$expected = array('h-card', 'h-person');
 		$actual = Mf2\mfNamesFromClass('someclass h-card someotherclass h-person yetanotherclass', 'h-');
 
-		$this->assertEquals($actual, $expected);
+		$this->assertEquals($expected, $actual);
 	}
 
 	public function testMicroformatStripsPrefixFromPropertyClassname() {
 		$expected = array('name');
 		$actual = Mf2\mfNamesFromClass('someclass p-name someotherclass', 'p-');
 
-		$this->assertEquals($actual, $expected);
+		$this->assertEquals($expected, $actual);
 	}
 
 	public function testNestedMicroformatPropertyNameWorks() {
-		$expected = array('location');
-		$test = 'someclass p-location someotherclass';
+		$expected = array('location' => array('p-'), 'author' => array('u-', 'p-'));
+		$test = 'someclass p-location someotherclass u-author p-author';
 		$actual = Mf2\nestedMfPropertyNamesFromClass($test);
-		
-		$this->assertEquals($actual, $expected);
+
+		$this->assertEquals($expected, $actual);
 	}
-	
+
+	public function testMicroformatNamesFromClassIgnoresPrefixesWithoutNames() {
+		$expected = array();
+		$actual = Mf2\mfNamesFromClass('someclass h- someotherclass', 'h-');
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testMicroformatNamesFromClassHandlesExcessiveWhitespace() {
+		$expected = array('h-card');
+		$actual = Mf2\mfNamesFromClass('  someclass
+			 	h-card 	 someotherclass		   	 ', 'h-');
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testMicroformatNamesFromClassIgnoresUppercaseClassnames() {
+		$expected = array();
+		$actual = Mf2\mfNamesFromClass('H-ENTRY', 'h-');
+
+		$this->assertEquals($expected, $actual);
+	}
+
 	public function testParseE() {
 		$input = '<div class="h-entry"><div class="e-content">Here is a load of <strong>embedded markup</strong></div></div>';
 		//$parser = new Parser($input);
@@ -64,14 +86,14 @@ class ParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('Here is a load of <strong>embedded markup</strong>', $output['items'][0]['properties']['content'][0]['html']);
 		$this->assertEquals('Here is a load of embedded markup', $output['items'][0]['properties']['content'][0]['value']);
 	}
-	
+
 	public function testParseEResolvesRelativeLinks() {
 		$input = '<div class="h-entry"><p class="e-content">Blah blah <a href="/a-url">thing</a>. <object data="/object"></object> <img src="/img" /></p></div>';
 		$parser = new Parser($input, 'http://example.com');
 		$output = $parser->parse();
-		
+
 		$this->assertEquals('Blah blah <a href="http://example.com/a-url">thing</a>. <object data="http://example.com/object"></object> <img src="http://example.com/img"></img>', $output['items'][0]['properties']['content'][0]['html']);
-		$this->assertEquals('Blah blah thing.', $output['items'][0]['properties']['content'][0]['value']);
+		$this->assertEquals('Blah blah thing.  http://example.com/img', $output['items'][0]['properties']['content'][0]['value']);
 	}
 
 	/**
@@ -88,58 +110,62 @@ class ParserTest extends PHPUnit_Framework_TestCase {
 				$this->fail();
 		}
 	}
-	
+
 	public function testHtmlSpecialCharactersWorks() {
 		$this->assertEquals('&lt;&gt;', htmlspecialchars('<>'));
 	}
-	
+
 	public function testHtmlEncodesNonEProperties() {
 		$input = '<div class="h-card">
 			<span class="p-name">&lt;p&gt;</span>
 			<span class="dt-published">&lt;dt&gt;</span>
 			<span class="u-url">&lt;u&gt;</span>
 			</div>';
-		
+
 		$parser = new Parser($input);
 		$output = $parser->parse();
-		
+
 		$this->assertEquals('<p>', $output['items'][0]['properties']['name'][0]);
 		$this->assertEquals('<dt>', $output['items'][0]['properties']['published'][0]);
 		$this->assertEquals('<u>', $output['items'][0]['properties']['url'][0]);
 	}
-	
+
+
 	public function testHtmlEncodesImpliedProperties() {
 		$input = '<a class="h-card" href="&lt;url&gt;"><img src="&lt;img&gt;" />&lt;name&gt;</a>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
-		
+
 		$this->assertEquals('<name>', $output['items'][0]['properties']['name'][0]);
 		$this->assertEquals('<url>', $output['items'][0]['properties']['url'][0]);
 		$this->assertEquals('<img>', $output['items'][0]['properties']['photo'][0]);
 	}
-	
+
 	public function testParsesRelValues() {
 		$input = '<a rel="author" href="http://example.com">Mr. Author</a>';
 		$parser = new Parser($input);
-		
+
 		$output = $parser->parse();
-		
+
 		$this->assertArrayHasKey('rels', $output);
 		$this->assertEquals('http://example.com', $output['rels']['author'][0]);
 	}
-	
+
 	public function testParsesRelAlternateValues() {
-		$input = '<a rel="alternate home" href="http://example.org" hreflang="de", media="screen"></a>';
+		$input = '<a rel="alternate home" href="http://example.org" hreflang="de", media="screen" type="text/html" title="German Homepage Link">German Homepage</a>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
-		
+
 		$this->assertArrayHasKey('alternates', $output);
 		$this->assertEquals('http://example.org', $output['alternates'][0]['url']);
 		$this->assertEquals('home', $output['alternates'][0]['rel']);
 		$this->assertEquals('de', $output['alternates'][0]['hreflang']);
 		$this->assertEquals('screen', $output['alternates'][0]['media']);
+		$this->assertEquals('text/html', $output['alternates'][0]['type']);
+		$this->assertEquals('German Homepage Link', $output['alternates'][0]['title']);
+		$this->assertEquals('German Homepage', $output['alternates'][0]['text']);
 	}
-	
+
 	public function testParseFromIdOnlyReturnsMicroformatsWithinThatId() {
 		$input = <<<EOT
 <div class="h-entry"><span class="p-name">Not Included</span></div>
@@ -150,14 +176,14 @@ class ParserTest extends PHPUnit_Framework_TestCase {
 
 <div class="h-entry"><span class="p-name">Not Included</span></div>
 EOT;
-		
+
 		$parser = new Parser($input);
 		$output = $parser->parseFromId('parse-here');
-		
+
 		$this->assertCount(1, $output['items']);
 		$this->assertEquals('Included', $output['items'][0]['properties']['name'][0]);
 	}
-	
+
 	/**
 	 * Issue #21 github.com/indieweb/php-mf2/issues/21
 	 */
@@ -167,16 +193,16 @@ EOT;
 	<div class="p-in-reply-to h-entry">
 		<span class="p-author h-card">Nested Author</span>
 	</div>
-	
+
 	<span class="p-author h-card">Real Author</span>
 </div>
 EOT;
 		$parser = new Parser($input);
 		$output = $parser->parse();
-		
+
 		$this->assertCount(1, $output['items'][0]['properties']['author']);
 	}
-	
+
 	public function testParsesNestedMicroformatsWithClassnamesInAnyOrder() {
 		$input = <<<EOT
 <div class="h-entry">
@@ -185,8 +211,205 @@ EOT;
 EOT;
 		$parser = new Parser($input);
 		$output = $parser->parse();
-		
+
 		$this->assertCount(1, $output['items'][0]['properties']['in-reply-to']);
 		$this->assertEquals('Name', $output['items'][0]['properties']['in-reply-to'][0]['properties']['name'][0]);
+	}
+
+	/**
+	 * @group network
+	 */
+	public function testFetchMicroformats() {
+		$mf = Mf2\fetch('http://waterpigs.co.uk/');
+		$this->assertArrayHasKey('items', $mf);
+
+		$mf = Mf2\fetch('http://waterpigs.co.uk/photo.jpg', null, $curlInfo);
+		$this->assertNull($mf);
+		$this->assertContains('jpeg', $curlInfo['content_type']);
+	}
+
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/48
+	 */
+	public function testIgnoreClassesEndingInHyphen() {
+		$input = '<span class="h-entry"> <span class="e-">foo</span> </span>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayNotHasKey('0', $output['items'][0]['properties']);
+	}
+
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/52
+	 * @see https://github.com/tommorris/mf2py/commit/92740deb7e19b8f1e7fbf6bec001cf52f2b07e99
+	 */
+	public function testIgnoresTemplateElements() {
+		$result = Mf2\parse('<template class="h-card"><span class="p-name">Tom Morris</span></template>');
+		$this->assertCount(0, $result['items']);
+	}
+
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/53
+	 * @see http://microformats.org/wiki/microformats2-parsing#parsing_an_e-_property
+	 */
+	public function testConvertsNestedImgElementToAltOrSrc() {
+		$input = <<<EOT
+<div class="h-entry">
+	<p class="e-content">It is a strange thing to see a <img alt="five legged elephant" src="/photos/five-legged-elephant.jpg" /></p>
+</div>
+EOT;
+		$result = Mf2\parse($input, 'http://waterpigs.co.uk/articles/five-legged-elephant');
+		$this->assertEquals('It is a strange thing to see a five legged elephant', $result['items'][0]['properties']['content'][0]['value']);
+	}
+
+	// parser not respecting not[h-*] in rule  "else if .h-x>a[href]:only-of-type:not[.h-*] then use that [href] for url"
+	public function testNotImpliedUrlFromHCard() {
+		$input = <<<EOT
+<span class="h-entry">
+	<a class="h-card" href="http://test.com">John Q</a>
+</span>
+EOT;
+
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayNotHasKey('url', $output['items'][0]['properties']);
+	}
+
+	public function testAreaTag() {
+		$input = <<<EOT
+<div class="h-entry">
+	<area class="p-category h-card" href="http://personB.example.com" alt="Person Bee" shape="rect" coords="100,100,120,120">
+</div>
+EOT;
+
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertEquals('Person Bee', $output['items'][0]['properties']['name'][0]);
+		$this->assertEquals('rect', $output['items'][0]['properties']['category'][0]['shape']);
+		$this->assertEquals('100,100,120,120', $output['items'][0]['properties']['category'][0]['coords']);
+		$this->assertEquals('Person Bee', $output['items'][0]['properties']['category'][0]['value']);
+	}
+
+	public function testParseHcardInCategory() {
+		$input = <<<EOT
+<span class="h-entry">
+	<a class="p-author h-card" href="http://a.example.com/">Alice</a> tagged
+	<a href="http://b.example.com/" class="u-category h-card">Bob Smith</a> in
+	<a class="u-tag-of u-in-reply-to" href="http://s.example.com/permalink47">
+		<img src="http://s.example.com/photo47.png" alt="a photo of Bob and Cole" />
+	</a>
+</span>
+EOT;
+
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertContains('h-entry', $output['items'][0]['type']);
+		$this->assertArrayHasKey('category', $output['items'][0]['properties']);
+		$this->assertContains('h-card', $output['items'][0]['properties']['category'][0]['type']);
+		$this->assertArrayHasKey('name', $output['items'][0]['properties']['category'][0]['properties']);
+		$this->assertEquals('Bob Smith', $output['items'][0]['properties']['category'][0]['properties']['name'][0]);
+		$this->assertArrayHasKey('url', $output['items'][0]['properties']['category'][0]['properties']);
+		$this->assertEquals('http://b.example.com/', $output['items'][0]['properties']['category'][0]['properties']['url'][0]);
+	}
+	
+	public function testApplyTransformationToSrcset() {
+		$transformation = function ($url) {
+			return 'https://example.com/' . ltrim($url, '/');
+		};
+		
+		// Example from https://developers.whatwg.org/edits.html#attr-img-srcset
+		$srcset = 'banner-HD.jpeg 2x, banner-phone.jpeg 100w, banner-phone-HD.jpeg 100w 2x';
+		$result = Mf2\applySrcsetUrlTransformation($srcset, $transformation);
+		$this->assertEquals('https://example.com/banner-HD.jpeg 2x, https://example.com/banner-phone.jpeg 100w, https://example.com/banner-phone-HD.jpeg 100w 2x', $result);
+	}
+
+
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/84
+	 */
+	public function testRelativeURLResolvedWithFinalURL() {
+		$mf = Mf2\fetch('http://aaron.pk/4Zn5');
+
+		$this->assertEquals('https://aaronparecki.com/2014/12/23/5/photo.jpeg', $mf['items'][0]['properties']['photo'][0]);
+	}
+	
+	public function testScriptTagContentsRemovedFromTextValue() {
+		$input = <<<EOT
+<div class="h-entry">
+	<div class="p-content">
+		<b>Hello World</b>
+		<script>alert("hi");</script>
+	</div>
+</div>
+EOT;
+
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertContains('h-entry', $output['items'][0]['type']);
+		$this->assertContains('Hello World', $output['items'][0]['properties']['content'][0]);
+		$this->assertNotContains('alert', $output['items'][0]['properties']['content'][0]);
+	}
+	
+	public function testScriptElementContentsRemovedFromAllPlaintextValues() {
+		$input = <<<EOT
+<div class="h-entry">
+	<span class="dt-published">contained<script>not contained</script><style>not contained</style></span>
+	<span class="u-url">contained<script>not contained</script><style>not contained</style></span>
+</div>
+EOT;
+
+		$parser = new Parser($input);
+		$output = $parser->parse();
+		
+		$this->assertNotContains('not contained', $output['items'][0]['properties']['published'][0]);
+		$this->assertNotContains('not contained', $output['items'][0]['properties']['url'][0]);
+	}
+
+	public function testScriptTagContentsNotRemovedFromHTMLValue() {
+		$input = <<<EOT
+<div class="h-entry">
+	<div class="e-content">
+		<b>Hello World</b>
+		<script>alert("hi");</script>
+		<style>body{ visibility: hidden; }</style>
+		<p>
+			<script>alert("hi");</script>
+			<style>body{ visibility: hidden; }</style>
+		</p>
+	</div>
+</div>
+EOT;
+
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertContains('h-entry', $output['items'][0]['type']);
+		$this->assertContains('Hello World', $output['items'][0]['properties']['content'][0]['value']);
+		$this->assertContains('<b>Hello World</b>', $output['items'][0]['properties']['content'][0]['html']);
+		# The script and style tags should be removed from plaintext results but left in HTML results.
+		$this->assertContains('alert', $output['items'][0]['properties']['content'][0]['html']);
+		$this->assertNotContains('alert', $output['items'][0]['properties']['content'][0]['value']);
+		$this->assertContains('visibility', $output['items'][0]['properties']['content'][0]['html']);
+		$this->assertNotContains('visibility', $output['items'][0]['properties']['content'][0]['value']);
+	}
+	
+	public function testWhitespaceBetweenElements() {
+		$input = <<<EOT
+<div class="h-entry">
+	<data class="p-rsvp" value="yes">I'm attending</data>
+	<a class="u-in-reply-to" href="https://snarfed.org/2014-06-16_homebrew-website-club-at-quip">Homebrew Website Club at Quip</a>
+	<div class="p-content">Thanks for hosting!</div>
+</div>
+EOT;
+
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertContains('h-entry', $output['items'][0]['type']);
+		$this->assertNotContains('attendingHomebrew', $output['items'][0]['properties']['name'][0]);
 	}
 }

--- a/external/mf2/tests/Mf2/URLTest.php
+++ b/external/mf2/tests/Mf2/URLTest.php
@@ -212,9 +212,6 @@ class UrlTest extends PHPUnit_Framework_TestCase {
 			array('relative add host from base',
 				'http://www.example.com', 'server.php', 'http://www.example.com/server.php'),
 
-			array('relative add scheme host user from base',
-				'http://user:@www.example.com', 'server.php', 'http://user:@www.example.com/server.php'),
-
 			array('relative add scheme host pass from base',
 				'http://:pass@www.example.com', 'server.php', 'http://:pass@www.example.com/server.php'),
 
@@ -249,9 +246,21 @@ class UrlTest extends PHPUnit_Framework_TestCase {
 				'http://www.example.com/pathOne/', './jquery.js', 'http://www.example.com/pathOne/jquery.js'),
 
 			array('testAbsolutePathHasDotDirecoryAndSourceHasDirectoryWithoutTrailingSlash',
-				'http://www.example.com/pathOne', './jquery.js', 'http://www.example.com/jquery.js')
+				'http://www.example.com/pathOne', './jquery.js', 'http://www.example.com/jquery.js'),
+
+			array('testAbsolutePathIncludesPortNumber',
+				'http://example.com:8080/index.html', '/photo.jpg', 'http://example.com:8080/photo.jpg')
 
 		);
+
+		// PHP 5.4 and before returns a different result, but either are acceptable
+		if(PHP_MAJOR_VERSION <= 5 && PHP_MINOR_VERSION <= 4) {
+			$cases[] = array('relative add scheme host user from base',
+				'http://user:@www.example.com', 'server.php', 'http://user@www.example.com/server.php');
+		} else {
+			$cases[] = array('relative add scheme host user from base',
+				'http://user:@www.example.com', 'server.php', 'http://user:@www.example.com/server.php');
+		}
 
 		// Test cases from RFC
 		// http://tools.ietf.org/html/rfc3986#section-5.4

--- a/external/mf2/tests/test-suite/test-suite-data/adr/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/adr/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="adr">665 3rd St. Suite 207 San Francisco, CA 94107 U.S.A.</p>

--- a/external/mf2/tests/test-suite/test-suite-data/adr/simpleproperties/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/adr/simpleproperties/input.html
@@ -1,0 +1,8 @@
+<p class="adr">
+    <span class="street-address">665 3rd St.</span>  
+    <span class="extended-address">Suite 207</span>  
+    <span class="locality">San Francisco</span>,  
+    <span class="region">CA</span>  
+    <span class="postal-code">94107</span>  
+    <span class="country-name">U.S.A.</span>  
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/geo/abbrpattern/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/geo/abbrpattern/input.html
@@ -1,0 +1,4 @@
+<p class="geo">
+ <abbr class="latitude" title="37.408183">N 37° 24.491</abbr>,  
+ <abbr class="longitude" title="-122.13855">W 122° 08.313</abbr>
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/geo/hidden/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/geo/hidden/input.html
@@ -1,0 +1,10 @@
+<p>
+    <span class="geo">The Bricklayer's Arms
+        <span class="latitude">
+            <span class="value-title" title="51.513458"> </span> 
+        </span>
+        <span class="longitude">
+            <span class="value-title" title="-0.14812"> </span>
+        </span>
+    </span>
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/geo/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/geo/justaname/input.html
@@ -1,0 +1,3 @@
+<p>On my way to The Bricklayer's Arms
+    (Geo: <span class="geo">51.513458;-0.14812</span>)
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/geo/simpleproperties/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/geo/simpleproperties/input.html
@@ -1,0 +1,6 @@
+We are meeting at 
+<span class="geo"> 
+    <span>The Bricklayer's Arms</span>
+    (Geo: <span class="p-latitude">51.513458</span>:
+    <span class="p-longitude">-0.14812</span>)
+</span>

--- a/external/mf2/tests/test-suite/test-suite-data/geo/valuetitleclass/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/geo/valuetitleclass/input.html
@@ -1,0 +1,10 @@
+<p>
+    <span class="geo">
+        <span class="latitude">
+            <span class="value-title" title="51.513458">N 51° 51.345</span>, 
+        </span>
+        <span class="longitude">
+            <span class="value-title" title="-0.14812">W -0° 14.812</span>
+        </span>
+    </span>
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-adr/geo/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-adr/geo/input.html
@@ -1,0 +1,10 @@
+<p class="h-adr">
+    <span class="p-name">Bricklayer's Arms</span>
+    <span class="p-label"> 
+        <span class="p-street-address">3 Charlotte Road</span>,  
+        <span class="p-locality">City of London</span>,  
+        <span class="p-postal-code">EC2A 3PE</span>, 
+        <span class="p-country-name">UK</span> 
+    </span> – 
+    Geo:(<span class="p-geo">51.526421;-0.081067</span>) 
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-adr/geourl/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-adr/geourl/input.html
@@ -1,0 +1,4 @@
+<p class="h-adr">
+    <a class="p-name u-geo" href="geo:51.526421;-0.081067;crs=wgs84;u=40">Bricklayer's Arms</a>, 
+    <span class="p-locality">London</span> 
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-adr/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-adr/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="h-adr">665 3rd St. Suite 207 San Francisco, CA 94107 U.S.A.</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-adr/simpleproperties/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-adr/simpleproperties/input.html
@@ -1,0 +1,8 @@
+<p class="h-adr">
+    <span class="p-street-address">665 3rd St.</span>  
+    <span class="p-extended-address">Suite 207</span>  
+    <span class="p-locality">San Francisco</span>,  
+    <span class="p-region">CA</span>  
+    <span class="p-postal-code">94107</span>  
+    <span class="p-country-name">U.S.A.</span>  
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-card/childimplied/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-card/childimplied/input.html
@@ -1,0 +1,6 @@
+<a class="h-card" href="http://people.opera.com/howcome/" title="Håkon Wium Lie, CTO Opera">
+  <article>
+     <h2 class="p-name">Håkon Wium Lie</h2>
+     <img src="http://upload.wikimedia.org/wikipedia/commons/thumb/9/96/H%C3%A5kon-Wium-Lie-2009-03.jpg/215px-H%C3%A5kon-Wium-Lie-2009-03.jpg" />
+  </article>
+</a>

--- a/external/mf2/tests/test-suite/test-suite-data/h-card/extendeddescription/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-card/extendeddescription/input.html
@@ -1,0 +1,10 @@
+<div class="h-card">
+  <img class="u-photo" alt="photo of Mitchell" src="http://blog.mozilla.org/press/files/2012/04/mitchell-baker.jpg" />
+  <p>
+    <a class="p-name u-url" href="http://blog.lizardwrangler.com/">Mitchell Baker</a>
+    (<a class="u-url" href="https://twitter.com/MitchellBaker">@MitchellBaker</a>)
+    <span class="p-org">Mozilla Foundation</span>
+  </p>
+  <p class="p-note">Mitchell is responsible for setting the direction and scope of the Mozilla Foundation and its activities.</p>
+  <p><span class="p-category">Strategy</span> and <span class="p-category">Leadership</span></p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-card/hcard/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-card/hcard/input.html
@@ -1,0 +1,4 @@
+<div class="h-card">
+  <a class="p-name u-url" href="http://blog.lizardwrangler.com/">Mitchell Baker</a> 
+  (<a class="p-org h-card" href="http://mozilla.org/">Mozilla Foundation</a>)
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-card/horghcard/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-card/horghcard/input.html
@@ -1,0 +1,4 @@
+<div class="h-card">
+  <a class="p-name u-url" href="http://blog.lizardwrangler.com/">Mitchell Baker</a> 
+  (<a class="p-org h-card h-org" href="http://mozilla.org/">Mozilla Foundation</a>)
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-card/hyperlinkedphoto/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-card/hyperlinkedphoto/input.html
@@ -1,0 +1,3 @@
+<a class="h-card" href="http://rohit.khare.org/">
+   <img alt="Rohit Khare" src="https://twimg0-a.akamaihd.net/profile_images/53307499/180px-Rohit-sq.jpg" />
+</a>

--- a/external/mf2/tests/test-suite/test-suite-data/h-card/justahyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-card/justahyperlink/input.html
@@ -1,0 +1,1 @@
+<a class="h-card" href="http://benward.me/">Ben Ward</a>

--- a/external/mf2/tests/test-suite/test-suite-data/h-card/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-card/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="h-card">Frances Berriman</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-card/nested/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-card/nested/input.html
@@ -1,0 +1,4 @@
+<div class="h-card">
+  <a class="p-name u-url" href="http://blog.lizardwrangler.com/">Mitchell Baker</a> 
+  (<a class="h-org h-card" href="http://mozilla.org/">Mozilla Foundation</a>)
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-card/p-property/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-card/p-property/input.html
@@ -1,0 +1,21 @@
+<div class="h-card">
+    <!-- innerText and value pattern -->
+    <span class="p-name">
+        <span class="p-given-name value">John</span> 
+        <abbr class="p-additional-name" title="Peter">P</abbr>  
+        <span class="p-family-name value ">Doe</span> 
+    </span>
+    <data class="p-honorific-suffix" value="MSc"></data>
+    
+    <!-- theses should return no value -->
+    <br class="p-honorific-suffix">BSc</br>
+    <hr class="p-honorific-suffix">BA</hr>
+    
+    <!-- image and area tags -->
+    <img class="p-honorific-suffix" src="images/logo.gif" alt="PHD" />
+    <img src="images/logo.gif" alt="company logos" usemap="#logomap" />
+    <map name="logomap">
+        <area class="p-org" shape="rect" coords="0,0,82,126" href="madgex.htm" alt="Madgex" />
+        <area class="p-org" shape="circle" coords="90,58,3" href="mozilla.htm" alt="Mozilla" />
+    </map>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-entry/justahyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-entry/justahyperlink/input.html
@@ -1,0 +1,1 @@
+<a class="h-entry" href="http://microformats.org/2012/06/25/microformats-org-at-7">microformats.org at 7</a>

--- a/external/mf2/tests/test-suite/test-suite-data/h-entry/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-entry/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="h-entry">microformats.org at 7</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-entry/summarycontent/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-entry/summarycontent/input.html
@@ -1,0 +1,19 @@
+<div class="h-entry">
+    <h1><a class="p-name u-url" href="http://microformats.org/2012/06/25/microformats-org-at-7">microformats.org at 7</a></h1>
+    <div class="e-content">
+        <p class="p-summary">Last week the microformats.org community 
+            celebrated its 7th birthday at a gathering hosted by Mozilla in 
+            San Francisco and recognized accomplishments, challenges, and 
+            opportunities.</p>
+
+        <p>The microformats tagline “humans first, machines second” 
+            forms the basis of many of our 
+            <a href="http://microformats.org/wiki/principles">principles</a>, and 
+            in that regard, we’d like to recognize a few people and 
+            thank them for their years of volunteer service </p>
+    </div>  
+    <p>Updated 
+        <time class="dt-updated" datetime="2012-06-25T17:08:26">June 25th, 2012</time> by
+        <a class="p-author h-card" href="http://tantek.com/">Tantek</a>
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-entry/u-property/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-entry/u-property/input.html
@@ -1,0 +1,28 @@
+<div class="h-entry">
+    <p class="p-name">microformats.org at 7</p>
+
+    <!-- value and value-title patterns -->
+    <p class="u-url">
+      <span class="value-title" title="http://microformats.org/"> </span>
+      Article permalink
+    </p>
+    <p class="u-url">
+        <span class="value">http://microformats.org/</span> - 
+        <span class="value">2012/06/25/microformats-org-at-7</span> 
+    </p> 
+
+    <p><a class="u-url" href="http://microformats.org/2012/06/25/microformats-org-at-7">Article permalink</a></p>
+
+    <img src="images/logo.gif" alt="company logos" usemap="#logomap" />
+    <map name="logomap">
+        <area class="u-url" shape="rect" coords="0,0,82,126" href="http://microformats.org/" alt="microformats.org" />
+    </map>
+
+    <img class="u-photo" src="images/logo.gif" alt="company logos" />
+
+    <object class="u-url" data="http://microformats.org/wiki/microformats2-parsing"></object>
+
+    <abbr class="u-url" title="http://microformats.org/wiki/value-class-pattern">value-class-pattern</abbr> 
+    <data class="u-url" value="http://microformats.org/wiki/"></data>
+    <p class="u-url">http://microformats.org/discuss</p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-event/ampm/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-event/ampm/input.html
@@ -1,0 +1,41 @@
+<span class="h-event">
+    <span class="p-name">The 4th Microformat party</span> will be on 
+    <ul>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07:00:00pm 
+        </span></li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07:00:00am 
+        </span></li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07:00pm 
+        </span></li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07pm 
+        </span></li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">7pm 
+        </span></li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">7:00pm 
+        </span></li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07:00p.m. 
+        </span></li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07:00PM 
+        </span></li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">7:00am 
+        </span></li>
+    </ul>
+</span>

--- a/external/mf2/tests/test-suite/test-suite-data/h-event/attendees/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-event/attendees/input.html
@@ -1,0 +1,12 @@
+<div class="h-event">       
+    <span class="p-name">CPJ Online Press Freedom Summit</span> 
+    (<time class="dt-start" datetime="2012-10-10">10 Nov 2012</time>) in 
+    <span class="p-location">San Francisco</span>. 
+    Attendees:
+    <ul>
+        <li class="p-attendee h-card">Brian Warner</li>
+        <li class="p-attendee h-card">Kyle Machulis</li>
+        <li class="p-attendee h-card">Tantek Çelik</li>
+        <li class="p-attendee h-card">Sid Sutter</li>
+    </ul>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-event/combining/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-event/combining/input.html
@@ -1,0 +1,13 @@
+<div class="h-event">
+  <a class="p-name u-url" href="http://indiewebcamp.com/2012">
+    IndieWebCamp 2012
+  </a>
+  from <time class="dt-start">2012-06-30</time> 
+  to <time class="dt-end">2012-07-01</time> at 
+  <span class="p-location h-card">
+    <a class="p-name p-org u-url" href="http://geoloqi.com/">Geoloqi</a>, 
+    <span class="p-street-address">920 SW 3rd Ave. Suite 400</span>, 
+    <span class="p-locality">Portland</span>, 
+    <abbr class="p-region" title="Oregon">OR</abbr>
+  </span>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-event/concatenate/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-event/concatenate/input.html
@@ -1,0 +1,7 @@
+<span class="h-event">
+ <span class="p-name">The 4th Microformat party</span> will be on 
+ <span class="dt-start">
+  <time class="value" datetime="2009-06-26">26 July</time>, from
+  <time class="value">19:00</time></span> to 
+ <span class="dt-end"><time class="value">22:00</time></span>.
+</span>

--- a/external/mf2/tests/test-suite/test-suite-data/h-event/dt-property/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-event/dt-property/input.html
@@ -1,0 +1,23 @@
+<span class="h-event">
+    <span class="p-name">The party</span> will be on 
+    <!-- value and value-title patterns -->
+    <p class="dt-start">
+      <span class="value-title" title="2013-03-14"> </span>
+      March 14th 2013
+    </p>
+    <p class="dt-start">
+        <time class="value" datetime="2013-06-25">25 July</time>, from
+        <span class="value">07:00:00am 
+    </span></p>   
+    <!-- elements with datetime attribute -->
+    <p>
+        <time class="dt-start" datetime="2013-06-26">26 June</time>
+        
+        <ins class="dt-start" datetime="2013-06-27">Just added</ins>, 
+        <del class="dt-start" datetime="2013-06-28">Removed</del>
+    </p>
+    <abbr class="dt-start" title="2013-06-29">June 29</abbr> 
+    <data class="dt-start" value="2013-07-01"></data>
+    <p class="dt-start">2013-07-02</p>
+    
+</span>

--- a/external/mf2/tests/test-suite/test-suite-data/h-event/justahyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-event/justahyperlink/input.html
@@ -1,0 +1,1 @@
+<a class="h-event" href="http://indiewebcamp.com/2012">IndieWebCamp 2012</a>

--- a/external/mf2/tests/test-suite/test-suite-data/h-event/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-event/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="h-event">IndieWebCamp 2012</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-event/time/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-event/time/input.html
@@ -1,0 +1,47 @@
+<span class="h-event">
+    <span class="p-name">The 4th Microformat party</span> will be on 
+    <ul>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00:00-08:00</time> 
+        </li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00:00-0800</time> 
+        </li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00:00+0800</time> 
+        </li> 
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00:00Z</time> 
+        </li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00:00</time> 
+        </li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00-08:00</time> 
+        </li> 
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00+08:00</time> 
+        </li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00Z</time> 
+        </li>
+        <li class="dt-start">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00</time> 
+        </li>  
+        <li>
+            <time class="dt-end" datetime="2013-034">3 February 2013</time>
+        </li>
+        <li>
+            <time class="dt-end" datetime="2013-06-27 15:34">26 July 2013</time>
+        </li>              
+    </ul>
+</span>

--- a/external/mf2/tests/test-suite/test-suite-data/h-geo/abbrpattern/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-geo/abbrpattern/input.html
@@ -1,0 +1,4 @@
+<p class="h-geo">
+ <abbr class="p-latitude" title="37.408183">N 37° 24.491</abbr>,  
+ <abbr class="p-longitude" title="-122.13855">W 122° 08.313</abbr>
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-geo/altitude/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-geo/altitude/input.html
@@ -1,0 +1,8 @@
+<p>My favourite hill in the lakes is 
+    <span class="h-geo">
+        <span class="p-name">Pen-y-ghent</span> 
+        (Geo: <span class="p-latitude">54.155278</span>,
+        <span class="p-longitude">-2.249722</span>). It
+        raises to <span class="p-altitude">694</span>m.
+  </span>
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-geo/hidden/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-geo/hidden/input.html
@@ -1,0 +1,10 @@
+<p>
+    <span class="h-geo">The Bricklayer's Arms
+        <span class="p-latitude">
+            <span class="value-title" title="51.513458"> </span> 
+        </span>
+        <span class="p-longitude">
+            <span class="value-title" title="-0.14812"> </span>
+        </span>
+    </span>
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-geo/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-geo/justaname/input.html
@@ -1,0 +1,3 @@
+<p>On my way to The Bricklayer's Arms
+    (Geo: <span class="h-geo">51.513458;-0.14812</span>)
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-geo/simpleproperties/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-geo/simpleproperties/input.html
@@ -1,0 +1,5 @@
+<p class="h-geo">We are meeting at 
+    <span class="p-name">The Bricklayer's Arms</span>
+    (Geo: <span class="p-latitude">51.513458</span>:
+    <span class="p-longitude">-0.14812</span>)
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-geo/valuetitleclass/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-geo/valuetitleclass/input.html
@@ -1,0 +1,10 @@
+<p>
+    <span class="h-geo">
+        <span class="p-latitude">
+            <span class="value-title" title="51.513458">N 51° 51.345</span>, 
+        </span>
+        <span class="p-longitude">
+            <span class="value-title" title="-0.14812">W -0° 14.812</span>
+        </span>
+    </span>
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-news/all/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-news/all/input.html
@@ -1,0 +1,35 @@
+<div class="h-news">
+    <div class="p-entry h-entry">
+        <h1><a class="p-name u-url" href="http://microformats.org/2012/06/25/microformats-org-at-7">microformats.org at 7</a></h1>
+        <div class="e-content">
+            <p class="p-summary">Last week the microformats.org community 
+                celebrated its 7th birthday at a gathering hosted by Mozilla in 
+                San Francisco and recognized accomplishments, challenges, and 
+                opportunities.</p>
+
+            <p>The microformats tagline “humans first, machines second” 
+                forms the basis of many of our 
+                <a href="http://microformats.org/wiki/principles">principles</a>, and 
+                in that regard, we’d like to recognize a few people and 
+                thank them for their years of volunteer service </p>
+        </div>  
+        <p>Updated 
+            <time class="dt-updated" datetime="2012-06-25T17:08:26">June 25th, 2012</time> by
+            <a class="p-author h-card" href="http://tantek.com/">Tantek</a>
+        </p>
+    </div>
+
+    <p>
+        <span class="p-dateline h-adr">
+            <span class="p-locality">San Francisco</span>, 
+            <span class="p-region">CA</span> 
+        </span>
+        (Geo: <span class="p-geo">37.774921;-122.445202</span>) 
+        <span class="p-source-org h-card">
+            <a class="p-name u-url" href="http://microformats.org/">microformats.org</a>
+        </span>
+    </p>
+    <p>
+        <a class="u-principles" href="http://microformats.org/wiki/Category:public_domain_license">Publishing policy</a>
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-news/minimum/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-news/minimum/input.html
@@ -1,0 +1,24 @@
+<div class="h-news">
+    <div class="p-entry h-entry">
+        <h1><a class="p-name u-url" href="http://microformats.org/2012/06/25/microformats-org-at-7">microformats.org at 7</a></h1>
+        <div class="e-content">
+            <p class="p-summary">Last week the microformats.org community 
+                celebrated its 7th birthday at a gathering hosted by Mozilla in 
+                San Francisco and recognized accomplishments, challenges, and 
+                opportunities.</p>
+
+            <p>The microformats tagline “humans first, machines second” 
+                forms the basis of many of our 
+                <a href="http://microformats.org/wiki/principles">principles</a>, and 
+                in that regard, we’d like to recognize a few people and 
+                thank them for their years of volunteer service </p>
+        </div>  
+        <p>Updated 
+            <time class="dt-updated" datetime="2012-06-25T17:08:26">June 25th, 2012</time> by
+            <a class="p-author h-card" href="http://tantek.com/">Tantek</a>
+        </p>
+    </div>
+    <p>
+        <a class="p-source-org h-card" href="http://microformats.org/">microformats.org</a> 
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-org/hyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-org/hyperlink/input.html
@@ -1,0 +1,1 @@
+<a class="h-org" href="http://mozilla.org/">Mozilla Foundation</a>

--- a/external/mf2/tests/test-suite/test-suite-data/h-org/simple/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-org/simple/input.html
@@ -1,0 +1,1 @@
+<span class="h-org">Mozilla Foundation</span>

--- a/external/mf2/tests/test-suite/test-suite-data/h-org/simpleproperties/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-org/simpleproperties/input.html
@@ -1,0 +1,4 @@
+<p class="h-org">
+    <span class="p-organization-name">W3C</span> - 
+    <span class="p-organization-unit">CSS Working Group</span>
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-product/aggregate/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-product/aggregate/input.html
@@ -1,0 +1,20 @@
+<div class="h-product">
+    <h2 class="p-name">Raspberry Pi</h2>
+    <img class="u-photo" src="http://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/RaspberryPi.jpg/320px-RaspberryPi.jpg" />
+    <p class="e-description">The Raspberry Pi is a credit-card sized computer that plugs into your TV and a keyboard. It’s a capable little PC which can be used for many of the things that your desktop PC does, like spreadsheets, word-processing and games. It also plays high-definition video. We want to see it being used by kids all over the world to learn programming.</p>
+    <a class="u-url" href="http://www.raspberrypi.org/">More info about the Raspberry Pi</a>
+    <p class="p-price">£29.95</p>
+    <p class="p-review h-review-aggregate">
+        <span class="p-rating h-rating">
+            <span class="p-average">9.2</span> out of 
+            <span class="p-best">10</span> 
+            based on <span class="p-count">178</span> reviews
+        </span>
+    </p>
+    <p>Categories: <span class="p-category">Computer</span>, <span class="p-category">Education</span></p>
+    <p class="p-brand h-card">From: 
+        <span class="p-name p-org">The Raspberry Pi Foundation</span> - 
+        <span class="p-locality">Cambridge</span> 
+        <span class="p-country-name">UK</span>
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-product/justahyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-product/justahyperlink/input.html
@@ -1,0 +1,1 @@
+<a class="h-product" href="http://www.raspberrypi.org/">Raspberry Pi</a>

--- a/external/mf2/tests/test-suite/test-suite-data/h-product/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-product/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="h-product">Raspberry Pi</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-product/simpleproperties/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-product/simpleproperties/input.html
@@ -1,0 +1,9 @@
+<div class="h-product">
+    <h2 class="p-name">Raspberry Pi</h2>
+    <img class="u-photo" src="http://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/RaspberryPi.jpg/320px-RaspberryPi.jpg" />
+    <p class="e-description">The Raspberry Pi is a credit-card sized computer that plugs into your TV and a keyboard. It’s a capable little PC which can be used for many of the things that your desktop PC does, like spreadsheets, word-processing and games. It also plays high-definition video. We want to see it being used by kids all over the world to learn programming.</p>
+    <a class="u-url" href="http://www.raspberrypi.org/">More info about the Raspberry Pi</a>
+    <p class="p-price">£29.95</p>
+    <p class="p-review h-review"><span class="p-rating">4.5</span> out of 5</p>
+    <p>Categories: <span class="p-category">Computer</span>, <span class="p-category">Education</span></p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-recipe/all/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-recipe/all/input.html
@@ -1,0 +1,63 @@
+<section class="hrecipe">
+    <h1 class="p-name">Yorkshire Puddings</h1>      
+    <p class="p-summary">Makes <span class="p-yield">6 good sized Yorkshire puddings</span>, the way my mum taught me</p>
+
+
+    <p><img class="u-photo" src="http://codebits.glennjones.net/semantic/yorkshire-puddings.jpg" /></p>
+
+    <span class="p-review h-review-aggregate">
+        <span class="p-rating">
+            <span class="p-average">4.5</span> stars out 5 based on </span>
+            <span class="p-count">35</span> reviews</span>
+         
+    
+
+    <div id="ingredients-container">
+        <h3>Ingredients</h3>
+        <ul>
+            <li class="e-ingredient">1 egg</li>
+            <li class="e-ingredient">75g plain flour</li>
+            <li class="e-ingredient">70ml milk</li>
+            <li class="e-ingredient">60ml water</li>
+            <li class="e-ingredient">Pinch of salt</li>
+        </ul>
+    </div>
+
+    <h3>Time</h3>
+    <ul>
+        <li class="prepTime">Preparation <span class="value-title" title="PT0H10M">10 mins</span></li>
+        <li class="cookTime">Cook <span class="value-title" title="PT0H25M">25 mins</span></li>
+    </ul> 
+
+
+    <h3>Instructions</h3>
+    <div class="e-instructions">
+        <ol>
+            <li>Pre-heat oven to 230C or gas mark 8. Pour the vegetable oil evenly into 2 x 4-hole 
+            Yorkshire pudding tins and place in the oven to heat through.</li> 
+            
+            <li>To make the batter, add all the flour into a bowl and beat in the eggs until smooth. 
+            Gradually add the milk and water while beating the mixture. It should be smooth and 
+            without lumps. Finally add a pinch of salt.</li>
+            
+            <li>Make sure the oil is piping hot before pouring the batter evenly into the tins. 
+            Place in the oven for 20-25 minutes until pudding have risen and look golden brown</li>
+        </ol>
+    </div>
+
+    <h3>Nutrition</h3>
+    <ul id="nutrition-list">
+        <li class="nutrition">Calories: <span class="calories">125</span></li>
+        <li class="nutrition">Fat: <span class="fat">3.2g</span></li>
+        <li class="nutrition">Cholesterol: <span class="cholesterol">77mg</span></li>
+    </ul>
+    <p>(Amount per pudding)</p>
+
+    <p>
+        Published on <time class="dt-published" datetime="2011-10-27">27 Oct 2011</time> by 
+        <span class="p-author h-card">
+            <a class="p-name u-url" href="http://glennjones.net">Glenn Jones</a>
+        </span>
+    </p>
+    <a href="http://www.flickr.com/photos/dithie/4106528495/">Photo by dithie</a>
+    </section>

--- a/external/mf2/tests/test-suite/test-suite-data/h-recipe/minimum/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-recipe/minimum/input.html
@@ -1,0 +1,7 @@
+<div class="h-recipe">  
+    <p class="p-name">Toast</p>
+    <ul>
+        <li class="e-ingredient">Slice of bread</li>
+        <li class="e-ingredient">Butter</li>
+    </ul>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-resume/affiliation/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-resume/affiliation/input.html
@@ -1,0 +1,12 @@
+<div class="h-resume">
+    <p>
+        <span class="p-name">Tim Berners-Lee</span>, 
+        <span class="p-summary">invented the World Wide Web</span>. 
+    </p> 
+    Belongs to following groups:
+    <p>   
+        <a class="p-affiliation h-card" href="http://www.w3.org/">
+            <img class="p-name u-photo" alt="W3C" src="http://www.w3.org/Icons/WWW/w3c_home_nb.png" />
+        </a>
+    </p>   
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-resume/contact/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-resume/contact/input.html
@@ -1,0 +1,17 @@
+<div class="h-resume">
+    <p class="p-name">Tim Berners-Lee</p>
+    <p class="p-summary">Invented the World Wide Web.</p><hr />
+    <div class="p-contact h-card">
+        <p class="p-name">MIT</p>
+        <p>
+            <span class="p-street-address">32 Vassar Street</span>, 
+            <span class="p-extended-address">Room 32-G524</span>, 
+            <span class="p-locality">Cambridge</span>,  
+            <span class="p-region">MA</span> 
+            <span class="p-postal-code">02139</span>, 
+            <span class="p-country-name">USA</span>.
+        </p>
+        <p>Tel:<span class="p-tel">+1 (617) 253 5702</span></p>
+        <p>Email:<a class="u-email" href="mailto:timbl@w3.org">timbl@w3.org</a></p>
+    </div>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-resume/education/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-resume/education/input.html
@@ -1,0 +1,13 @@
+<div class="h-resume">
+    <p class="p-name">Tim Berners-Lee</p>
+    <div class="p-contact h-card">
+        <p class="p-title">Director of the World Wide Web Foundation</p>
+    </div>
+    <p class="p-summary">Invented the World Wide Web.</p><hr />
+    <p class="p-education h-event h-card">
+        <span class="p-name p-org">The Queen's College, Oxford University</span>, 
+        <span class="p-description">BA Hons (I) Physics</span> 
+        <time class="dt-start" datetime="1973-09">1973</time> –
+        <time class="dt-end" datetime="1976-06">1976</time>
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-resume/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-resume/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="h-resume">Tim Berners-Lee, invented the World Wide Web.</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-resume/skill/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-resume/skill/input.html
@@ -1,0 +1,12 @@
+<div class="h-resume">
+    <p>
+        <span class="p-name">Tim Berners-Lee</span>, 
+        <span class="p-summary">invented the World Wide Web</span>.
+    </p>
+    Skills:     
+    <ul>
+        <li class="p-skill">information systems</li>
+        <li class="p-skill">advocacy</li>
+        <li class="p-skill">leadership</li>
+    <ul>   
+</ul></ul></div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-resume/work/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-resume/work/input.html
@@ -1,0 +1,15 @@
+<div class="h-resume">
+    <p class="p-name">Tim Berners-Lee</p>
+    <div class="p-contact h-card">
+        <p class="p-title">Director of the World Wide Web Foundation</p>
+    </div>
+    <p class="p-summary">Invented the World Wide Web.</p><hr />
+    <div class="p-experience h-event h-card">
+        <p class="p-title">Director</p>
+        <p><a class="p-name p-org u-url" href="http://www.webfoundation.org/">World Wide Web Foundation</a></p>
+        <p>
+            <time class="dt-start" datetime="2009-01-18">Jan 2009</time> – Present
+            <time class="dt-duration" datetime="P2Y11M">(2 years 11 month)</time>
+        </p>
+    </div>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-review-aggregate/hevent/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-review-aggregate/hevent/input.html
@@ -1,0 +1,13 @@
+<div class="h-review-aggregate">
+    <div class="p-item h-event">
+        <h3 class="p-name">Fullfrontal</h3>
+        <p class="p-description">A one day JavaScript Conference held in Brighton</p>
+        <p><time class="dt-start" datetime="2012-11-09">9th November 2012</time></p>    
+    </div> 
+    
+    <p class="p-rating">
+        <span class="p-average value">9.9</span> out of 
+        <span class="p-best">10</span> 
+        based on <span class="p-count">62</span> reviews
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-review-aggregate/justahyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-review-aggregate/justahyperlink/input.html
@@ -1,0 +1,8 @@
+<div class="h-review-aggregate">
+    <h3 class="p-item h-item">Mediterranean Wraps</h3>
+     <span class="p-summary">
+        Customers flock to this small restaurant for their 
+        tasty falafel and shawerma wraps and welcoming staff.
+    </span>
+    <span class="p-rating">4.5</span> out of 5 
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-review-aggregate/simpleproperties/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-review-aggregate/simpleproperties/input.html
@@ -1,0 +1,18 @@
+<div class="hreview-aggregate">
+    <div class="p-item h-card">
+        <h3 class="p-name">Mediterranean Wraps</h3>
+        <p>
+            <span class="p-street-address">433 S California Ave</span>, 
+            <span class="p-locality">Palo Alto</span>, 
+            <span class="p-region">CA</span> - 
+            <span class="p-tel">(650) 321-8189</span>
+        </p>
+    </div> 
+    <span class="p-summary">Customers flock to this small restaurant for their 
+    tasty falafel and shawerma wraps and welcoming staff.</span>
+    <span class="p-rating">
+        <span class="p-average value">9.2</span> out of 
+        <span class="p-best">10</span> 
+        based on <span class="p-count">17</span> reviews
+    </span>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-review/hyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-review/hyperlink/input.html
@@ -1,0 +1,1 @@
+<a class="h-review" href="https://plus.google.com/116941523817079328322/about">Crepes on Cole</a>

--- a/external/mf2/tests/test-suite/test-suite-data/h-review/implieditem/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-review/implieditem/input.html
@@ -1,0 +1,4 @@
+<div class="h-review">
+    <a class="p-item h-item" href="http://example.com/crepeoncole">Crepes on Cole</a>
+    <p><span class="rating">4.7</span> out of 5 stars</p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-review/item/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-review/item/input.html
@@ -1,0 +1,7 @@
+<div class="h-review">
+    <p class="p-item h-item">
+        <img class="u-photo" src="images/photo.gif" />
+        <a class="p-name u-url" href="http://example.com/crepeoncole">Crepes on Cole</a>
+    </p>
+    <p><span class="p-rating">5</span> out of 5 stars</p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/h-review/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-review/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="h-review">Crepes on Cole</p>

--- a/external/mf2/tests/test-suite/test-suite-data/h-review/photo/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-review/photo/input.html
@@ -1,0 +1,1 @@
+<img class="h-review" src="images/photo.gif" alt="Crepes on Cole" />

--- a/external/mf2/tests/test-suite/test-suite-data/h-review/vcard/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/h-review/vcard/input.html
@@ -1,0 +1,23 @@
+<div class="h-review">
+    <span><span class="p-rating">5</span> out of 5 stars</span>
+    <h4 class="p-name">Crepes on Cole is awesome</h4>
+    <span class="p-reviewer h-card">
+        Reviewer: <span class="p-name">Tantek</span> - 
+    </span>
+    <time class="dt-reviewed" datetime="2005-04-18">April 18, 2005</time>
+    <div class="e-description">
+        <p class="p-item h-card">
+        <span class="p-name p-org">Crepes on Cole</span> is one of the best little 
+        creperies in <span class="p-adr h-adr"><span class="p-locality">San Francisco</span></span>.
+        Excellent food and service. Plenty of tables in a variety of sizes 
+        for parties large and small.  Window seating makes for excellent 
+        people watching to/from the N-Judah which stops right outside.  
+        I've had many fun social gatherings here, as well as gotten 
+        plenty of work done thanks to neighborhood WiFi.
+        </p>
+    </div>
+    <p>Visit date: <span>April 2005</span></p>
+    <p>Food eaten: <a class="p-category" href="http://en.wikipedia.org/wiki/crepe">crepe</a></p>
+    <p>Permanent link for review: <a class="u-url" href="http://example.com/crepe">http://example.com/crepe</a></p>
+    <p><a rel="license" href="http://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License">Creative Commons Attribution-ShareAlike License</a></p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hcalendar/ampm/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcalendar/ampm/input.html
@@ -1,0 +1,41 @@
+<div class="vevent">
+    <span class="summary">The 4th Microformat party</span> will be on 
+    <ul>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07:00:00pm 
+        </span></li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07:00:00am 
+        </span></li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07:00pm 
+        </span></li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07pm 
+        </span></li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">7pm 
+        </span></li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">7:00pm 
+        </span></li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07:00p.m. 
+        </span></li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">07:00PM 
+        </span></li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <span class="value">7:00am 
+        </span></li>
+    </ul>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hcalendar/attendees/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcalendar/attendees/input.html
@@ -1,0 +1,12 @@
+<div class="vevent">       
+    <span class="summary">CPJ Online Press Freedom Summit</span> 
+    (<time class="dtstart" datetime="2012-10-10">10 Nov 2012</time>) in 
+    <span class="location">San Francisco</span>. 
+    Attendees:
+    <ul>
+        <li class="attendee vcard">Brian Warner</li>
+        <li class="attendee vcard">Kyle Machulis</li>
+        <li class="attendee vcard">Tantek Çelik</li>
+        <li class="attendee vcard">Sid Sutter</li>
+    </ul>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hcalendar/combining/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcalendar/combining/input.html
@@ -1,0 +1,15 @@
+<div class="vevent">
+  <a class="summary url" href="http://indiewebcamp.com/2012">
+    IndieWebCamp 2012
+  </a>
+  from <time class="dtstart">2012-06-30</time> 
+  to <time class="dtend">2012-07-01</time> at 
+  <span class="location vcard">
+    <a class="fn org url" href="http://geoloqi.com/">Geoloqi</a>, 
+    <span class="adr">
+        <span class="street-address">920 SW 3rd Ave. Suite 400</span>, 
+        <span class="locality">Portland</span>, 
+        <abbr class="region" title="Oregon">OR</abbr>
+    </span>
+  </span>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hcalendar/concatenate/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcalendar/concatenate/input.html
@@ -1,0 +1,7 @@
+<div class="vevent">
+ <span class="summary">The 4th Microformat party</span> will be on 
+ <span class="dtstart">
+  <time class="value" datetime="2009-06-26">26 July</time>, from
+  <time class="value">19:00</time></span> to 
+ <span class="dtend"><time class="value">22:00</time></span>.
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hcalendar/justahyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcalendar/justahyperlink/input.html
@@ -1,0 +1,1 @@
+<a class="vevent" href="http://indiewebcamp.com/2012">IndieWebCamp 2012</a>

--- a/external/mf2/tests/test-suite/test-suite-data/hcalendar/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcalendar/justaname/input.html
@@ -1,0 +1,1 @@
+<a class="vevent" href="http://indiewebcamp.com/2012">IndieWebCamp 2012</a>

--- a/external/mf2/tests/test-suite/test-suite-data/hcalendar/time/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcalendar/time/input.html
@@ -1,0 +1,44 @@
+<div class="vevent">
+    <span class="summary">The 4th Microformat party</span> will be on 
+    <ul>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00:00-08:00</time> 
+        </li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00:00-0800</time> 
+        </li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00:00+0800</time> 
+        </li> 
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00:00Z</time> 
+        </li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00:00</time> 
+        </li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00-08:00</time> 
+        </li> 
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00+08:00</time> 
+        </li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00Z</time> 
+        </li>
+        <li class="dtstart">
+            <time class="value" datetime="2009-06-26">26 July</time>, from
+            <time class="value">19:00</time> 
+        </li>  
+        <li>
+            <time class="dtend" datetime="2013-034">3 February 2013</time>
+        </li>              
+    </ul>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hcard/email/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcard/email/input.html
@@ -1,0 +1,14 @@
+<div class="vcard">
+    <span class="fn">John Doe</span> 
+    <ul>
+        <li><a class="email" href="mailto:john@example.com">notthis@example.com</a></li>
+        <li>
+            <span class="email">
+                <span class="type">internet</span> 
+                <a class="value" href="mailto:john@example.com">notthis@example.com</a>
+            </span>
+        </li> 
+        <li><a class="email" href="mailto:john@example.com?subject=parser-test">notthis@example.com</a></li>
+        <li class="email">john@example.com</li>
+    </ul>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hcard/format/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcard/format/input.html
@@ -1,0 +1,6 @@
+<p class="vcard">
+    <span class="profile-name fn n">
+        <span class=" given-name ">John</span> 
+        <span class="FAMILY-NAME">Doe</span> 
+    </span>
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/hcard/hyperlinkedphoto/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcard/hyperlinkedphoto/input.html
@@ -1,0 +1,3 @@
+<a class="vcard" href="http://rohit.khare.org/">
+   <img alt="Rohit Khare" src="https://twimg0-a.akamaihd.net/profile_images/53307499/180px-Rohit-sq.jpg" />
+</a>

--- a/external/mf2/tests/test-suite/test-suite-data/hcard/justahyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcard/justahyperlink/input.html
@@ -1,0 +1,1 @@
+<a class="vcard" href="http://benward.me/">Ben Ward</a>

--- a/external/mf2/tests/test-suite/test-suite-data/hcard/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcard/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="vcard">Frances Berriman</p>

--- a/external/mf2/tests/test-suite/test-suite-data/hcard/multiple/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcard/multiple/input.html
@@ -1,0 +1,73 @@
+<div class="vcard">
+    <!-- This may not be the best semantic use of HTML element -->
+    <div class="fn n"><span class="given-name">John</span> <span class="family-name">Doe</span></div>
+    <a class="sound" href="http://www.madgex.com/johndoe.mpeg">Pronunciation of my name</a>
+    <div><img class="photo" src="images/photo.gif" alt="Photo of John Doe" /></div>
+
+    <p>Nicknames:</p>
+    <ul>
+        <li class="nickname">Man with no name</li>
+        <li class="nickname">Lost boy</li>
+    </ul>
+
+    <p>About:</p>
+    <p class="note">John Doe is one of those names you always have issues with.</p>
+    <p class="note">It can be a real problem booking a hotel room with the name John Doe.</p>
+
+    <p>Companies:</p>
+    <div>
+        <img class="logo" src="images/logo.gif" alt="Madgex company logo" />
+        <img class="logo" src="images/logo.gif" alt="Web Feet Media company logo" />
+    </div>
+    <ul>
+        <li><a class="url org" href="http://www.madgex.com/">Madgex</a> <span class="title">Creative Director</span></li>
+        <li><a class="url org" href="http://www.webfeetmedia.com/">Web Feet Media Ltd</a> <span class="title">Owner</span></li>
+    </ul>
+    
+    <p>Tags: 
+    <a rel="tag" class="category" href="http://en.wikipedia.org/wiki/design">design</a>, 
+    <a rel="tag" class="category" href="http://en.wikipedia.org/wiki/development">development</a> and
+    <a rel="tag" class="category" href="http://en.wikipedia.org/wiki/web">web</a>
+    </p>
+    
+    <p>Phone numbers:</p>
+    <ul>
+        <li class="tel">
+            <span class="type">Work</span> (<span class="type">pref</span>erred):
+            <span class="value">+1 415 555 100</span>
+        </li>
+        <li class="tel"><span class="type">Home</span>: <span class="value">+1 415 555 200</span></li>
+        <li class="tel"><span class="type">Postal</span>: <span class="value">+1 415 555 300</span></li>
+    </ul>
+    
+    <p>Emails:</p>
+    <ul>
+        <li><a class="email" href="mailto:john.doe@madgex.com">John Doe at Madgex</a></li>
+        <li><a class="email" href="mailto:john.doe@webfeetmedia.com">John Doe at Web Feet Media</a></li>
+    </ul>
+    <p>John Doe uses <span class="mailer">PigeonMail 2.1</span> or <span class="mailer">Outlook 2007</span> for email.</p>
+
+    <p>Addresses:</p>
+    <ul>
+        <li class="label">
+            <span class="adr">
+                <span class="type">Work</span>: 
+                <span class="street-address">North Street</span>, 
+                <span class="locality">Brighton</span>, 
+                <span class="country-name">United Kingdom</span>
+            </span>
+            
+        </li>
+        <li class="label">
+            <span class="adr">
+                <span class="type">Home</span>: 
+                <span class="street-address">West Street</span>, 
+                <span class="locality">Brighton</span>, 
+                <span class="country-name">United Kingdom</span>
+            </span>
+        </li>
+    </ul>
+    
+    <p>In emergency contact: <span class="agent">Jane Doe</span> or <span class="agent vcard">Dave Doe</span>.</p>
+    <p>Key: <span class="key">hd02$Gfu*d%dh87KTa2=23934532479</span></p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hcard/name/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcard/name/input.html
@@ -1,0 +1,10 @@
+<div class="vcard">
+    <div class="name">
+        <span class="honorific-prefix">Dr</span> 
+        <span class="given-name">John</span> 
+        <abbr class="additional-name" title="Peter">P</abbr>  
+        <span class="family-name">Doe</span> 
+        <data class="honorific-suffix" value="MSc"></data>
+        <img class="honorific-suffix" src="images/logo.gif" alt="PHD" />
+    </div>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hcard/single/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hcard/single/input.html
@@ -1,0 +1,14 @@
+<div class="vcard">
+        <!-- This may not be the best semantic use of HTML element -->
+        <div class="fn n"><span class="given-name sort-string">John</span> Doe</div>
+        <div>Birthday: <abbr class="bday" title="2000-01-01T00:00:00-08:00">January 1st, 2000</abbr></div>
+        <div>Role: <span class="role">Designer</span></div>
+        <div>Location: <abbr class="geo" title="30.267991;-97.739568">Brighton</abbr></div>
+        <div>Time zone: <abbr class="tz" title="-05:00">Eastern Standard Time</abbr></div>
+        
+        <div>Profile details:
+            <div>Profile id: <span class="uid">http://example.com/profiles/johndoe</span></div>
+            <div>Details are: <span class>Public</span></div>
+            <div>Last updated: <abbr class="rev" title="2008-01-01T13:45:00">January 1st, 2008 - 13:45</abbr></div>
+        </div>
+    </div>

--- a/external/mf2/tests/test-suite/test-suite-data/hentry/justahyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hentry/justahyperlink/input.html
@@ -1,0 +1,1 @@
+<a class="hentry" href="http://microformats.org/2012/06/25/microformats-org-at-7">microformats.org at 7</a>

--- a/external/mf2/tests/test-suite/test-suite-data/hentry/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hentry/justaname/input.html
@@ -1,0 +1,1 @@
+<a class="hentry" href="http://microformats.org/2012/06/25/microformats-org-at-7">microformats.org at 7</a>

--- a/external/mf2/tests/test-suite/test-suite-data/hentry/summarycontent/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hentry/summarycontent/input.html
@@ -1,0 +1,19 @@
+<div class="hentry">
+    <h1><a class="entry-title" href="http://microformats.org/2012/06/25/microformats-org-at-7">microformats.org at 7</a></h1>
+    <div class="entry-content">
+        <p class="entry-summary">Last week the microformats.org community 
+            celebrated its 7th birthday at a gathering hosted by Mozilla in 
+            San Francisco and recognized accomplishments, challenges, and 
+            opportunities.</p>
+
+        <p>The microformats tagline “humans first, machines second” 
+            forms the basis of many of our 
+            <a href="http://microformats.org/wiki/principles">principles</a>, and 
+            in that regard, we’d like to recognize a few people and 
+            thank them for their years of volunteer service </p>
+    </div>  
+    <p>Updated 
+        <time class="updated" datetime="2012-06-25T17:08:26">June 25th, 2012</time> by
+        <a class="author vcard" href="http://tantek.com/">Tantek</a>
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hnews/all/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hnews/all/input.html
@@ -1,0 +1,37 @@
+<div class="hnews">
+    <div class="entry hentry">
+        <h1><a class="entry-title" rel="bookmark" href="http://microformats.org/2012/06/25/microformats-org-at-7">microformats.org at 7</a></h1>
+        <div class="entry-content">
+            <p class="entry-summary">Last week the microformats.org community 
+                celebrated its 7th birthday at a gathering hosted by Mozilla in 
+                San Francisco and recognized accomplishments, challenges, and 
+                opportunities.</p>
+
+            <p>The microformats tagline “humans first, machines second” 
+                forms the basis of many of our 
+                <a href="http://microformats.org/wiki/principles">principles</a>, and 
+                in that regard, we’d like to recognize a few people and 
+                thank them for their years of volunteer service </p>
+        </div>  
+        <p>Updated 
+            <time class="updated" datetime="2012-06-25T17:08:26">June 25th, 2012</time> by
+            <span class="author vcard"><a class="fn url" href="http://tantek.com/">Tantek</a></span>
+        </p>
+    </div>
+
+    <p>
+        <span class="dateline vcard">
+            <span class="adr">
+                <span class="locality">San Francisco</span>, 
+                <span class="region">CA</span> 
+            </span>
+        </span>
+        (Geo: <span class="geo">37.774921;-122.445202</span>) 
+        <span class="source-org vcard">
+            <a class="fn org url" href="http://microformats.org/">microformats.org</a>
+        </span>
+    </p>
+    <p>
+        <a rel="principles" href="http://microformats.org/wiki/Category:public_domain_license">Publishing policy</a>
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hnews/minimum/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hnews/minimum/input.html
@@ -1,0 +1,25 @@
+<div class="hnews">
+    <div class="entry hentry">
+        <h1><a class="entry-title" rel="bookmark" href="http://microformats.org/2012/06/25/microformats-org-at-7">microformats.org at 7</a></h1>
+        <div class="entry-content">
+            <p class="entry-summary">Last week the microformats.org community 
+                celebrated its 7th birthday at a gathering hosted by Mozilla in 
+                San Francisco and recognized accomplishments, challenges, and 
+                opportunities.</p>
+
+            <p>The microformats tagline “humans first, machines second” 
+                forms the basis of many of our 
+                <a href="http://microformats.org/wiki/principles">principles</a>, and 
+                in that regard, we’d like to recognize a few people and 
+                thank them for their years of volunteer service </p>
+        </div>  
+        <p>Updated 
+            <time class="updated" datetime="2012-06-25T17:08:26">June 25th, 2012</time> by
+            <span class="author vcard"><a class="fn url" href="http://tantek.com/">Tantek</a></span>
+        </p>
+    </div>
+
+    <p class="source-org vcard">
+        <a class="fn org url" href="http://microformats.org/">microformats.org</a> 
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hproduct/aggregate/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hproduct/aggregate/input.html
@@ -1,0 +1,25 @@
+<div class="hproduct">
+    <h2 class="fn">Raspberry Pi</h2>
+    <img class="photo" src="http://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/RaspberryPi.jpg/320px-RaspberryPi.jpg" />
+    <p class="description">The Raspberry Pi is a credit-card sized computer that plugs into your TV and a keyboard. It’s a capable little PC which can be used for many of the things that your desktop PC does, like spreadsheets, word-processing and games. It also plays high-definition video. We want to see it being used by kids all over the world to learn programming.</p>
+    <a class="url" href="http://www.raspberrypi.org/">More info about the Raspberry Pi</a>
+    <p class="price">£29.95</p>
+    <p class="review hreview-aggregate">
+        <span class="rating">
+            <span class="average value">9.2</span> out of 
+            <span class="best">10</span> 
+            based on <span class="count">178</span> reviews
+        </span>
+    </p>
+    <p>Categories: 
+        <a rel="tag" href="http://en.wikipedia.org/wiki/computer" class="category">Computer</a>, 
+        <a rel="tag" href="http://en.wikipedia.org/wiki/education" class="category">Education</a>
+    </p>
+    <p class="brand vcard">From: 
+        <span class="fn org">The Raspberry Pi Foundation</span> - 
+        <span class="adr">
+            <span class="locality">Cambridge</span> 
+            <span class="country-name">UK</span>
+        </span>
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hproduct/justahyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hproduct/justahyperlink/input.html
@@ -1,0 +1,1 @@
+<a class="hproduct" href="http://www.raspberrypi.org/">Raspberry Pi</a>

--- a/external/mf2/tests/test-suite/test-suite-data/hproduct/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hproduct/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="hproduct">Raspberry Pi</p>

--- a/external/mf2/tests/test-suite/test-suite-data/hproduct/simpleproperties/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hproduct/simpleproperties/input.html
@@ -1,0 +1,12 @@
+<div class="hproduct">
+    <h2 class="fn">Raspberry Pi</h2>
+    <img class="photo" src="http://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/RaspberryPi.jpg/320px-RaspberryPi.jpg" />
+    <p class="description">The Raspberry Pi is a credit-card sized computer that plugs into your TV and a keyboard. It’s a capable little PC which can be used for many of the things that your desktop PC does, like spreadsheets, word-processing and games. It also plays high-definition video. We want to see it being used by kids all over the world to learn programming.</p>
+    <a class="url" href="http://www.raspberrypi.org/">More info about the Raspberry Pi</a>
+    <p class="price">£29.95</p>
+    <p class="review h-review"><span class="rating">4.5</span> out of 5</p>
+    <p>Categories: 
+        <a rel="tag" href="http://en.wikipedia.org/wiki/computer" class="category">Computer</a>, 
+        <a rel="tag" href="http://en.wikipedia.org/wiki/education" class="category">Education</a>
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hrecipe/all/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hrecipe/all/input.html
@@ -1,0 +1,63 @@
+<section class="hrecipe">
+    <h1 class="p-name">Yorkshire Puddings</h1>      
+    <p class="p-summary">Makes <span class="p-yield">6 good sized Yorkshire puddings</span>, the way my mum taught me</p>
+
+
+    <p><img class="u-photo" src="http://codebits.glennjones.net/semantic/yorkshire-puddings.jpg" /></p>
+
+    <span class="p-review h-review-aggregate">
+        <span class="p-rating">
+            <span class="p-average">4.5</span> stars out 5 based on </span>
+            <span class="p-count">35</span> reviews</span>
+         
+    
+
+    <div id="ingredients-container">
+        <h3>Ingredients</h3>
+        <ul>
+            <li class="e-ingredient">1 egg</li>
+            <li class="e-ingredient">75g plain flour</li>
+            <li class="e-ingredient">70ml milk</li>
+            <li class="e-ingredient">60ml water</li>
+            <li class="e-ingredient">Pinch of salt</li>
+        </ul>
+    </div>
+
+    <h3>Time</h3>
+    <ul>
+        <li class="prepTime">Preparation <span class="value-title" title="PT0H10M">10 mins</span></li>
+        <li class="cookTime">Cook <span class="value-title" title="PT0H25M">25 mins</span></li>
+    </ul> 
+
+
+    <h3>Instructions</h3>
+    <div class="e-instructions">
+        <ol>
+            <li>Pre-heat oven to 230C or gas mark 8. Pour the vegetable oil evenly into 2 x 4-hole 
+            Yorkshire pudding tins and place in the oven to heat through.</li> 
+            
+            <li>To make the batter, add all the flour into a bowl and beat in the eggs until smooth. 
+            Gradually add the milk and water while beating the mixture. It should be smooth and 
+            without lumps. Finally add a pinch of salt.</li>
+            
+            <li>Make sure the oil is piping hot before pouring the batter evenly into the tins. 
+            Place in the oven for 20-25 minutes until pudding have risen and look golden brown</li>
+        </ol>
+    </div>
+
+    <h3>Nutrition</h3>
+    <ul id="nutrition-list">
+        <li class="nutrition">Calories: <span class="calories">125</span></li>
+        <li class="nutrition">Fat: <span class="fat">3.2g</span></li>
+        <li class="nutrition">Cholesterol: <span class="cholesterol">77mg</span></li>
+    </ul>
+    <p>(Amount per pudding)</p>
+
+    <p>
+        Published on <time class="dt-published" datetime="2011-10-27">27 Oct 2011</time> by 
+        <span class="p-author h-card">
+            <a class="p-name u-url" href="http://glennjones.net">Glenn Jones</a>
+        </span>
+    </p>
+    <a href="http://www.flickr.com/photos/dithie/4106528495/">Photo by dithie</a>
+    </section>

--- a/external/mf2/tests/test-suite/test-suite-data/hrecipe/minimum/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hrecipe/minimum/input.html
@@ -1,0 +1,7 @@
+<div class="h-recipe">  
+    <p class="p-name">Toast</p>
+    <ul>
+        <li class="e-ingredient">Slice of bread</li>
+        <li class="e-ingredient">Butter</li>
+    </ul>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hresume/affiliation/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hresume/affiliation/input.html
@@ -1,0 +1,12 @@
+<div class="h-resume">
+    <p>
+        <span class="contact vcard"><span class="fn">Tim Berners-Lee</span></span>, 
+        <span class="summary">invented the World Wide Web</span>.
+    </p>
+    Belongs to following groups:
+    <p>   
+        <a class="affiliation vcard" href="http://www.w3.org/">
+            <img class="fn photo" alt="W3C" src="http://www.w3.org/Icons/WWW/w3c_home_nb.png" />
+        </a>
+    </p>   
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hresume/contact/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hresume/contact/input.html
@@ -1,0 +1,18 @@
+<div class="hresume">
+    <div class="contact vcard">
+        <p class="fn">Tim Berners-Lee</p>
+        <p class="org">MIT</p>
+        <p class="adr">
+            <span class="street-address">32 Vassar Street</span>, 
+            <span class="extended-address">Room 32-G524</span>, 
+            <span class="locality">Cambridge</span>,  
+            <span class="region">MA</span> 
+            <span class="postal-code">02139</span>, 
+            <span class="country-name">USA</span>.  
+            (<span class="type">Work</span>)
+        </p>
+        <p>Tel:<span class="tel">+1 (617) 253 5702</span></p>
+        <p>Email:<a class="email" href="mailto:timbl@w3.org">timbl@w3.org</a></p>
+    </div>
+    <p class="summary">Invented the World Wide Web.</p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hresume/education/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hresume/education/input.html
@@ -1,0 +1,13 @@
+<div class="hresume">
+    <div class="contact vcard">
+        <p class="fn">Tim Berners-Lee</p>
+        <p class="title">Director of the World Wide Web Foundation</p>
+    </div>
+    <p class="summary">Invented the World Wide Web.</p><hr />
+    <p class="education vevent vcard">
+        <span class="fn summary org">The Queen's College, Oxford University</span>, 
+        <span class="description">BA Hons (I) Physics</span> 
+        <time class="dtstart" datetime="1973-09">1973</time> –
+        <time class="dtend" datetime="1976-06">1976</time>
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hresume/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hresume/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="h-resume">Tim Berners-Lee, invented the World Wide Web.</p>

--- a/external/mf2/tests/test-suite/test-suite-data/hresume/skill/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hresume/skill/input.html
@@ -1,0 +1,13 @@
+<div class="h-resume">
+    
+    <p>
+        <span class="contact vcard"><span class="fn">Tim Berners-Lee</span></span>, 
+        <span class="summary">invented the World Wide Web</span>.
+    </p>
+    Skills:     
+    <ul>
+        <li><a class="skill" rel="tag" href="http://example.com/skills/informationsystems">information systems</a></li>
+        <li><a class="skill" rel="tag" href="http://example.com/skills/advocacy">advocacy</a></li>
+        <li><a class="skill" rel="tag" href="http://example.com/skills/informationsystems">leadership</a></li>
+    <ul>   
+</ul></ul></div>

--- a/external/mf2/tests/test-suite/test-suite-data/hresume/work/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hresume/work/input.html
@@ -1,0 +1,15 @@
+<div class="hresume">
+    <div class="contact vcard">
+        <p class="fn">Tim Berners-Lee</p>
+        <p class="title">Director of the World Wide Web Foundation</p>
+    </div>
+    <p class="summary">Invented the World Wide Web.</p><hr />
+    <div class="experience vevent vcard">
+        <p class="title">Director</p>
+        <p><a class="fn summary org url" href="http://www.webfoundation.org/">World Wide Web Foundation</a></p>
+        <p>
+            <time class="dtstart" datetime="2009-01-18">Jan 2009</time> – Present
+            <time class="duration" datetime="P2Y11M">(2 years 11 month)</time>
+        </p>
+    </div>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hreview-aggregate/hcard/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hreview-aggregate/hcard/input.html
@@ -1,0 +1,18 @@
+<div class="hreview-aggregate">
+    <div class="item vcard">
+        <h3 class="fn org">Mediterranean Wraps</h3>    
+        <p>
+            <span class="adr">
+                <span class="street-address">433 S California Ave</span>, 
+                <span class="locality">Palo Alto</span>, 
+                <span class="region">CA</span></span> - 
+            
+            <span class="tel">(650) 321-8189</span>
+        </p>
+    </div> 
+    <p class="rating">
+        <span class="average value">9.2</span> out of 
+        <span class="best">10</span> 
+        based on <span class="count">17</span> reviews
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hreview-aggregate/justahyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hreview-aggregate/justahyperlink/input.html
@@ -1,0 +1,6 @@
+<p class="hreview-aggregate">
+    <span class="item">
+        <a class="fn url" href="http://example.com/mediterraneanwraps">Mediterranean Wraps</a>
+    </span> - Rated: 
+    <span class="rating">4.5</span> out of 5 (<span class="count">6</span> reviews)
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/hreview-aggregate/vevent/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hreview-aggregate/vevent/input.html
@@ -1,0 +1,13 @@
+<div class="hreview-aggregate">
+    <div class="item vevent">
+        <h3 class="summary">Fullfrontal</h3>
+        <p class="description">A one day JavaScript Conference held in Brighton</p>
+        <p><time class="dtstart" datetime="2012-11-09">9th November 2012</time></p>    
+    </div> 
+    
+    <p class="rating">
+        <span class="average value">9.9</span> out of 
+        <span class="best">10</span> 
+        based on <span class="count">62</span> reviews
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hreview/hyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hreview/hyperlink/input.html
@@ -1,0 +1,1 @@
+<a class="hreview" href="https://plus.google.com/116941523817079328322/about">Crepes on Cole</a>

--- a/external/mf2/tests/test-suite/test-suite-data/hreview/implieditem/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hreview/implieditem/input.html
@@ -1,0 +1,4 @@
+<div class="hreview">
+    <a class="item" href="http://example.com/crepeoncole">Crepes on Cole</a>
+    <p><span class="rating">4.7</span> out of 5 stars</p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hreview/item/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hreview/item/input.html
@@ -1,0 +1,7 @@
+<div class="hreview">
+    <p class="item">
+        <img class="photo" src="images/photo.gif" />
+        <a class="fn url" href="http://example.com/crepeoncole">Crepes on Cole</a>
+    </p>
+    <p><span class="rating">5</span> out of 5 stars</p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/hreview/justaname/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hreview/justaname/input.html
@@ -1,0 +1,1 @@
+<p class="hreview">Crepes on Cole</p>

--- a/external/mf2/tests/test-suite/test-suite-data/hreview/photo/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hreview/photo/input.html
@@ -1,0 +1,1 @@
+<img class="hreview" src="images/photo.gif" alt="Crepes on Cole" />

--- a/external/mf2/tests/test-suite/test-suite-data/hreview/vcard/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/hreview/vcard/input.html
@@ -1,0 +1,23 @@
+<div class="hreview">
+    <span><span class="rating">5</span> out of 5 stars</span>
+    <h4 class="summary">Crepes on Cole is awesome</h4>
+    <span class="reviewer vcard">
+        Reviewer: <span class="fn">Tantek</span> - 
+    </span>
+    <time class="reviewed" datetime="2005-04-18">April 18, 2005</time>
+    <div class="description">
+        <p class="item vcard">
+        <span class="fn org">Crepes on Cole</span> is one of the best little 
+        creperies in <span class="adr"><span class="locality">San Francisco</span></span>.
+        Excellent food and service. Plenty of tables in a variety of sizes 
+        for parties large and small.  Window seating makes for excellent 
+        people watching to/from the N-Judah which stops right outside.  
+        I've had many fun social gatherings here, as well as gotten 
+        plenty of work done thanks to neighborhood WiFi.
+        </p>
+    </div>
+    <p>Visit date: <span>April 2005</span></p>
+    <p>Food eaten: <a rel="tag" href="http://en.wikipedia.org/wiki/crepe">crepe</a></p>
+    <p>Permanent link for review: <a rel="self bookmark" href="http://example.com/crepe">http://example.com/crepe</a></p>
+    <p><a rel="license" href="http://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License">Creative Commons Attribution-ShareAlike License</a></p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/includes/hcarditemref/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/includes/hcarditemref/input.html
@@ -1,0 +1,16 @@
+<div class="h-card" itemref="mozilla-org mozilla-adr">
+    <span class="p-name">Brendan Eich</span>
+</div>
+<div class="h-card" itemref="mozilla-org mozilla-adr">
+    <span class="p-name">Mitchell Baker</span>
+</div>
+
+<p id="mozilla-org" class="p-org">Mozilla</p>
+<p id="mozilla-adr" class="p-adr h-adr">
+    <span class="p-street-address">665 3rd St.</span>  
+    <span class="p-extended-address">Suite 207</span>  
+    <span class="p-locality">San Francisco</span>,  
+    <span class="p-region">CA</span>  
+    <span class="p-postal-code">94107</span>  
+    <span class="p-country-name">U.S.A.</span>  
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/includes/heventitemref/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/includes/heventitemref/input.html
@@ -1,0 +1,25 @@
+<div class="h-event" itemref="io-session07">
+    <span class="p-name">Monetizing Android Apps</span> - spaekers: 
+    <span class="p-speaker">Chrix Finne</span>, 
+    <span class="p-speaker">Kenneth Lui</span> - 
+    <span itemref="io-location" class="p-location h-adr">
+        <span class="p-extended-address">Room 10</span>
+    </span>  
+</div>
+<div class="h-event" itemref="io-session07">
+    <span class="p-name">New Low-Level Media APIs in Android</span> - spaekers: 
+    <span class="p-speaker">Dave Burke</span> -
+    <span itemref="io-location" class="p-location h-adr">
+        <span class="p-extended-address">Room 11</span>
+    </span>  
+</div>
+
+<p id="io-session07">
+    Session 01 is between: 
+    <time class="dt-start" datetime="2012-06-27T15:45:00-0800">3:45PM</time> to 
+    <time class="dt-end" datetime="2012-06-27T16:45:00-0800">4:45PM</time> 
+</p>   
+<p id="io-location">
+    <span class="p-extended-address">Moscone Center</span>,   
+    <span class="p-locality">San Francisco</span>  
+</p>

--- a/external/mf2/tests/test-suite/test-suite-data/includes/hyperlink/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/includes/hyperlink/input.html
@@ -1,0 +1,18 @@
+<div class="h-card">
+    <span class="p-name">Ben Ward</span>
+    <a class="include" href="#twitter">Twitter</a>
+</div>
+<div class="h-card">
+    <span class="p-name">Dan Webb</span>
+    <a class="include" href="#twitter">Twitter</a>
+</div>
+
+<div id="twitter">
+    <p class="p-org">Twitter</p>
+    <p class="p-adr h-adr">
+        <span class="p-street-address">1355 Market St</span>,
+        <span class="p-locality">San Francisco</span>, 
+        <span class="p-region">CA</span>
+        <span class="p-postal-code">94103</span>
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/includes/object/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/includes/object/input.html
@@ -1,0 +1,23 @@
+<div class="h-event">
+    <span class="p-name">HTML5 & CSS3 latest features in action!</span> - 
+    <span class="p-speaker">David Rousset</span> -
+    <time class="dt-start" datetime="2012-10-30T11:45:00-08:00">Tue 11:45am</time>
+    <object data="#buildconf" class="include" type="text/html" height="0" width="0"></object>
+</div>
+<div class="h-event">
+    <span class="p-name">Building High-Performing JavaScript for Modern Engines</span> -
+    <span class="p-speaker">John-David Dalton</span> and 
+    <span class="p-speaker">Amanda Silver</span> -
+    <time class="dt-start" datetime="2012-10-31T11:15:00-08:00">Wed 11:15am</time>
+    <object data="#buildconf" class="include" type="text/html" height="0" width="0"></object>
+</div>
+
+
+<div id="buildconf">
+    <p class="p-summary">Build Conference</p>
+    <p class="p-location h-adr">
+        <span class="p-locality">Redmond</span>, 
+        <span class="p-region">Washington</span>, 
+        <span class="p-country-name">USA</span>
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/includes/table/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/includes/table/input.html
@@ -1,0 +1,11 @@
+<table>
+    <tr>
+        <th id="org"><a class="u-url p-org" href="http://dev.opera.com/">Opera</a></th>
+    </tr>
+    <tr>
+        <td class="h-card" headers="org"><span class="p-name">Chris Mills</span></td>
+    </tr>
+    <tr>
+        <td class="h-card" headers="org"><span class="p-name">Erik Möller</span></td>
+    </tr>
+  </table>

--- a/external/mf2/tests/test-suite/test-suite-data/mixed-versions/mixedpropertries/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/mixed-versions/mixedpropertries/input.html
@@ -1,0 +1,13 @@
+<div class="h-card">
+    <p>
+        <a class="p-name org u-url" href="http://mozilla.org/">Mozilla Foundation</a>
+    </p>
+    <p class="adr">
+        <span class="street-address">665 3rd St.</span>  
+        <span class="extended-address">Suite 207</span>  
+        <span class="locality">San Francisco</span>,  
+        <span class="region">CA</span>  
+        <span class="postal-code">94107</span>  
+        <span class="country-name">U.S.A.</span>  
+    </p>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/mixed-versions/mixedroots/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/mixed-versions/mixedroots/input.html
@@ -1,0 +1,15 @@
+<div class="h-resume">
+    <div class="p-contact vcard">
+        <p class="fn">Tim Berners-Lee</p>
+        <p class="title">Director of the World Wide Web Foundation</p>
+    </div>
+    <p class="summary">Invented the World Wide Web.</p><hr />
+    <div class="p-experience vevent h-card">
+        <p class="title">Director</p>
+        <p><a class="fn p-org summary url" href="http://www.webfoundation.org/">World Wide Web Foundation</a></p>
+        <p>
+            <time class="dtstart" datetime="2009-01-18">Jan 2009</time> – Present
+            <time class="duration" datetime="P2Y11M">(2 years 11 month)</time>
+        </p>
+    </div>
+</div>

--- a/external/mf2/tests/test-suite/test-suite-data/mixed-versions/tworoots/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/mixed-versions/tworoots/input.html
@@ -1,0 +1,1 @@
+<p class="h-card vcard">Frances Berriman</p>

--- a/external/mf2/tests/test-suite/test-suite-data/rel/alternate/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/rel/alternate/input.html
@@ -1,0 +1,1 @@
+<link rel="updates alternate" type="application/atom+xml" href="updates.atom" />

--- a/external/mf2/tests/test-suite/test-suite-data/rel/license/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/rel/license/input.html
@@ -1,0 +1,1 @@
+<a rel="license" href="http://creativecommons.org/licenses/by/2.5/">cc by 2.5</a>

--- a/external/mf2/tests/test-suite/test-suite-data/rel/nofollow/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/rel/nofollow/input.html
@@ -1,0 +1,1 @@
+<a rel="nofollow" href="http://microformats.org/wiki/microformats:copyrights">Copyrights</a>

--- a/external/mf2/tests/test-suite/test-suite-data/rel/xfn-all/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/rel/xfn-all/input.html
@@ -1,0 +1,19 @@
+<ul>
+    <li><a rel="friend" href="http://example.com/profile/jane">jane</a></li>
+    <li><a rel="acquaintance" href="http://example.com/profile/jeo">jeo</a></li>
+    <li><a rel="contact" href="http://example.com/profile/lily">lily</a></li>
+    <li><a rel="met" href="http://example.com/profile/oliver">oliver</a></li>
+    <li><a rel="co-worker" href="http://example.com/profile/emily">emily</a></li>
+    <li><a rel="colleague" href="http://example.com/profile/jack">jack</a></li>
+    <li><a rel="neighbor" href="http://example.com/profile/isabella">isabella</a></li>
+    <li><a rel="child" href="http://example.com/profile/harry">harry</a></li>
+    <li><a rel="parent" href="http://example.com/profile/sophia">sophia</a></li>
+    <li><a rel="sibling" href="http://example.com/profile/charlie">charlie</a></li>
+    <li><a rel="spouse" href="http://example.com/profile/olivia">olivia</a></li>
+    <li><a rel="kin" href="http://example.com/profile/james">james</a></li>
+    <li><a rel="muse" href="http://example.com/profile/ava">ava</a></li>
+    <li><a rel="crush" href="http://example.com/profile/joshua">joshua</a></li>
+    <li><a rel="date" href="http://example.com/profile/chloe">chloe</a></li>
+    <li><a rel="sweetheart" href="http://example.com/profile/alfie">alfie</a></li>
+    <li><a rel="me" href="http://example.com/profile/isla">isla</a></li>
+</ul>

--- a/external/mf2/tests/test-suite/test-suite-data/rel/xfn-elsewhere/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/rel/xfn-elsewhere/input.html
@@ -1,0 +1,10 @@
+<ul>
+    <li><a rel="me" href="http://twitter.com/glennjones">twitter</a></li>
+    <li><a rel="me" href="http://delicious.com/glennjonesnet/">delicious</a></li>
+    <li><a rel="me" href="https://plus.google.com/u/0/105161464208920272734/about">google+</a></li>
+    <li><a rel="me" href="http://lanyrd.com/people/glennjones/">lanyrd</a></li>
+    <li><a rel="me" href="http://github.com/glennjones">github</a></li>
+    <li><a rel="me" href="http://www.flickr.com/photos/glennjonesnet/">flickr</a></li>
+    <li><a rel="me" href="http://www.linkedin.com/in/glennjones">linkedin</a></li>
+    <li><a rel="me" href="http://www.slideshare.net/glennjones/presentations">slideshare</a></li>
+</ul>

--- a/external/mf2/tests/test-suite/test-suite-data/url/urlincontent/input.html
+++ b/external/mf2/tests/test-suite/test-suite-data/url/urlincontent/input.html
@@ -1,0 +1,13 @@
+<div class="h-entry">
+    <h1><a class="p-name">Expanding URLs within HTML content</a></h1>
+    <div class="e-content">
+        <ul>
+            <li><a href="http://www.w3.org/">Should not change: http://www.w3.org/</a></li>
+            <li><a href="http://example.com/">Should not change: http://example.com/</a></li>
+            <li><a href="test.html">File relative: test.html = http://example.com/test.html</a></li>
+            <li><a href="/test/test.html">Directory relative: /test/test.html = http://example.com/test/test.html</a></li>
+            <li><a href="/test.html">Relative to root: /test.html = http://example.com/test.html</a></li>
+        </ul>
+        <img src="http://www.w3.org/2008/site/images/logo-w3c-mobile-lg" /><img src="/images/test.gif" />
+    </div>  
+</div>

--- a/external/mf2/tests/test-suite/test-suite.php
+++ b/external/mf2/tests/test-suite/test-suite.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * php-mf2 test suite
+ * CLI usage from the tests/test-suite/ directory: php test-suite.php
+ * @see https://github.com/tobiastom/tests
+ *
+ * This will look through the specified directory for suite.json files
+ * that represent a suite of tests. Then, for each suite the sub-directories
+ * will be parsed for input.html, output.json, and test.json files. Each
+ * test will then be executed. If a test fails, a message is displayed along
+ * with the parsed output (array format) and the expected output (array format).
+ *
+ * Individual test suites may be run by calling TestSuite->runSuite($path)
+ * where $path is the file path to the suite.json file.
+ */
+
+namespace Mf2\Parser\TestSuite;
+
+use Mf2\Parser;
+use Mf2;
+
+require dirname(__DIR__) . '/../vendor/autoload.php';
+
+class TestSuite
+{
+	private $path = '';
+
+	private $suites;
+
+	private $tests_total = 0;
+
+	private $tests_passed = 0;
+
+	private $tests_failed = 0;
+
+	/**
+	 * This method constructs the TestSuite
+	 * @param string $path: path to test-suite-data 
+	 * @access public
+	 */
+	public function __construct($path = './test-suite-data/')
+	{
+		$this->path = $path;
+	} # end method __construct()
+
+
+	/**
+	 * This method runs the test suite
+	 * @param array 
+	 * @access public
+	 * @return bool
+	 */
+	public function start()
+	{
+		$directory = new \RecursiveDirectoryIterator($this->path);
+		$iterator = new \RecursiveIteratorIterator($directory);
+		$this->suites = new \RegexIterator($iterator, '/^.+suite\.json$/i', \RecursiveRegexIterator::GET_MATCH);
+
+		foreach ( $this->suites as $suite )
+		{
+			$this->runSuite(reset($suite));
+			// echo "\n";
+		}
+
+		echo sprintf('Total tests: %d', $this->tests_total), "\n";
+		echo sprintf('Passed: %d', $this->tests_passed), "\n";
+		echo sprintf('Failed: %d', $this->tests_failed), "\n";
+
+		return TRUE;
+	} # end method start()
+
+
+	/**
+	 * This method handles running a test suite
+	 * @param string $path: path to the suite's JSON file 
+	 * @access public
+	 * @return bool
+	 */
+	public function runSuite($path)
+	{
+		$suite = json_decode(file_get_contents($path));
+		echo sprintf('Running %s.', $suite->name), "\n";
+
+		$iterator = new \DirectoryIterator(dirname($path));
+
+		# loop: each file in the test suite
+		foreach ( $iterator as $file )
+		{	
+
+			# if: file is a sub-directory and not a dot-directory
+			if ( $file->isDir() && !$file->isDot() )
+			{
+				$this->tests_total++;
+
+				$path_of_test = $file->getPathname() . '/';
+
+				$test = json_decode(file_get_contents($path_of_test . 'test.json'));
+				$input = file_get_contents($path_of_test . 'input.html');
+				$expected_output = json_decode(file_get_contents($path_of_test . 'output.json'), TRUE);
+
+				$parser = new Parser($input, '', TRUE);
+				$output = $parser->parse(TRUE);
+
+				# if: test passed
+				if ( $output['items'] === $expected_output['items'] )
+				{
+					// echo '.'; # can output a dot for successful tests
+					$this->tests_passed++;
+				}
+				# else: test failed
+				else
+				{
+					echo sprintf('"%s" failed.', $test->name), "\n\n";
+					echo sprintf('Parsed: %s', print_r($output, TRUE)), "\n";
+					echo sprintf('Expected: %s', print_r($expected_output, TRUE)), "\n";
+					$this->tests_failed++;
+				} # end if
+
+			} # end if
+
+		} # end loop
+
+		return TRUE;
+	} # end method runSuite()
+
+}
+
+$TestSuite = new TestSuite();
+$TestSuite->start(); # run all test suites
+
+// Alternately, run a specific suite
+// $TestSuite->runSuite('./test-suite-data/adr/suite.json');

--- a/templates/default/content/syndication.tpl.php
+++ b/templates/default/content/syndication.tpl.php
@@ -33,9 +33,10 @@
 
                             // give plugins a chance to pre-select a service (e.g. if replying to a tweet, pre-select twitter)
                             $preselect = \Idno\Core\Idno::site()->triggerEvent('syndication/selected/' . $service, [
-                                'service'  => $service,
-                                'username' => $account['username'],
-                                'reply-to' => \Idno\Core\Idno::site()->currentPage()->getInput('share_url')
+                                'service'       => $service,
+                                'username'      => $account['username'],
+                                'reply-to'      => \Idno\Core\Idno::site()->currentPage()->getInput('share_url'),
+                                'syndicated-to' => \Idno\Core\Idno::site()->currentPage()->getInput('syndicatedto'),
                             ], false);
 
                             $button .= $this->__([


### PR DESCRIPTION
## Here's what I fixed or added:

- update php-mf2 to latest version (old version did annoying, albeit reasonable,
  thing returning stdClass for empty "rels" array)
- improve Webmention::addSyndicatedReplyTargets to search u-syndication
  in addition to rel-syndication
- pre-fill the twitter @-name of the person we are replying to (e.g. if I reply to
  a post on known.kevinmarks.com that is syndicated to twitter, it will
  prefill with "@kevinmarks ")
- pass syndication URLs to the preselect hook so the Twitter plugin
  can preselect syndication

## Here's why I did it:

see discussion in https://github.com/idno/Known/issues/1396#issuecomment-207215698