### PR TITLE
Make parseUsers() pluggable for in_reply_to events

### DIFF
--- a/Idno/Core/Template.php
+++ b/Idno/Core/Template.php
@@ -447,7 +447,12 @@
                             } else if (strpos($in_reply_to, 'github.com') !== false) {
                                 return '<a href="https://github.com/' . urlencode(ltrim($matches[1], '@')) . '" >' . $url . '</a>';
                             } else {
-                                return $url;
+                                return \Idno\Core\Idno::site()->triggerEvent("template/parseusers", [
+                                    'in_reply_to' => $in_reply_to,
+                                    'in_reply_to_domain' => parse_url($in_reply_to, PHP_URL_HOST),
+                                    'username' => ltrim($matches[1], '@'),
+                                    'match' => $url
+                                ], $url);
                             }
                         }, $text);
 


### PR DESCRIPTION
## Here's what I fixed or added:

Trigger an event for default in_reply_to parseUsers() callback

## Here's why I did it:

So plugins can extend @whatever users

