### PR TITLE
Increase entropy on generated file ids

### DIFF
--- a/Idno/Files/LocalFileSystem.php
+++ b/Idno/Files/LocalFileSystem.php
@@ -66,7 +66,7 @@
                     $metadata = json_encode($metadata);
 
                     // Generate a random ID
-                    $id = md5(time() . $metadata);
+                    $id = md5(rand() . microtime(true) . $metadata);
 
                     // Generate save path
                     if ($path[sizeof($path) - 1] != '/') {


### PR DESCRIPTION
## Here's what I fixed or added:

Increased the entropy of file ID generation for the LocalFileSystem engine.

## Here's why I did it:

md5 of time() . metadata was in no way "random", and could result in a collision of a file was saved twice in quick succession (rare but sometimes desirable)


