### PR TITLE
fix layout of Convoy+IndiePub plugin account page

### DIFF
--- a/IdnoPlugins/Convoy/templates/default/convoy/account/signup.tpl.php
+++ b/IdnoPlugins/Convoy/templates/default/convoy/account/signup.tpl.php
@@ -3,7 +3,7 @@
 
         <?= $this->draw('account/menu') ?>
 
-        <h1 style="text-align: center; margin: 1em">
+        <h1>
             Connect to social media
         </h1>
         <h2 style="margin-bottom: 1em !important; margin-top: 1em !important">

--- a/IdnoPlugins/IndiePub/templates/default/account/indiepub.tpl.php
+++ b/IdnoPlugins/IndiePub/templates/default/account/indiepub.tpl.php
@@ -5,45 +5,46 @@ use Idno\Core\Idno;
 $baseURL = Idno::site()->config()->getDisplayURL();
 $user = Idno::site()->session()->currentUser();
 ?>
+<div class="row">
+    <div class="col-md-offset-1 col-md-10">
 
-<div class="col-md-offset-1 col-md-10">
+        <?= $this->draw('account/menu') ?>
+        <h1>IndiePub Accounts</h1>
 
-    <?= $this->draw('account/menu') ?>
-    <h1>IndiePub Accounts</h1>
 
-    
-    <?php 
-    if (empty($user->indieauth_tokens)) {
-        ?>
-        <div class="explanation">
-            <p>
-                There are currently no IndiePub accounts associated with this site.
-            </p>
-        </div>
-    <?php
-    } else {
-        foreach ((array) $user->indieauth_tokens as $token => $details) { ?>
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                Client ID: <a href="<?= $details['client_id'] ?>" target="_blank"><?= $details['client_id'] ?></a>
-            </div>
-            <div class="panel-body" >
+        <?php
+        if (empty($user->indieauth_tokens)) {
+            ?>
+            <div class="explanation">
                 <p>
-                    Authorized <strong><?= strftime('%Y-%m-%d', $details['issued_at']) ?></strong>
-                    with the scope <strong><?= $details['scope'] ?></strong>.
+                    There are currently no IndiePub accounts associated with this site.
                 </p>
-                <p>
-                  Token: <?= substr($token, 0, 5) ?>&hellip;
-                </p>
-                <form action="<?= Idno::site()->config()->getDisplayURL() ?>account/indiepub/revoke" method="POST">
-                    <input name="token" type="hidden" value="<?= $token ?>">
-                    <button class="btn btn-warning" type="submit">Revoke Access</button>
-                    <?= Idno::site()->actions()->signForm('account/indiepub/revoke') ?>
-                </form>
             </div>
-        </div>
-    <?php 
-        }
-    }?>
+        <?php
+        } else {
+            foreach ((array) $user->indieauth_tokens as $token => $details) { ?>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    Client ID: <a href="<?= $details['client_id'] ?>" target="_blank"><?= $details['client_id'] ?></a>
+                </div>
+                <div class="panel-body" >
+                    <p>
+                        Authorized <strong><?= strftime('%Y-%m-%d', $details['issued_at']) ?></strong>
+                        with the scope <strong><?= $details['scope'] ?></strong>.
+                    </p>
+                    <p>
+                      Token: <?= substr($token, 0, 5) ?>&hellip;
+                    </p>
+                    <form action="<?= Idno::site()->config()->getDisplayURL() ?>account/indiepub/revoke" method="POST">
+                        <input name="token" type="hidden" value="<?= $token ?>">
+                        <button class="btn btn-warning" type="submit">Revoke Access</button>
+                        <?= Idno::site()->actions()->signForm('account/indiepub/revoke') ?>
+                    </form>
+                </div>
+            </div>
+        <?php
+            }
+        }?>
 
+</div>
 </div>


### PR DESCRIPTION
## Here's what I fixed or added:

fixed h1 heading in Convoy plugin and added row div in IndiePub plugin account page

## Here's why I did it:

Cycling through the "Account settings" sub pages the layouts of "Connect services" and "IndiePub" weren't in line with the other pages. Now they are.
