### PR TITLE
Pages errors

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -113,7 +113,7 @@
                 return false;
             }
 
-            function exception(\Exception $e)
+            function exception($e)
             {
                 $this->setResponse(500);
                 http_response_code($this->response);

--- a/IdnoPlugins/StaticPages/templates/default/staticpages/admin.tpl.php
+++ b/IdnoPlugins/StaticPages/templates/default/staticpages/admin.tpl.php
@@ -34,7 +34,7 @@
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
         <p class="pages">
-            <a href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() ?>staticpages/edit/?category=<?= urlencode($category) ?>"
+            <a href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() ?>staticpages/edit/"
                class="btn btn-primary btn-add">Add new page</a>
         </p>
     </div>


### PR DESCRIPTION
## Here's what I fixed or added:

Removed \Exception type constraint.

Removed a notice error.

## Here's why I did it:

PHP7 has different type hierarchy. 