### PR TITLE
support webmentions for subdirectory installations

### DIFF
--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -534,9 +534,7 @@
 
             function getPageHandler($path_info)
             {
-                if (substr_count($path_info, \Idno\Core\Idno::site()->config()->url)) {
-                    $path_info = '/' . str_replace(\Idno\Core\Idno::site()->config()->url, '', $path_info);
-                }
+                $path_info = parse_url($path_info, PHP_URL_PATH);
                 if ($q = strpos($path_info, '?')) {
                     $path_info = substr($path_info, 0, $q);
                 }


### PR DESCRIPTION
## Here's what I fixed or added:

fixed #1473

## Here's why I did it:

the routes all have KNOWN_SUBDIRECTORY prepended to them, so stripping
it off path_info before trying to find a matching handler is counter productive.

@herbsmn It would be awesome if you could pull this branch (or copy/paste the three-line change) into your installation and check that it actually works before we merged into master. Thanks!