### PR TITLE
Limit ACL lookup to 'published' status posts.

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1256,17 +1256,19 @@
                 if ($this->getOwnerID() == $user_id) return true;
                 
                 // Check against access groups
-                $access = $this->getAccess();
-                if ($access instanceof \Idno\Entities\AccessGroup) {
-                    
-                    // If the user has been added to write
-                    if ($access->isMember($user_id, 'write')) {
-                        return \Idno\Core\Idno::site()->triggerEvent('canEdit', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
-                    }
-                    
-                    // If the user is an ADMIN member of the access group
-                    if ($access->isMember($user_id, 'admin')) {
-                        return \Idno\Core\Idno::site()->triggerEvent('canEdit', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
+                if ($this->getPublishStatus() == 'published') {
+                    $access = $this->getAccess();
+                    if ($access instanceof \Idno\Entities\AccessGroup) {
+
+                        // If the user has been added to write
+                        if ($access->isMember($user_id, 'write')) {
+                            return \Idno\Core\Idno::site()->triggerEvent('canEdit', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
+                        }
+
+                        // If the user is an ADMIN member of the access group
+                        if ($access->isMember($user_id, 'admin')) {
+                            return \Idno\Core\Idno::site()->triggerEvent('canEdit', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
+                        }
                     }
                 }
 
@@ -1300,16 +1302,18 @@
                     }
                 }
 
-                if ($access instanceof \Idno\Entities\AccessGroup) {
-                    
-                    // If the user is a regular member of the access group
-                    if ($access->isMember($user_id)) {
-                        return \Idno\Core\Idno::site()->triggerEvent('canRead', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
-                    }
-                    
-                    // If the user is an ADMIN member of the access group
-                    if ($access->isMember($user_id, 'admin')) {
-                        return \Idno\Core\Idno::site()->triggerEvent('canRead', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
+                if ($this->getPublishStatus() == 'published') {
+                    if ($access instanceof \Idno\Entities\AccessGroup) {
+
+                        // If the user is a regular member of the access group
+                        if ($access->isMember($user_id)) {
+                            return \Idno\Core\Idno::site()->triggerEvent('canRead', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
+                        }
+
+                        // If the user is an ADMIN member of the access group
+                        if ($access->isMember($user_id, 'admin')) {
+                            return \Idno\Core\Idno::site()->triggerEvent('canRead', array('object' => $this, 'user_id' => $user_id, 'access_group' => $access));
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Here's what I fixed or added:

AccessGroup check on canEdit() and canRead() methods are now limited to objects that are 'published'.

## Here's why I did it:

It occurred to me that objects saved as e.g. 'draft' in a shared context (e.g. a group) would loadable by others in the shared context's acl, which, although we could filter these out, could still be accessible if you knew or could guess the uuid.

While I'm pondering, I still think the entity retrieval functions should still retrieve based on ACL, this modification means that non-published entities can only be displayed by owner and admin for access limited posts.

I'm not sure whether we want this, or whether it's the best way, so I push this as a starting point for discussion.

