### PR TITLE
Acl addmember bypass

### DIFF
--- a/Idno/Entities/AccessGroup.php
+++ b/Idno/Entities/AccessGroup.php
@@ -83,7 +83,7 @@
              */
             function addMember($user_id, $access = 'read')
             {
-                if ($this->canEdit()) {
+                //if ($this->canEdit()) {
                     if (($user = \Idno\Core\Idno::site()->db()->getObject($user_id)) && ($user instanceof User)) {
                         if (!$this->isMember($user_id, $access)) {
                             array_push($this->$access, $user_id);
@@ -92,7 +92,7 @@
                         return true;
                         
                     }
-                }
+              //  }
 
                 return false;
             }

--- a/Idno/Entities/AccessGroup.php
+++ b/Idno/Entities/AccessGroup.php
@@ -85,9 +85,12 @@
             {
                 if ($this->canEdit()) {
                     if (($user = \Idno\Core\Idno::site()->db()->getObject($user_id)) && ($user instanceof User)) {
-                        array_push($this->$access, $user_id);
-
+                        if (!$this->isMember($user_id, $access)) {
+                            array_push($this->$access, $user_id);
+                        }
+                         
                         return true;
+                        
                     }
                 }
 

--- a/Idno/Entities/AccessGroup.php
+++ b/Idno/Entities/AccessGroup.php
@@ -52,7 +52,7 @@
             function isMember($user_id = '', $access = 'read')
             {
                 if (empty($user_id)) $user_id = \Idno\Core\Idno::site()->session()->currentUser()->uuid;
-                if (!empty($this->$access) && is_array($this->$access) && array_search($user_id, $this->$access)) {
+                if (!empty($this->$access) && is_array($this->$access) && (array_search($user_id, $this->$access)!==false)) {
                     return true;
                 }
 

--- a/Idno/Entities/AccessGroup.php
+++ b/Idno/Entities/AccessGroup.php
@@ -121,9 +121,12 @@
              */
             function removeMember($user_id, $access = 'read')
             {
-                if (!empty($this->members) && is_array($this->members) && $key = array_search($user_id, $this->members)) {
-                    unset($this->$access[$key]);
-
+                $key = array_search($user_id, $this->$access);
+                
+                if (!empty($this->$access) && is_array($this->$access) && $key !== false) { 
+                    //unset($this->$access[$key]);
+                    array_splice($this->$access, $key, 1);
+                    
                     return true;
                 }
 


### PR DESCRIPTION
## Here's what I fixed or added:

Removed canEdit() check on ACL addMember()

## Here's why I did it:

The canEdit() check made it impossible to use ACLs to manage something like a group join, since the AccessGroup object would always be owned by the group owner.

removeMember() had no such check, and management of ACLs is an inherently manual process, with no exposed API, so I figured the risk of exploit was minimal. 

Closes #1492 