### PR TITLE
Closes #1465: Allows the commonly used .@ reply notation

### DIFF
--- a/Idno/Core/Template.php
+++ b/Idno/Core/Template.php
@@ -418,7 +418,7 @@
                         if (is_array($in_reply_to))
                             $in_reply_to = $in_reply_to[0];
 
-                        $r = preg_replace_callback('/(?<=^|[\>\s\n])(\@[\w0-9\_]+)/i', function ($matches) use ($in_reply_to) {
+                        $r = preg_replace_callback('/(?<=^|[\>\s\n\.])(\@[\w0-9\_]+)/i', function ($matches) use ($in_reply_to) {
                             $url = $matches[1];
 
                             // Find and replace twitter


### PR DESCRIPTION
## Here's what I fixed or added:

Modified regex to allow .@ username notation

## Here's why I did it:

It's common practice to use .@user at the start of a tweet to make a public reply, however the local copy didn't activate the username.
