### PR TITLE
Make entity canEdit/canRead ACL aware

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1226,6 +1226,21 @@
                 }
 
                 if ($this->getOwnerID() == $user_id) return true;
+                
+                // Check against access groups
+                $access = $this->getAccess();
+                if ($access instanceof \Idno\Entities\AccessGroup) {
+                    
+                    // If the user has been added to write
+                    if ($access->isMember($user_id, 'write')) {
+                        return \Idno\Core\Idno::site()->triggerEvent('canEdit', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
+                    }
+                    
+                    // If the user is an ADMIN member of the access group
+                    if ($access->isMember($user_id, 'admin')) {
+                        return \Idno\Core\Idno::site()->triggerEvent('canEdit', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
+                    }
+                }
 
                 return \Idno\Core\Idno::site()->triggerEvent('canEdit', array('object' => $this, 'user_id' => $user_id), false);
 

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1252,7 +1252,14 @@
                 if ($this->getOwnerID() == $user_id) return true;
 
                 if ($access instanceof \Idno\Entities\AccessGroup) {
+                    
+                    // If the user is a regular member of the access group
                     if ($access->isMember($user_id)) {
+                        return \Idno\Core\Idno::site()->triggerEvent('canRead', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
+                    }
+                    
+                    // If the user is an ADMIN member of the access group
+                    if ($access->isMember($user_id, 'admin')) {
                         return \Idno\Core\Idno::site()->triggerEvent('canRead', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
                     }
                 }


### PR DESCRIPTION
## Here's what I fixed or added:

* Added ACL admin awareness to canRead()
* Added ACL awareness of write and admin groups to canEdit().

This, among other things, makes these methods consistent with the database object read methods.

## Here's why I did it:

A user could be able to access an object, but not edit it, if they were in an ACL write group. Admins should always be able to write, so to should users who have been given admin writes over an object in it's acl. 

Since ACLs were not a well trodden path, this functionality was missing.
