### PR TITLE
bugfix: support delete webmentions

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1701,11 +1701,19 @@
                     if (is_array($annotations)) {
                         foreach ($annotations as $subtype => $array) {
                             if (is_array($array)) {
+                                // try to remove the annotation by its local /annotation url
                                 if (array_key_exists($annotation_url, $array)) {
                                     unset($annotations[$subtype][$annotation_url]);
                                     $this->annotations = $annotations;
-
                                     return true;
+                                }
+                                // try to remove the annotation by its source permalink
+                                foreach ($array as $local_url => $properties) {
+                                    if (isset($properties['permalink']) && $properties['permalink'] === $annotation_url) {
+                                        unset($annotations[$subtype][$local_url]);
+                                        $this->annotations = $annotations;
+                                        return true;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Here's what I fixed or added:

Entity::removeAnnotation(...) removes based on the local annotation URL.
This change modifies it so that it also searches each annotation's "permalink"
field for a remote URL (i.e. the webmention source).

## Here's why I did it:

Webmentions where the source returns HTTP 410 were being processed and
acknowledged, but weren't actually deleting the comment