### PR TITLE
Add pronouns to Known profiles

### DIFF
--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -188,6 +188,48 @@
             }
 
             /**
+             * Retrieve this user's oblique pronoun
+             * @return string
+             */
+            function getPronounOblique()
+            {
+                return !empty($this->profile['pronoun-oblique']) ? $this->profile['pronoun-oblique'] : '';
+            }
+
+            /**
+             * Retrieve this user's nominative pronoun
+             * @return string
+             */
+            function getPronounNominative()
+            {
+                return !empty($this->profile['pronoun-nominative']) ? $this->profile['pronoun-nominative'] : '';
+            }
+
+            /**
+             * Retrieve this user's possessive pronoun
+             * @return string
+             */
+            function getPronounPossessive()
+            {
+                return !empty($this->profile['pronoun-possessive']) ? $this->profile['pronoun-possessive'] : '';
+            }
+
+            /**
+             * Retrieve this user's pronouns
+             * @return array
+             */
+            function getPronoun()
+            {
+                $pronoun = [
+                    'oblique'    => $this->getPronounOblique(),
+                    'nominative' => $this->getPronounNominative(),
+                    'possessive' => $this->getPronounPossessive()
+                ];
+                if (!sizeof(array_filter($pronoun))) return [];
+                return $pronoun;
+            }
+
+            /**
              * Retrieves user by email address
              * @param string $email
              * @return User|false Depending on success

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -221,8 +221,8 @@
             function getPronoun()
             {
                 $pronoun = [
-                    'oblique'    => $this->getPronounOblique(),
                     'nominative' => $this->getPronounNominative(),
+                    'oblique'    => $this->getPronounOblique(),
                     'possessive' => $this->getPronounPossessive()
                 ];
                 if (!sizeof(array_filter($pronoun))) return [];

--- a/Tests/Entities/UserTest.php
+++ b/Tests/Entities/UserTest.php
@@ -1,0 +1,26 @@
+<?php
+
+    namespace Tests\Common;
+
+    use Idno\Core\Template;
+
+    class UserTest extends \Tests\KnownTestCase {
+
+        function testPronounDisplay() {
+            $user = $this->user();
+            $user->profile['pronoun-nominative'] = 'xe';
+            $user->profile['pronoun-oblique'] = 'xem';
+            $user->profile['pronoun-possessive'] = 'xyrs';
+
+            \Idno\Core\Idno::site()->config()->enable_pronouns = true;
+            $profile = (new Template())->__(['user' => $user])->draw('entity/User');
+            $pronoun = (new Template())->__(['pronouns' => $user->getPronoun()])->draw('entity/User/profile/pronouns');
+            $this->assertTrue((bool) substr_count($profile, $pronoun), 'Pronouns should display when enable_pronouns is true');
+
+            \Idno\Core\Idno::site()->config()->enable_pronouns = false;
+            $profile = (new Template())->__(['user' => $user])->draw('entity/User');
+            $pronoun = (new Template())->__(['pronouns' => $user->getPronoun()])->draw('entity/User/profile/pronouns');
+            $this->assertFalse((bool) substr_count($profile, $pronoun), 'Pronouns should not display when enable_pronouns is false');
+        }
+
+    }

--- a/templates/default/entity/User.tpl.php
+++ b/templates/default/entity/User.tpl.php
@@ -22,24 +22,20 @@
             <div class="col-md-4 namebadge">
                 <p>
                     <a href="<?= $vars['user']->getDisplayURL() ?>" class="u-url icon-container"><img class="u-photo"
-                                                                                               src="<?= $vars['user']->getIcon() ?>"/></a>
+                        src="<?= $vars['user']->getIcon() ?>"/></a>
                 </p>
+                <?php
 
-                        <?php
-
-                            if ($vars['user']->canEdit() && $vars['user']->getUUID() == \Idno\Core\Idno::site()->session()->currentUserUUID()) {
-                                // If you're wondering, this is wrapped in an h1 tag to keep it aligned with
-                                // the user's name over in the next div. TODO: find a better way to do this
-                                // that retains visual consistency.
-                                ?>
-                                <h1><a href="<?= $vars['user']->getEditURL() ?>" class="btn btn-default">Edit profile</a></h1>
-                            <?php
-
-                            }
-
+                    if ($vars['user']->canEdit() && $vars['user']->getUUID() == \Idno\Core\Idno::site()->session()->currentUserUUID()) {
+                        // If you're wondering, this is wrapped in an h1 tag to keep it aligned with
+                        // the user's name over in the next div. TODO: find a better way to do this
+                        // that retains visual consistency.
                         ?>
-                    </div>
-            
+                        <h1><a href="<?= $vars['user']->getEditURL() ?>" class="btn btn-default">Edit profile</a></h1>
+                        <?php
+                    }
+                ?>
+            </div>
             <div class="col-md-8 namebadge-profile">
                 <div class="row">
                     <div class="col-md-12">
@@ -63,10 +59,12 @@
                                         <a href="<?= $vars['user']->getDisplayURL() ?>/edit/">Click here to fill in your
                                             profile information.</a>
                                     </p>
-                                <?php
+                                    <?php
+                                }
+                                if (($pronoun_forms = $vars['user']->getPronoun()) && \Idno\Core\Idno::site()->config()->enable_pronouns) {
+                                    echo $this->__(['pronouns' => $pronoun_forms])->draw('entity/User/profile/pronouns');
                                 }
                             ?></div>
-
                         <?= $this->draw('entity/User/profile/fields') ?>
                     </div>
                 </div>

--- a/templates/default/entity/User/edit.tpl.php
+++ b/templates/default/entity/User/edit.tpl.php
@@ -15,9 +15,10 @@
             <div class="col-md-3">
                 <div class="text-center">
 
-                    <div id="photo-preview"><img src="<?= \Idno\Core\Idno::site()->session()->currentUser()->getIcon() ?>"
-                                                 class="avatar img-circle"
-                                                 alt="avatar" style="width: 100px"></div>
+                    <div id="photo-preview"><img
+                            src="<?= \Idno\Core\Idno::site()->session()->currentUser()->getIcon() ?>"
+                            class="avatar img-circle"
+                            alt="avatar" style="width: 100px"></div>
 
                         <span class="btn btn-primary btn-file">
                             <i class="fa fa-camera"></i> 
@@ -40,20 +41,50 @@
                            value="<?= htmlspecialchars($vars['user']->getTitle()) ?>">
                 </div>
 
-                <!--<div class="form-group">
-                    <label class="control-label" for="tagline">Short description</label>
-                    <input class="form-control" type="text" id="tagline" name="profile[tagline]"
-                           value="<?= htmlspecialchars($vars['user']->getShortDescription()) ?>">
-                </div>-->
-
                 <div class="form-group">
                     <label class="control-label" for="body">About you</label><br>
 
                     <textarea name="profile[description]" id="body"
                               class="form-control bodyInput"><?= htmlspecialchars($vars['user']->getDescription()) ?></textarea>
-
-
                 </div>
+
+                <?php
+
+                    // For now, this is only available to users who explicitly switch pronouns on.
+                    if (\Idno\Core\Idno::site()->config()->enable_pronouns) {
+
+                ?>
+                <div class="form-group form-pronoun">
+                    <p>
+                        <label for="pronoun">Your pronoun</label><br>
+                        <small>Your pronoun lets people know how to address you.</small>
+                    </p>
+                    <div class="row">
+                        <div class="col-md-4">
+                            <input name="profile[pronoun-nominative]" id="pronoun"
+                                   class="form-control textInput"
+                                   value="<?= htmlspecialchars($vars['user']->getPronounNominative()) ?>"
+                                   placeholder="she">
+                        </div>
+                        <div class="col-md-4">
+                            <input name="profile[pronoun-oblique]" id="pronoun"
+                                   class="form-control textInput"
+                                   value="<?= htmlspecialchars($vars['user']->getPronounOblique()) ?>"
+                                   placeholder="her">
+                        </div>
+                        <div class="col-md-4">
+                            <input name="profile[pronoun-possessive]" id="pronoun"
+                                   class="form-control textInput"
+                                   value="<?= htmlspecialchars($vars['user']->getPronounPossessive()) ?>"
+                                   placeholder="hers">
+                        </div>
+                    </div>
+                </div>
+                <?php
+
+                    }
+
+                ?>
 
                 <div class="form-group">
                     <p>
@@ -84,7 +115,7 @@
                                                 </small>
                                             </div>
                                         </div>
-                                    <?php
+                                        <?php
                                     }
                                 }
                             }
@@ -95,7 +126,7 @@
                                 <input type="text" name="profile[url][]" id="title" value="" placeholder="http://"
                                        class="form-control"/></div>
                             <div class="col-md-2" style="margin-top: 0.75em">
-                                <small >
+                                <small>
                                     <a href="#" onclick="$(this).parent().parent().parent().remove(); return false;">Remove</a>
                                 </small>
                             </div>

--- a/templates/default/entity/User/profile/pronouns.tpl.php
+++ b/templates/default/entity/User/profile/pronouns.tpl.php
@@ -1,4 +1,4 @@
-<p class="p-pronoun pronoun small">
+<p class="pronoun small">
     <?php
 
         $pronoun_list = [];

--- a/templates/default/entity/User/profile/pronouns.tpl.php
+++ b/templates/default/entity/User/profile/pronouns.tpl.php
@@ -1,0 +1,11 @@
+<p class="p-pronoun pronoun small">
+    <?php
+
+        $pronoun_list = [];
+        foreach($vars['pronouns'] as $type => $pronoun) {
+            $pronoun_list[] = '<span class="p-x-pronoun-' . $type . '">' . $pronoun . '</span>';
+        }
+        echo implode(' / ', $pronoun_list);
+
+    ?>
+</p>


### PR DESCRIPTION
## Here's what I fixed or added:

I added pronoun support for Known. Right now it needs to be manually added by setting `enable_pronouns=true` in `config.ini`. Eventually, once we've arrived at a good way to display this, we should remove the config check and just make it live.
## Here's why I did it:

Pronouns are not a given and part of owning your own identity is having the right to state yours clearly.
