### PR TITLE
Pubsub: findFeed now supports atom alternatives

### DIFF
--- a/Idno/Core/PubSubHubbub.php
+++ b/Idno/Core/PubSubHubbub.php
@@ -203,6 +203,16 @@
                     }
 
                 }
+                
+                if (empty($feed)) {
+                    if (preg_match_all('#<link[^>]+type="application/atom\+xml"[^>]*>#is', $data, $rawMatches)) {
+
+                    if (preg_match('#href="([^"]+)"#i', $rawMatches[0][0], $rawUrl)) {
+                        $feed = $rawUrl[1];
+                    }
+
+                }
+                }
 
                 return $feed;
             }


### PR DESCRIPTION
## Here's what I fixed or added:

Added atom feed to findFeed regex

## Here's why I did it:

We were previously only detecting atom feeds.

