### PR TITLE
Fixes plugin requirements listing on plugins page.

### DIFF
--- a/docs/developers/plugins/index.md
+++ b/docs/developers/plugins/index.md
@@ -50,10 +50,10 @@ specifying a minimum version of those plugins):
     plugin[] =          "Another Known plugin,0.8"
 
 The requirements section may also define a minimum PHP version and
-Known core version (called "idno" here for historical reasons).
+Known core version.
 
     php =               5.5
-    idno =              0.9
+    known =              0.9
 
 This plugin requires PHP >= 5.5 or higher and Known >= 0.9.
 

--- a/templates/default/admin/plugins/plugin.tpl.php
+++ b/templates/default/admin/plugins/plugin.tpl.php
@@ -2,11 +2,20 @@
     $plugin_description = $vars['plugin']['Plugin description'];
     $shortname = $vars['plugin']['shortname'];
 
-    $requirements = null;
-    if (isset($vars['plugin']['requirements'])) {
-        $requirements = $vars['plugin']['requirements'];
+    // Construct requirements array
+    $requirements = [];
+    if (isset($plugin_description['php'])) {
+        $requirements['php'] = $plugin_description['php'];
     }
-
+    if (isset($plugin_description['idno'])) {
+        $requirements['idno'] = $plugin_description['idno'];
+    }
+    if (isset($plugin_description['extension'])) {
+        $requirements['extension'] = $plugin_description['extension'];
+    }
+    if (isset($plugin_description['plugin'])) {
+        $requirements['plugin'] = $plugin_description['plugin'];
+    }
 ?>
 <div class="well well-large">
     <div class="row">

--- a/templates/default/admin/plugins/plugin.tpl.php
+++ b/templates/default/admin/plugins/plugin.tpl.php
@@ -7,8 +7,10 @@
     if (isset($plugin_description['php'])) {
         $requirements['php'] = $plugin_description['php'];
     }
-    if (isset($plugin_description['idno'])) {
-        $requirements['idno'] = $plugin_description['idno'];
+    if (isset($plugin_description['known'])) {
+        $requirements['known'] = $plugin_description['known'];
+    } else if (isset($plugin_description['idno'])) {
+        $requirements['known'] = $plugin_description['idno'];
     }
     if (isset($plugin_description['extension'])) {
         $requirements['extension'] = $plugin_description['extension'];
@@ -56,7 +58,7 @@
                     <div class="requirements">
 
                         <?php
-                            if (isset($requirements['idno'])) {
+                            if (isset($requirements['known'])) {
                                 ?>
                                 <p><label>Known
                                         Version: <?php echo $this->__(array('version' => $requirements['idno']))->draw('admin/dependencies/idno'); ?> </label>


### PR DESCRIPTION
## Here's what I fixed or added:

Bring back plugin requirements display

## Here's why I did it:

For some reason the $requirements array from the plugin details has been lost when passed to the plugin template. 
