### PR TITLE
Version patches

### DIFF
--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -63,55 +63,34 @@
                             $schema_dir        = dirname(dirname(dirname(__FILE__))) . '/schemas/mysql/';
                             $client            = $this->client;
                             /* @var \PDO $client */
-                            if ($basedate < 2014100801) {
-                                if ($sql = @file_get_contents($schema_dir . '2014100801.sql')) {
-                                    try {
-                                        $statement = $client->prepare($sql);
-                                        $statement->execute();
-                                    } catch (\Exception $e) {
-                                        error_log($e->getMessage());
-                                    }
-                                }
-                                $newdate = 2014100801;
-                            }
-                            if ($basedate < 2015061501) {
-                                if ($sql = @file_get_contents($schema_dir . '2015061501.sql')) {
-                                    try {
-                                        $statement = $client->prepare($sql);
-                                        $statement->execute();
-                                    } catch (\Exception $e) {
-                                        error_log($e->getMessage());
-                                    }
-                                }
-                                $newdate = 2015061501;
-                            }
-                            if ($basedate < 2016013101) {
-                                if ($sql = @file_get_contents($schema_dir . '2016013101.sql')) {
-                                    try {
-                                        $statement = $client->prepare($sql);
-                                        $statement->execute();
-                                    } catch (\Exception $e) {
-                                        error_log($e->getMessage());
-                                    }
-                                }
-                                $newdate = 2016013101;
-                            }
-                            if ($basedate < 2016102601) {
-                                if ($sql = @file_get_contents($schema_dir . '2016102601.sql')) {
-                                    $statements = explode(";\n", $sql); // Explode statements; only mysql can support multiple statements per line, and then only badly.
-                                    foreach ($statements as $sql) {
-                                        $sql = trim($sql);
-                                        if (!empty($sql)) {
-                                            try {
-                                                $statement = $client->prepare($sql);
-                                                $statement->execute();
-                                            } catch (\Exception $e) {
-                                                error_log($e->getMessage());
+                            
+                            
+                            // Optimise upgrades
+                            foreach ([
+                                // List upgrades, add yours to the end
+                                2014100801,
+                                2015061501,
+                                2016013101,
+                                2016102601,
+                                2016110301
+                            ] as $date) {
+                                if ($basedate < $date) {
+                                    if ($sql = @file_get_contents($schema_dir . $date . '.sql')) {
+                                        $statements = explode(";\n", $sql); // Explode statements; only mysql can support multiple statements per line, and then only badly.
+                                        foreach ($statements as $sql) {
+                                            $sql = trim($sql);
+                                            if (!empty($sql)) {
+                                                try {
+                                                    $statement = $client->prepare($sql);
+                                                    $statement->execute();
+                                                } catch (\Exception $e) {
+                                                    error_log($e->getMessage());
+                                                }
                                             }
                                         }
                                     }
+                                    $newdate = $date;
                                 }
-                                $newdate = 2016102601;
                             }
                         }
                     }

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -76,6 +76,9 @@
                             ] as $date) {
                                 if ($basedate < $date) {
                                     if ($sql = @file_get_contents($schema_dir . $date . '.sql')) {
+                                        
+                                        error_log("Applying schema updates from {$schema_dir}{$date}.sql");
+                                        
                                         $statements = explode(";\n", $sql); // Explode statements; only mysql can support multiple statements per line, and then only badly.
                                         foreach ($statements as $sql) {
                                             $sql = trim($sql);

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -75,6 +75,9 @@
                             ] as $date) {
                                 if ($basedate < $date) {
                                     if ($sql = @file_get_contents($schema_dir . $date . '.sql')) {
+                                        
+                                        error_log("Applying schema updates from {$schema_dir}{$date}.sql");
+                                        
                                         $statements = explode(";\n", $sql); // Explode statements; only mysql can support multiple statements per line, and then only badly.
                                         foreach ($statements as $sql) {
                                             $sql = trim($sql);

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -68,24 +68,30 @@
                             $schema_dir        = dirname(dirname(dirname(__FILE__))) . '/schemas/mysql/';
                             $client            = $this->client;
 
-                            
-                            if ($basedate < 2016102601) {
-                                if ($sql = @file_get_contents($schema_dir . '2016102601.sql')) {
-                                    $statements = explode(";\n", $sql); // Explode statements; only mysql can support multiple statements per line.
-                                    foreach ($statements as $sql) {
-                                        $sql = trim($sql);
-                                        if (!empty($sql)) {
-                                            try {
-                                                $statement = $client->prepare($sql);
-                                                $statement->execute();
-                                            } catch (\Exception $e) {
-                                                error_log($e->getMessage());
+                            foreach ([
+                                // List upgrades, add yours to the end
+                                2016102601,
+                                2016110301
+                            ] as $date) {
+                                if ($basedate < $date) {
+                                    if ($sql = @file_get_contents($schema_dir . $date . '.sql')) {
+                                        $statements = explode(";\n", $sql); // Explode statements; only mysql can support multiple statements per line, and then only badly.
+                                        foreach ($statements as $sql) {
+                                            $sql = trim($sql);
+                                            if (!empty($sql)) {
+                                                try {
+                                                    $statement = $client->prepare($sql);
+                                                    $statement->execute();
+                                                } catch (\Exception $e) {
+                                                    error_log($e->getMessage());
+                                                }
                                             }
                                         }
                                     }
+                                    $newdate = $date;
                                 }
-                                $newdate = 2016102601;
                             }
+                            
                         }
                     }
                 }

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -74,22 +74,28 @@
                             $client            = $this->client;
                             
                             
-                            if ($basedate < 2016102601) {
-                                if ($sql = @file_get_contents($schema_dir . '2016102601.sql')) {
-                                    $statements = explode(";\n", $sql); // Explode statements; only mysql can support multiple statements per line.
-                                    foreach ($statements as $sql) {
-                                        $sql = trim($sql);
-                                        if (!empty($sql)) {
-                                            try {
-                                                $statement = $client->prepare($sql);
-                                                $statement->execute();
-                                            } catch (\Exception $e) {
-                                                error_log($e->getMessage());
+                            foreach ([
+                                // List upgrades, add yours to the end
+                                2016102601,
+                                2016110301
+                            ] as $date) {
+                                if ($basedate < $date) {
+                                    if ($sql = @file_get_contents($schema_dir . $date . '.sql')) {
+                                        $statements = explode(";\n", $sql); // Explode statements; only mysql can support multiple statements per line, and then only badly.
+                                        foreach ($statements as $sql) {
+                                            $sql = trim($sql);
+                                            if (!empty($sql)) {
+                                                try {
+                                                    $statement = $client->prepare($sql);
+                                                    $statement->execute();
+                                                } catch (\Exception $e) {
+                                                    error_log($e->getMessage());
+                                                }
                                             }
                                         }
                                     }
+                                    $newdate = $date;
                                 }
-                                $newdate = 2016102601;
                             }
                         }
                     }

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -81,6 +81,9 @@
                             ] as $date) {
                                 if ($basedate < $date) {
                                     if ($sql = @file_get_contents($schema_dir . $date . '.sql')) {
+                                        
+                                        error_log("Applying schema updates from {$schema_dir}{$date}.sql");
+                                        
                                         $statements = explode(";\n", $sql); // Explode statements; only mysql can support multiple statements per line, and then only badly.
                                         foreach ($statements as $sql) {
                                             $sql = trim($sql);

--- a/schemas/mysql/2016110301.sql
+++ b/schemas/mysql/2016110301.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS `versions` (
+  `label` varchar(32) NOT NULL,
+  `value` varchar(10) NOT NULL,
+  PRIMARY KEY (`label`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+REPLACE INTO `versions` VALUES('schema', '2016110301');

--- a/schemas/mysql/mysql.sql
+++ b/schemas/mysql/mysql.sql
@@ -110,4 +110,4 @@ CREATE TABLE IF NOT EXISTS `session` (
     PRIMARY KEY (`session_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-REPLACE INTO `versions` VALUES('schema', '2016102601');
+REPLACE INTO `versions` VALUES('schema', '2016110301');

--- a/schemas/postgres/2016110301.sql
+++ b/schemas/postgres/2016110301.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS versions (
+  label varchar(32) NOT NULL,
+  value varchar(10) NOT NULL,
+  PRIMARY KEY (label)
+);
+
+DELETE FROM versions WHERE label = 'schema';
+INSERT INTO versions VALUES('schema', '2016110301');

--- a/schemas/postgres/postgres.sql
+++ b/schemas/postgres/postgres.sql
@@ -105,7 +105,7 @@ CREATE TABLE IF NOT EXISTS versions (
 );
 
 DELETE FROM versions WHERE label = 'schema';
-INSERT INTO versions VALUES('schema', '2016102601');
+INSERT INTO versions VALUES('schema', '2016110301');
 
 --
 -- Session handling table

--- a/schemas/sqlite3/2016110301.sql
+++ b/schemas/sqlite3/2016110301.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS versions (
+  label varchar(32) NOT NULL PRIMARY KEY,
+  value varchar(10) NOT NULL
+);
+
+REPLACE INTO `versions` VALUES('schema', '2016110301');

--- a/schemas/sqlite3/sqlite3.sql
+++ b/schemas/sqlite3/sqlite3.sql
@@ -119,4 +119,4 @@ CREATE TABLE IF NOT EXISTS session (
     session_time int(11) NOT NULL
 );
 
-REPLACE INTO `versions` VALUES('schema', '2016102601');
+REPLACE INTO `versions` VALUES('schema', '2016110301');


### PR DESCRIPTION
## Here's what I fixed or added:

Further to 6b168a1de4fc683849ed1506bac6b46f640701fb, I've added a CREATE TABLE to create a versions table if it was missing (for really old schemas)

I also optimised the schema upgrade code.

## Here's why I did it:

Many sites were running old old schemas which didn't have versions, and so this broke upgrades.