### PR TITLE
Deprecate PHP 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
 matrix:
     allow_failures:
         - php: 5.4
+        - php: 5.5
 
 branches:
   only:

--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -76,7 +76,7 @@
                 }
 
                 // Check PHP version 
-                if (version_compare(phpversion(), '5.5') >= 0) {
+                if (version_compare(phpversion(), '5.6') >= 0) {
                     $basics['report']['php-version'] = [
                         'status' => 'Ok'
                     ];
@@ -84,7 +84,7 @@
                     $basics['status']             = 'Failure';
                     $basics['report']['php-version'] = [
                         'status'  => 'Warning',
-                        'message' => 'You are running Known using a very old version of PHP (' . phpversion() . '), which is no longer supported. Although Known will currently still install, some features will not work, so you should upgrade soon. You may need to ask your server administrator to upgrade PHP for you.'
+                        'message' => 'You are running Known using a very old version of PHP (' . phpversion() . '), which is no longer actively supported. Although Known will currently still install, some features may not work, so you should upgrade soon. You may need to ask your server administrator to upgrade PHP for you.'
                     ];
                 } else {
                     $basics['report']['php-version'] = [

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -4,7 +4,7 @@ Known _requires_ the following server components:
 
 + A Web Server that supports URL rewriting (Apache + mod_rewrite recommended).
 + If you are using Apache, you also need to make sure support for .htaccess is enabled (using [the AllowOverride All directive](https://help.ubuntu.com/community/EnablingUseOfApacheHtaccessFiles)).
-+ PHP 5.5 or above.
++ PHP 5.6 or above.
 + MySQL 5+, MongoDB, Postgres or SQLite3. We recommend MySQL.
 
 Known can either be installed at the root of a domain or subdomain, or in a subdirectory.

--- a/warmup/requirements.php
+++ b/warmup/requirements.php
@@ -22,12 +22,12 @@
 
             <?php
 
-                if (version_compare(phpversion(), '5.5') >= 0) {
+                if (version_compare(phpversion(), '5.6') >= 0) {
                     $class = 'success';
                     $text = 'You are running PHP version ' . phpversion() . '.';
                 } else if (version_compare(phpversion(), '5.4') >= 0) {
                     $class = 'warning';
-                    $text = 'You are running Known using a very old version of PHP (' . phpversion() . '), which is no longer supported. Although Known will currently still install, some features will not work, so you should upgrade soon. You may need to ask your server administrator to upgrade PHP for you.';
+                    $text = 'You are running Known using a very old version of PHP (' . phpversion() . '), which is no longer actively supported. Although Known will currently still install, some features may not work, so you should upgrade soon. You may need to ask your server administrator to upgrade PHP for you.';
                 } else {
                     $class = 'failure';
                     $text = 'You are running PHP version ' . phpversion() . ', which cannot run Known. You may need to ask your server administrator to upgrade PHP for you.';


### PR DESCRIPTION
## Here's what I fixed or added:
- Diagnostics and warmup will nag on both PHP 5.4 and PHP 5.5
- Installation requirements now documented as PHP 5.6+
- Moved 5.5 build to travis' allowed_failures branch
## Here's why I did it:

PHP 5.5 is dead, and will not be receiving security patches across the board, we should no longer go out of our way to support it. 

As with previous patch for 5.4, this isn't a hard failure, so those stuck on 5.5 can still install (with a massive warning), but the travis change means that while we will make best efforts to maintain support, we won't be held back.
