### PR TITLE
Delete attachment on deletion of entity

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -755,6 +755,10 @@
                         $this->deleteData();
                         \Idno\Core\Idno::site()->triggerEvent('deleted', array('object' => $this));
 
+                      if(!empty($this->getAttachments()))
+                      {
+                        $this->deleteAttachments();
+                      }
                         return $return;
                     }
 

--- a/IdnoPlugins/Media/Media.php
+++ b/IdnoPlugins/Media/Media.php
@@ -29,15 +29,6 @@
             }
 
             /**
-             * Extend delete to remove attached media
-             */
-            function delete()
-            {
-                $this->deleteAttachments();
-                return parent::delete();
-            }
-
-            /**
              * Saves changes to this object based on user input
              * @return bool
              */

--- a/IdnoPlugins/Media/Media.php
+++ b/IdnoPlugins/Media/Media.php
@@ -29,6 +29,15 @@
             }
 
             /**
+             * Extend delete to remove attached media
+             */
+            function delete()
+            {
+                $this->deleteAttachments();
+                return parent::delete();
+            }
+
+            /**
              * Saves changes to this object based on user input
              * @return bool
              */

--- a/IdnoPlugins/Photo/Photo.php
+++ b/IdnoPlugins/Photo/Photo.php
@@ -62,6 +62,15 @@
             }
 
             /**
+             * Extend delete to remove attached images
+             */
+            function delete()
+            {
+                $this->deleteAttachments();
+                return parent::delete();
+            }
+
+            /**
              * Saves changes to this object based on user input
              * @return bool
              */

--- a/IdnoPlugins/Photo/Photo.php
+++ b/IdnoPlugins/Photo/Photo.php
@@ -61,15 +61,7 @@
                 return $object;
             }
 
-            /**
-             * Extend delete to remove attached images
-             */
-            function delete()
-            {
-                $this->deleteAttachments();
-                return parent::delete();
-            }
-
+           
             /**
              * Saves changes to this object based on user input
              * @return bool


### PR DESCRIPTION
## Here's what I fixed or added:
Delete all attachment on deletion of entity
## Here's why I did it:
closes #1475 optimises upload as it deletes media which is no more required