### PR TITLE
Closes #1538: Make default return consistent with Input::getInput()

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -110,7 +110,7 @@
                     }
                 }
 
-                return false;
+                return null;
             }
 
             function exception($e)


### PR DESCRIPTION
## Here's what I fixed or added:

Changed Page::getInput() default return from false to null
## Here's why I did it:

getInput() was inconsistent when called from Input or Page
