### PR TITLE
Debug session validation tripwire for hosted domains (refs #1403)

### DIFF
--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -57,6 +57,7 @@
                 } catch (\Exception $ex) {
                     // Session didn't validate, log & destroy
                     \Idno\Core\Idno::site()->logging->error('Error validating session', ['error' => $ex]);
+                    header('X-KNOWN-DEBUG: Tilt!');
 
                     $_SESSION = [];
                     session_destroy();


### PR DESCRIPTION
## Here's what I fixed or added:

Set a client visible header when validation tripwire is fired

## Here's why I did it:

Debugging session issues for hosted version, where logs are not available.
