### PR TITLE
Pour some salt on the slug debug

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -450,11 +450,11 @@
                             $title = md5(rand() . microtime(true));
                         }
                     }
-                    \Idno\Core\Idno::site()->logging()->debug("Setting resilient slug");
+                    //\Idno\Core\Idno::site()->logging()->debug("Setting resilient slug");
                     $this->setSlugResilient($title);
-                    \Idno\Core\Idno::site()->logging()->debug("Set resilient slug");
+                    //\Idno\Core\Idno::site()->logging()->debug("Set resilient slug");
                 } else {
-                    \Idno\Core\Idno::site()->logging()->debug("Had slug: " . $this->getSlug());
+                    //\Idno\Core\Idno::site()->logging()->debug("Had slug: " . $this->getSlug());
                 }
 
                 // Force users to be public


### PR DESCRIPTION
## Here's what I fixed or added:

Commented out all the slug debug / setting resilient slug messages

## Here's why I did it:

It's pretty clear this code is working now, and it makes for noisy logs when you're trying to debug something else.

