### PR TITLE
Fix photo uploads on mongo

### DIFF
--- a/Idno/Files/MongoDBFileSystem.php
+++ b/Idno/Files/MongoDBFileSystem.php
@@ -52,6 +52,10 @@
                             $file->metadata[$k] = $v;
                         }
                         
+                        if ($k == 'filename') {
+                            $file->metadata[$k] = basename($v);
+                        }
+                        
                         if ($v instanceof \MongoDB\BSON\UTCDateTime) { // Handle MongoDB dates
                             $file->metadata[$k] = $v->__toString();
                         }
@@ -70,7 +74,7 @@
             public function storeFile($file_path, $metadata, $options) {
 
                 $bucket = $this->gridfs_object;
-                
+                error_log("Storing $file_path with " . print_r($metadata, true));
                 try {
                     
                     if ($source = fopen($file_path, 'rb')) {


### PR DESCRIPTION
## Here's what I fixed or added:

Added basename to MongoFS file construction

## Here's why I did it:

On mongo, the new mongodb bucket library code passes the full file path as the filename. This caused broken images on photos, since the regex could not handle urls with an encoded "/" in the url.

Interestingly, this only happened with *some* images (the ones that work seem to get named "thumb.jpg"), not sure why that occurs... Aaaaanyway, this hadn't turned up in testing.

Note, files were still uploaded, so no data was actually being lost.
