### PR TITLE
Actually log exceptions, can't believe this was overlooked before.

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -117,6 +117,9 @@
             {
                 $this->setResponse(500);
                 http_response_code($this->response);
+                
+                \Idno\Core\Idno::site()->logging()->critical($e->getMessage() . " [".$e->getFile().":".$e->getLine()."]");
+                
                 $t = \Idno\Core\Idno::site()->template();
                 $t->__(array('body' => $t->__(array('exception' => $e))->draw('pages/500'), 'title' => 'Exception'))->drawPage();
                 exit;


### PR DESCRIPTION
## Here's what I fixed or added:

Added a log of exceptions

## Here's why I did it:

Page exception handler displayed the exception but suppressed it's entry into the log (!!), meaning background processes were harder to debug.

