### PR TITLE
Catch duplicate exceptions.

### DIFF
--- a/Idno/start.php
+++ b/Idno/start.php
@@ -11,8 +11,10 @@
     register_shutdown_function(function () {
         $error = error_get_last();
         if ($error["type"] == E_ERROR) {
-
-            ob_clean();
+            
+            try {
+                ob_clean();
+            } catch (ErrorException $e) {}
 
             http_response_code(500);
 


### PR DESCRIPTION
## Here's what I fixed or added:

Added a try/catch around ob_clean() call in fallback exception handler.

## Here's why I did it:

When running in pedantic mode, a test where an exception is thrown before output buffering has started, ob_clean() throws a notice, which in turn is converted into an exception and thus losing the original error.
