### PR TITLE
Ignore netbeans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ Idno/.idea/.name
 /.DS_Store
 /*/.DS_Store
 
+/codedocs/
+
 config.ini
 *.json
 tests/_output/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Idno/.idea/.name
 /nbproject/private/nbproject/project.xml
 /nbproject/project.properties
 /nbproject/private/
+/**/nbproject/
 /.htaccess
 /doc/output/
 /Uploads/*


### PR DESCRIPTION
## Here's what I fixed or added:

* Added a gitignore for /foo/bar/nbproject 
* Added /codedocs/

## Here's why I did it:

To prevent accidentally committing project and code docs when working on the project