### PR TITLE
Closes #739: Using datetime form control where supported, because HTML5

### DIFF
--- a/IdnoPlugins/Event/templates/default/entity/Event/edit.tpl.php
+++ b/IdnoPlugins/Event/templates/default/entity/Event/edit.tpl.php
@@ -34,13 +34,13 @@
             <div class="content-form">
                 <label for="starttime">
                     Start day and time</label>
-                    <input type="text" name="starttime" id="starttime" placeholder="Type in the start day and time" value="<?=htmlspecialchars($vars['object']->starttime)?>" class="form-control" />
+                <input type="datetime-local" name="starttime" id="starttime" placeholder="Type in the start day and time" value="<?=htmlspecialchars($vars['object']->starttime)?>" class="form-control" />
 
             </div>
             <div class="content-form">
                 <label for="endtime">
                     End day and time</label>
-                    <input type="text" name="endtime" id="endtime" placeholder="Type in the end day and time" value="<?=htmlspecialchars($vars['object']->endtime)?>" class="form-control" />
+                    <input type="datetime-local" name="endtime" id="endtime" placeholder="Type in the end day and time" value="<?=htmlspecialchars($vars['object']->endtime)?>" class="form-control" />
 
             </div>
             <?php echo $this->drawSyndication('event', $vars['object']->getPosseLinks()); ?>


### PR DESCRIPTION
## Here's what I fixed or added:

Making start/end control datetime-local

## Here's why I did it:

Adds a date picker where supported, without the need for jquery or similar libraries.

Discuss as to whether this is the correct approach.

cc/ @benwerd 

