### PR TITLE
Access defaults

### DIFF
--- a/templates/default/content/access.tpl.php
+++ b/templates/default/content/access.tpl.php
@@ -1,10 +1,13 @@
 <?php
-
+ 
     $access = 'PUBLIC';
     if (!empty($vars['object'])) {
         if (!empty($vars['object']->access)) {
             $access = $vars['object']->access;
         }
+    } 
+    if (!empty($vars['default-access'])) {
+        $access = $vars['default-access'];
     }
 
     if (!empty(\Idno\Core\Idno::site()->config()->show_privacy) || $access != 'PUBLIC') {


### PR DESCRIPTION
## Here's what I fixed or added:

Added the ability to pass a "default" access permission to the ACL control box

## Here's why I did it:

It wasn't possible to default the box to anything other than 'PUBLIC'

