### PR TITLE
Added a new community plugin for Videos

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -8,6 +8,7 @@ listings here do not imply endorsement by the Known project team in any way.
 
 ### Content types
 
+* [Video] (https://github.com/cweiske/withknownVideo) – Post videos to your Known site, by [Christian Weiske][]
 * [Video](https://github.com/tjgillies/Video) – Post videos to your Known site, by [Tyler Gillies][]
 * [Recipe](https://github.com/cleverdevil/Known-Recipes) – Post recipes to your Known site, by [Jonathan LaCour][]
 * [Review](https://github.com/cleverdevil/Known-Reviews) – Post reviews to your Known site, by [Jonathan LaCour][]
@@ -103,6 +104,7 @@ listings here do not imply endorsement by the Known project team in any way.
 [Yann Sallou]: http://winds.fr/
 [Tino Kremer]: https://tinokremer.nl/
 [Björn Stierand]: https://bjoern.stierand.org/
+[Christian Weiske]: https://cweiske.de/
 
 ## Submissions
 


### PR DESCRIPTION
## Here's what I fixed or added:

I saw that a fork was made of the community Video plugin that was listed, so I added the forked Video plugin to the list in the docs so that others can find it easier in the future.

## Here's why I did it:

People said that the other community Video plugin wasn't working https://twitter.com/finalcut/status/817123405321355264