### PR TITLE
Provide a backup cache directory for HTML purifier

### DIFF
--- a/Idno/Core/Purifier.php
+++ b/Idno/Core/Purifier.php
@@ -9,8 +9,13 @@
 
             function init()
             {
+                $upload_dir = Idno::site()->config()->getUploadPath();
+                if (empty($upload_dir)) {
+                    $upload_dir = \Idno\Core\Idno::site()->config()->getTempDir();
+                }
+                
                 $config = \HTMLPurifier_Config::createDefault();
-                $config->set('Cache.SerializerPath', Idno::site()->config()->getUploadPath());
+                $config->set('Cache.SerializerPath', $upload_dir);
                 $this->purifier = new \HTMLPurifier($config);
             }
 


### PR DESCRIPTION
## Here's what I fixed or added:

If upload_dir isn't specified, purifier will use system temp for cache data

## Here's why I did it:

To remove this errrors.