### PR TITLE
Homepage and Profile feeds are draft aware

### DIFF
--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -621,7 +621,7 @@
              */
             function machineVersion()
             {
-                return '2016042301';
+                return '2016110101';
             }
 
             /**

--- a/Idno/Data/Mongo.php
+++ b/Idno/Data/Mongo.php
@@ -104,6 +104,28 @@
                         \Idno\Core\Idno::site()->logging()->debug("Mongo: Applying mongo upgrades - adding index.");
                         $this->database->entities->createIndex(['created' => 1]);
                     }
+                    if ($last_update < 2016110101) {
+                        \Idno\Core\Idno::site()->logging()->debug("Mongo: Applying mongo upgrades - adding publish_status backfill.");
+
+                        $limit = 25;
+                        $offset = 0;
+
+                        set_time_limit(0);
+
+                        while ($results = \Idno\Common\Entity::getFromAll([], [], $limit, $offset)) {
+
+                            foreach ($results as $item) {
+
+                                if (empty($item->publish_status)) {
+                                    \Idno\Core\Idno::site()->logging()->debug("Setting publish status on " . get_class($item) . " " . $item->getUUID());
+                                    $item->setPublishStatus();
+                                    $item->save();
+                                }
+                            }
+
+                            $offset += $limit;
+                        }
+                    }
                 });
             }
 

--- a/Idno/Pages/Homepage.php
+++ b/Idno/Pages/Homepage.php
@@ -78,6 +78,8 @@
                     $types = (array) $types;
                 }
 
+                $search['publish_status'] = 'published';
+                
                 $count = \Idno\Common\Entity::countFromX($types, array());
                 $feed  = \Idno\Common\Entity::getFromX($types, $search, array(), \Idno\Core\Idno::site()->config()->items_per_page, $offset);
                 if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {

--- a/Idno/Pages/User/View.php
+++ b/Idno/Pages/User/View.php
@@ -34,8 +34,8 @@
 
                 $types  = ['IdnoPlugins\Status\Status', 'IdnoPlugins\Text\Entry'];
                 $offset = (int)$this->getInput('offset');
-                $count  = \Idno\Common\Entity::countFromX($types, array('owner' => $user->getUUID()));
-                $feed   = \Idno\Common\Entity::getFromX($types, array('owner' => $user->getUUID()), array(), \Idno\Core\Idno::site()->config()->items_per_page, $offset);
+                $count  = \Idno\Common\Entity::countFromX($types, array('owner' => $user->getUUID(), 'publish_status' => 'published'));
+                $feed   = \Idno\Common\Entity::getFromX($types, array('owner' => $user->getUUID(), 'publish_status' => 'published'), array(), \Idno\Core\Idno::site()->config()->items_per_page, $offset);
 
                 $last_modified = $user->updated;
                 if (!empty($feed) && is_array($feed)) {


### PR DESCRIPTION
## Here's what I fixed or added:

* Mongo publish_status backfill
* Homepage and Profile feeds are draft aware

## Here's why I did it:

Because.
