### PR TITLE
Remove pedantic-mode error when file is missing

### DIFF
--- a/Idno/Entities/File.php
+++ b/Idno/Entities/File.php
@@ -217,8 +217,10 @@
              */
             public static function isImage($file_path)
             {
-                if ($photo_information = getimagesize($file_path)) {
-                    return true;
+                if (!empty($file_path)) {
+                    if ($photo_information = getimagesize($file_path)) {
+                        return true;
+                    }
                 }
 
                 return false;


### PR DESCRIPTION
## Here's what I fixed or added:

Added conditional around $file_path

## Here's why I did it:

To avoid pedantic-mode exception

