### PR TITLE
Adding admin bypass to canRead

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1266,6 +1266,12 @@
                 if ($access == 'PUBLIC') return true;
                 if ($access == 'SITE' && \Idno\Core\Idno::site()->session()->isLoggedIn()) return true;
                 if ($this->getOwnerID() == $user_id) return true;
+                
+                if ($user = User::getByUUID($user_id)) {
+                    if ($user->isAdmin()) {
+                        return true;
+                    }
+                }
 
                 if ($access instanceof \Idno\Entities\AccessGroup) {
                     


### PR DESCRIPTION
## Here's what I fixed or added:

Added an isAdmin() shortcircuit to Entity::canRead()

## Here's why I did it:

Queries have an admin ACL bypass, so it was possible to retrieve the object but not view the object.