### PR TITLE
don't double encode unicode characters in setSlugResilient

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -594,9 +594,17 @@
                 $slug = preg_replace("/([^A-Za-z0-9%\p{L}\-\_ ])/u", '', $slug);
                 $slug = preg_replace("/[ ]+/u", ' ', $slug);
                 $slug = implode('-', array_slice(explode(' ', $slug), 0, $max_pieces));
-                $slug = rawurlencode($slug);
 
-                $slug = substr($slug, 0, $max_chars);
+                // trim the source string until the encoded string is <= max_chars
+                for ($chars = $max_chars ; $chars >= 0 ; $chars--) {
+                    $truncated = mb_substr($slug, 0, $chars, 'UTF-8');
+                    $encoded = rawurlencode(mb_substr($slug, 0, $chars, 'UTF-8'));
+                    if (strlen($encoded) <= $max_chars) {
+                        $slug = $encoded;
+                        break;
+                    }
+                }
+
                 while (substr($slug, -1) == '-') {
                     $slug = substr($slug, 0, strlen($slug) - 1);
                 }

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -562,11 +562,6 @@
             {
                 // UUID max length is 255 chars; slug length <= 255 - (base URL + year + slash)
                 $max_chars = 245 - strlen(\Idno\Core\Idno::site()->config()->getDisplayURL());
-
-                $slug = $this->prepareSlug($slug, $max_pieces, $max_chars - 10);
-                if (empty($slug)) {
-                    return false;
-                }
                 if ($this->setSlug($slug, $max_pieces, $max_chars - 10)) {
                     return true;
                 }
@@ -611,7 +606,6 @@
                 if (is_callable('mb_convert_encoding')) {
                     $slug = mb_convert_encoding($slug, 'UTF-8', 'UTF-8');
                 }
-
                 return $slug;
             }
 

--- a/Tests/Common/EntityTest.php
+++ b/Tests/Common/EntityTest.php
@@ -51,7 +51,11 @@ class EntityTest extends \Tests\KnownTestCase {
         // borrowed this one from @nekr0z
         $this->assertEquals(
             '%D0%B4%D0%B0-%D1%8F-%D0%B6-%D0%B4%D0%B0%D0%B2%D0%B5%D1%87%D0%B0-%D0%B2-%D1%81%D0%BF%D0%BE%D1%80%D1%82%D0%BC%D0%B0%D1%81%D1%82%D0%B5%D1%80%D0%B5-%D0%B1%D1%8B%D0%BB',
-            $entity->prepareSlug('Да, я ж давеча в Спортмастере был...'));
+            $entity->prepareSlug('Да, я ж давеча в Спортмастере был'));
+        // don't truncate in the middle of a encoded character
+        $this->assertEquals(
+            '%D0%B4%D0%B0-%D1%8F',
+            $entity->prepareSlug('Да, я ж давеча в Спортмастере был', 10, 24));
         $this->assertEquals(
             'make-sure-spaces-are-collapsed-and-tags-are-stripped',
             $entity->prepareSlug('Make Sure    <b>Spaces</b> are  Collapsed and Tags  Are  <i>Stripped</i>'));
@@ -59,8 +63,9 @@ class EntityTest extends \Tests\KnownTestCase {
 
     function testSetSlugResilient()
     {
-        $title  = "IndieWebCamp Nürnberg 2016 is live!";
-        $slug   = "indiewebcamp-n%C3%BCrnberg-2016-is-live";
+        $unique = md5(time() . rand(0, 9999));
+        $title  = "IndieWebCamp Nürnberg $unique is live!";
+        $slug   = "indiewebcamp-n%C3%BCrnberg-$unique-is-live";
 
         $entity = new Entity();
         $entity->setSlugResilient($title);

--- a/Tests/Common/EntityTest.php
+++ b/Tests/Common/EntityTest.php
@@ -14,10 +14,9 @@ class EntityTest extends \Tests\KnownTestCase {
         $this->user()->save();
     }
 
-
     function tearDown()
     {
-        if (isset($entity->toDelete)) {
+        if (isset($this->toDelete)) {
             foreach ($this->toDelete as $entity) {
                 $entity->delete();
             }
@@ -56,6 +55,24 @@ class EntityTest extends \Tests\KnownTestCase {
         $this->assertEquals(
             'make-sure-spaces-are-collapsed-and-tags-are-stripped',
             $entity->prepareSlug('Make Sure    <b>Spaces</b> are  Collapsed and Tags  Are  <i>Stripped</i>'));
+    }
+
+    function testSetSlugResilient()
+    {
+        $title  = "IndieWebCamp Nürnberg 2016 is live!";
+        $slug   = "indiewebcamp-n%C3%BCrnberg-2016-is-live";
+
+        $entity = new Entity();
+        $entity->setSlugResilient($title);
+        $this->assertEquals($slug, $entity->getSlug());
+        $entity->save();
+        $this->toDelete[] = $entity;
+
+        $entity = new Entity();
+        $entity->setSlugResilient($title);
+        $this->assertEquals($slug . '-1', $entity->getSlug());
+        $entity->save();
+        $this->toDelete[] = $entity;
     }
 
     /**


### PR DESCRIPTION
## Here's what I fixed or added:

- remove redundant call to prepareSlug at the beginning of setSlugResilient

## Here's why I did it:

- calling prepareSlug twice meant that unicode characters got
  converted from ü to %C3%BC to %25c3%25bc which was bad!