### PR TITLE
Testing private ACLS, introducing getByAccessGroup

### DIFF
--- a/Idno/Entities/AccessGroup.php
+++ b/Idno/Entities/AccessGroup.php
@@ -134,6 +134,27 @@
 
                 return false;
             }
+            
+            /**
+             * Get entities by access group.
+             * @param mixed $access_group
+             * @param type $search
+             * @param type $fields
+             * @param type $limit
+             * @param type $offset
+             * @return boolean
+             */
+            static function getByAccessGroup($access_group, $search = array(), $fields = array(), $limit = 10, $offset = 0)
+            {
+                if (!empty($access_group)) {
+                    
+                    $search = array_merge($search, ['access' => $access_group]);
+
+                    return \Idno\Core\Idno::site()->db()->getObjects('', $search, $fields, $limit, $offset, static::$retrieve_collection);
+                }
+                
+                return false;
+            }
 
         }
 

--- a/Tests/Data/AccessGroupTest.php
+++ b/Tests/Data/AccessGroupTest.php
@@ -74,6 +74,12 @@ namespace Tests\Data {
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
             $this->assertFalse(empty($tmp));
             
+            
+            // Test objects in this UUID
+            $objs = \Idno\Entities\AccessGroup::getByAccessGroup(self::$acl->getUUID());
+            $this->assertTrue(count($objs) == 1);
+            
+            
             $obj->delete();
             
             // Restore old user if there was one

--- a/Tests/Data/AccessGroupTest.php
+++ b/Tests/Data/AccessGroupTest.php
@@ -78,6 +78,39 @@ namespace Tests\Data {
             $this->swapUser($old);
         }
         
+        // Create an owner only object
+        public function testOwnerOnly() {
+            $user = $this->user();
+            $old = $this->swapUser($user);
+            
+            // Create user only object
+            $obj = $this->newObject($user, $user->getUUID());
+            $obj->save();
+            
+            // Swap user
+            $a = $this->swapUser(self::$testUserB);
+            
+            // Check that B can't access object
+            $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
+            $this->assertTrue(empty($tmp));
+            
+            // Check that A can
+            $b = $this->swapUser($a);
+            $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
+            var_export($tmp);
+            $this->assertTrue(!empty($tmp));
+            
+            // Check Admin can always read
+            $admin = $this->admin();
+            $this->swapUser($admin);
+            
+            $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
+            $this->assertFalse(empty($tmp));
+            
+            // Restore old user if there was one
+            $this->swapUser($old);
+        }
+        
         public static function tearDownAfterClass()
         {
             self::$acl->delete(); 

--- a/Tests/Data/AccessGroupTest.php
+++ b/Tests/Data/AccessGroupTest.php
@@ -74,6 +74,8 @@ namespace Tests\Data {
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
             $this->assertFalse(empty($tmp));
             
+            $obj->delete();
+            
             // Restore old user if there was one
             $this->swapUser($old);
         }
@@ -106,6 +108,8 @@ namespace Tests\Data {
             
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
             $this->assertFalse(empty($tmp));
+            
+            $obj->delete();
             
             // Restore old user if there was one
             $this->swapUser($old);


### PR DESCRIPTION
## Here's what I fixed or added:

* Explicitly testing owner only "PRIVATE" ACL access
* Adding getByAccessGroup helper function to retrieve objects based on access group.

## Here's why I did it:

* The former needed to be tested
* The latter was useful
