### PR TITLE
Reset object's attachment array after deleting attachment files.

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -699,6 +699,8 @@
                             $file->delete();
                         }
                     }
+		    
+		    $this->attachments = [];
                 }
             }
 


### PR DESCRIPTION
## Here's what I fixed or added:

Reset the ->attachments array

## Here's why I did it:

Deleting object attachments removed the files but not the array, resulting in duplicates / broken images when displaying.


