### PR TITLE
Fixing acls redux

### DIFF
--- a/Idno/Entities/AccessGroup.php
+++ b/Idno/Entities/AccessGroup.php
@@ -85,9 +85,12 @@
             {
                 if ($this->canEdit()) {
                     if (($user = \Idno\Core\Idno::site()->db()->getObject($user_id)) && ($user instanceof User)) {
-                        array_push($this->$access, $user_id);
-
+                        if (!$this->isMember($user_id, $access)) {
+                            array_push($this->$access, $user_id);
+                        }
+                         
                         return true;
+                        
                     }
                 }
 

--- a/Idno/Entities/AccessGroup.php
+++ b/Idno/Entities/AccessGroup.php
@@ -52,7 +52,7 @@
             function isMember($user_id = '', $access = 'read')
             {
                 if (empty($user_id)) $user_id = \Idno\Core\Idno::site()->session()->currentUser()->uuid;
-                if (!empty($this->$access) && is_array($this->$access) && array_search($user_id, $this->$access)) {
+                if (!empty($this->$access) && is_array($this->$access) && (array_search($user_id, $this->$access)!==false)) {
                     return true;
                 }
 

--- a/Idno/Entities/AccessGroup.php
+++ b/Idno/Entities/AccessGroup.php
@@ -121,9 +121,12 @@
              */
             function removeMember($user_id, $access = 'read')
             {
-                if (!empty($this->members) && is_array($this->members) && $key = array_search($user_id, $this->members)) {
-                    unset($this->$access[$key]);
-
+                $key = array_search($user_id, $this->$access);
+                
+                if (!empty($this->$access) && is_array($this->$access) && $key !== false) { 
+                    //unset($this->$access[$key]);
+                    array_splice($this->$access, $key, 1);
+                    
                     return true;
                 }
 


### PR DESCRIPTION
## Here's what I fixed or added:

Prevent duplicate entries; fixing isMember()

## Here's why I did it:

* It was possible to enter a user into a given acl multiple times.
* isMember() would fail if $user_id was the first entry due to key '0' evaluating to boolean false.

