### PR TITLE
PHP 5.4 compatibility

### DIFF
--- a/IdnoPlugins/StaticPages/Main.php
+++ b/IdnoPlugins/StaticPages/Main.php
@@ -48,7 +48,8 @@
 
                 if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {
                     if (\Idno\Core\Idno::site()->session()->currentUser()->isAdmin()) {
-                        if (!empty(\Idno\Common\Entity::getByID($pageId))) {
+                        $obj = \Idno\Common\Entity::getByID($pageId);
+                        if (!empty($obj)) {
                             \Idno\Core\Idno::site()->config->staticPages['homepage'] = $pageId;
                             return \Idno\Core\Idno::site()->config->save();
                         }


### PR DESCRIPTION
## Here's what I fixed or added:

Passing function result to variable before passing to empty().

## Here's why I did it:

Using function result in empty() isn't supported in PHP < 5.5, and while php 5.4 is no longer officially supported, this was a simple fix.

Closes #1440 
