### PR TITLE
Use temporary directory when upload_path not set

### DIFF
--- a/Idno/Core/Purifier.php
+++ b/Idno/Core/Purifier.php
@@ -43,7 +43,13 @@
             {
                 if ($basic_html) {
                     $config = \HTMLPurifier_Config::createDefault();
-                    $config->set('Cache.SerializerPath', Idno::site()->config()->getUploadPath());
+                    
+                    $upload_dir = Idno::site()->config()->getUploadPath();
+                    if (empty($upload_dir)) {
+                        $upload_dir = \Idno\Core\Idno::site()->config()->getTempDir();
+                    }
+                    
+                    $config->set('Cache.SerializerPath', $upload_dir);
                     $config->set('CSS.AllowedProperties', []);
                     $config->set('HTML.TidyRemove', 'br@clear');
                     $purifier = new \HTMLPurifier($config);


### PR DESCRIPTION
## Here's what I fixed or added:

Use temporary directory when upload_path not set for $basic_html route

## Here's why I did it:

Avoid error messages