### PR TITLE
Closes #1558: Unset $this->vars['body'] after wizard display.

### DIFF
--- a/templates/default/robot/wizard.tpl.php
+++ b/templates/default/robot/wizard.tpl.php
@@ -69,3 +69,5 @@
             }
         }
     }
+    
+    unset($this->vars['body']);


### PR DESCRIPTION
## Here's what I fixed or added:

Unsets body after robot message is displayed

## Here's why I did it:

Body was ending up in posts.

Refs: benwerd/bonita#2