### PR TITLE
URL Safe base64 encoding methods

### DIFF
--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -446,6 +446,23 @@
                 return false;
             }
 
+            /**
+             * Utility method to produce URL save base64 encoding.
+             * @param type $string
+             * @return string
+             */
+            static function base64UrlEncode($string) {
+                return strtr(base64_encode($string), '+/=', '-_,');
+            }
+
+            /**
+             * Utility method to decode URL save base64 encoding.
+             * @param type $string
+             * @return string
+             */
+            static function base64UrlDecode($string) {
+                return base64_decode(strtr($string, '-_,', '+/='));
+            }
         }
 
     }


### PR DESCRIPTION
## Here's what I fixed or added:

Added a URL safe version of base64.

## Here's why I did it:

It is not safe to include base64 content in urls, but it's handy to be able to do so.

