### PR TITLE
Closes #1420: Defer deniedContent() until page is set.

### DIFF
--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -444,7 +444,6 @@
                         }
 
                         \Idno\Core\Idno::site()->logging()->error("API Login failure from $ip");
-                        \Idno\Core\Idno::site()->currentPage()->deniedContent();
                     }
                 }
 


### PR DESCRIPTION
## Here's what I fixed or added:

Removed call to Page::deniedContent() from tryAuthUser()

## Here's why I did it:

It was previously causing a fatal error when api auth failed. Calling deniedContent here is not necessary, since if $return isn't set, then no user has been found.

Defer the page content error.

