### PR TITLE
Fixing File::getByURL()

### DIFF
--- a/Idno/Entities/File.php
+++ b/Idno/Entities/File.php
@@ -281,8 +281,11 @@
             static function getByURL($url)
             {
                 if (substr_count($url, \Idno\Core\Idno::site()->config()->getDisplayURL() . 'file/')) {
-                    $url = str_replace(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'file/', '', $url);
-
+                    
+                    if (preg_match('#'.\Idno\Core\Idno::site()->config()->getDisplayURL() ."file\/([a-zA-Z0-9]+)+#", $url, $matches)) {
+                        $url = $matches[1];
+                    }
+                    
                     return self::getByID($url);
                 }
 


### PR DESCRIPTION
## Here's what I fixed or added:

Changed getByURL() to better extract photo ids from urls.

## Here's why I did it:

The new mongo code exposed an error with File::getByURL() where by the file ID contained /thumb.jpg and so the object failed to be loaded from Mongo.



