### PR TITLE
Make micropub authentication work on FastCGI servers

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,6 +4,9 @@
     RewriteEngine on
     #RewriteBase /
 
+    RewriteCond %{HTTP:Authorization} ^(.+)$
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
     RewriteCond %{ENV:BASE} ^$
     RewriteCond $1::%{REQUEST_URI} ^(.*)::(.*?)\1$
     RewriteRule ^(.*)$ - [ENV=BASE:%2]

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -860,12 +860,11 @@
              */
             static function getallheaders()
             {
-                if (function_exists('getallheaders')) {
-                    return getallheaders();
-                }
-
                 $headers = '';
                 foreach ($_SERVER as $name => $value) {
+                    if (substr($name, 0, 14) == 'REDIRECT_HTTP_') {
+                        $name = substr($name, 9);
+                    }
                     if (substr($name, 0, 5) == 'HTTP_') {
                         $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
                     }

--- a/htaccess-2.4.dist
+++ b/htaccess-2.4.dist
@@ -4,6 +4,9 @@
     RewriteEngine on
     #RewriteBase /
 
+    RewriteCond %{HTTP:Authorization} ^(.+)$
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
     RewriteCond %{ENV:BASE} ^$
     RewriteCond $1::%{REQUEST_URI} ^(.*)::(.*?)\1$
     RewriteRule ^(.*)$ - [ENV=BASE:%2]

--- a/htaccess.dist
+++ b/htaccess.dist
@@ -4,6 +4,9 @@
     RewriteEngine on
     #RewriteBase /
 
+    RewriteCond %{HTTP:Authorization} ^(.+)$
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
     RewriteCond %{ENV:BASE} ^$
     RewriteCond $1::%{REQUEST_URI} ^(.*)::(.*?)\1$
     RewriteRule ^(.*)$ - [ENV=BASE:%2]


### PR DESCRIPTION
## Here's what I fixed or added:
See full description in #1509.

When Apache connects to PHP via FastCGI, the HTTP "Authorization" header
is not sent to PHP.
.htaccess is modified so that the header is made available to PHP.

The header is available as REDIRECT_HTTP_AUTHORIZATION, so the
Idno/Common/Page::getallheaders() is adjusted to take that into account.
Usage of the native `getallheaders()` function is dropped since it does not
return the REDIRECT_HTTP_AUTHORIZATION header at all.

Resolves: #1505, #1509