### PR TITLE
Allow user access group lists to be extended programmatically

### DIFF
--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -671,7 +671,7 @@
                     $return = array_merge($return, $groups);
                 }
 
-                return $return;
+                return \Idno\Core\Idno::site()->triggerEvent("permission:$permission:entities", [], $return);
             }
 
             /**
@@ -719,7 +719,7 @@
                     }
                 }
 
-                return $return;
+                return \Idno\Core\Idno::site()->triggerEvent("permission:$permission:ids", [], $return);
             }
 
             /**


### PR DESCRIPTION
## Here's what I fixed or added:

Added a plugin hook for access control groups

## Here's why I did it:

Allow for programmatic modification/addition of access control lists.
