### PR TITLE
Closes #1453: Introducing getSize() on File interface.

### DIFF
--- a/Idno/Files/File.php
+++ b/Idno/Files/File.php
@@ -56,6 +56,12 @@
              * @return string
              */
             abstract function getFilename();
+            
+            /**
+             * Return the file's size in bytes.
+             * @return int
+             */
+            abstract function getSize();
 
             /* Delete this file
              * @return bool

--- a/Idno/Files/LocalFile.php
+++ b/Idno/Files/LocalFile.php
@@ -18,6 +18,12 @@
                     return file_get_contents($this->internal_filename);
                 }
             }
+            
+            function getSize() {
+                if (file_exists($this->internal_filename)) {
+                    return filesize($this->internal_filename);
+                }
+            }
 
             /**
              * Output the contents of the file to the buffer


### PR DESCRIPTION
## Here's what I fixed or added:

A getSize() method on the File interface.

## Here's why I did it:

So it's possible to retrieve the size of the file, and provide's some interface parity with MongoGridFSFile.

This fixes the issue where *SQL users were seeing broken images.

