### PR TITLE
micropub: update format of q=syndicate-to response

### DIFF
--- a/Idno/Core/Syndication.php
+++ b/Idno/Core/Syndication.php
@@ -223,9 +223,8 @@
                     foreach ($services as $service_name => $service) {
                         foreach ($service as $account) {
                             $data[] = [
-                                'id'      => $service_name . '::' . $account['username'],
-                                'name'    => $account['name'],
-                                'service' => $service_name
+                                'uid'  => $service_name . '::' . $account['username'],
+                                'name' => $account['name'] . ' on ' . ucwords($service_name),
                             ];
                         }
                     }

--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -12,13 +12,22 @@
         class Endpoint extends \Idno\Common\Page
         {
 
-            private function getServiceAccountsFromHub()
+            /**
+             * Fetch syndication endpoints from Convoy.
+             *
+             * @param array $account_strings flat list of syndication
+             *   IDs
+             * @param array $account_data list of complex account data
+             *   conforming to
+             *   http://micropub.net/draft/#syndication-targets
+             */
+            private function getServiceAccountsFromHub(&$account_strings, &$account_data)
             {
-                $results = [];
                 if (\Idno\Core\Idno::site()->hub()) {
                     $result = \Idno\Core\Idno::site()->hub()->makeCall('hub/user/syndication', [
                         'content_type' => 'note',
                     ]);
+
                     if (!empty($result['content'])) {
                         $content = $result['content'];
 
@@ -29,11 +38,14 @@
                         $toggles = (new DOMXPath($doc))->query('//*[@name="syndication[]"]');
 
                         foreach ($toggles as $toggle) {
-                            $results[] = $toggle->getAttribute('value');
+                            $uid  = $toggle->getAttribute('value');
+                            $name = trim(strip_tags($toggle->getAttribute('data-on')));
+
+                            $account_strings[] = $uid;
+                            $account_data[]    = ['uid' => $uid, 'name' => $name];
                         }
                     }
                 }
-                return $results;
             }
 
             function get($params = array())
@@ -44,14 +56,12 @@
                     case 'syndicate-to':
                         $account_strings = \Idno\Core\Idno::site()->syndication()->getServiceAccountStrings();
                         $account_data    = \Idno\Core\Idno::site()->syndication()->getServiceAccountData();
-                        // TODO augment $account_data too
-                        $account_strings = array_merge($account_strings, $this->getServiceAccountsFromHub());
+                        $this->getServiceAccountsFromHub($account_strings, $account_data);
 
                         if ($this->isAcceptedContentType('application/json')) {
                             header('Content-Type: application/json');
                             echo json_encode([
-                                'syndicate-to'          => $account_strings,
-                                'syndicate-to-expanded' => $account_data,
+                                'syndicate-to' => $account_data,
                             ], JSON_PRETTY_PRINT);
                         } else {
                             echo http_build_query([

--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -39,7 +39,12 @@
 
                         foreach ($toggles as $toggle) {
                             $uid  = $toggle->getAttribute('value');
-                            $name = trim(strip_tags($toggle->getAttribute('data-on')));
+
+                            $account = strip_tags($toggle->getAttribute('data-on'));
+                            $service = ucwords(explode('::', $uid, 2)[0]);
+
+                            $name =  "$account on $service";
+                            $name = trim(preg_replace('/\s+/u', ' ', $name));
 
                             $account_strings[] = $uid;
                             $account_data[]    = ['uid' => $uid, 'name' => $name];


### PR DESCRIPTION
## Here's what I fixed or added:

based on draft http://micropub.net/draft/#syndication-targets, we shouldn't need to provide syndicate-to and syndicate-to-expanded. All the fancy data can go right in syndicate-to as long as they are requesting JSON.

Note we still fall back to just sending service IDS if the Accept header is not set to application/json

## Here's why I did it:

Iterating on the best format for syndication targets in the micropub spec right now. Sending back the old style flat targets in JSON breaks integration with Quill.

fixes #1423