### PR TITLE
Bypass access groups query for site admins.

### DIFF
--- a/Idno/Data/AbstractSQL.php
+++ b/Idno/Data/AbstractSQL.php
@@ -169,10 +169,12 @@
                 }
 
                 // Make sure we're only getting objects that we're allowed to see
-                if (empty($readGroups)) {
-                    $readGroups = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
+                if (!\Idno\Core\site()->session()->isAdmin()) {
+                    if (empty($readGroups)) {
+                        $readGroups = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
+                    }
+                    $query_parameters['access'] = array('$in' => $readGroups);
                 }
-                $query_parameters['access'] = array('$in' => $readGroups);
 
                 // Join the rest of the search query elements to this search
                 $query_parameters = array_merge($query_parameters, $search);
@@ -246,8 +248,10 @@
                 }
 
                 // Make sure we're only getting objects that we're allowed to see
-                $readGroups                 = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
-                $query_parameters['access'] = array('$in' => $readGroups);
+                if (!\Idno\Core\site()->session()->isAdmin()) {
+                    $readGroups                 = \Idno\Core\Idno::site()->session()->getReadAccessGroupIDs();
+                    $query_parameters['access'] = array('$in' => $readGroups);
+                }
 
                 // Join the rest of the search query elements to this search
                 $query_parameters = array_merge($query_parameters, $search);


### PR DESCRIPTION
## Here's what I fixed or added:

When logged in as site admin, acls are bypassed.

## Here's why I did it:

While there is an admin bypass on canEdit() etc, object retrieval as site admin meant that such objects could not be retrieved and edited if created as another user.

Admins should be as Gods.

(Probably needs some discussion/checking to make sure this isn't some horrible security hole)
