### PR TITLE
Adding missing counts to Homepage feed

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -110,7 +110,7 @@
              * Count the number of objects of any specified class(es) that we're allowed to see
              *
              * @param array|string $class Class(es) to search (blank for all)
-             * @param array $search
+             * @param array $search List of filter terms (default: none)
              * @return int
              */
             static function countFromX($class, $search = array())

--- a/Idno/Pages/Homepage.php
+++ b/Idno/Pages/Homepage.php
@@ -78,7 +78,7 @@
                     $types = (array) $types;
                 }
 
-                $count = \Idno\Common\Entity::countFromX($types, array());
+                $count = \Idno\Common\Entity::countFromX($types, $search);
                 $feed  = \Idno\Common\Entity::getFromX($types, $search, array(), \Idno\Core\Idno::site()->config()->items_per_page, $offset);
                 if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {
                     $create = \Idno\Common\ContentType::getRegistered();


### PR DESCRIPTION
## Here's what I fixed or added:

Pass $search array to countFromX() call

## Here's why I did it:

Counts would return the incorrect value for searches.
