### PR TITLE
Only load initial_plugins the once

### DIFF
--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -194,6 +194,10 @@
                 }
 
                 if (!empty($this->ini_config)) {
+                    
+                    if (isset($this->config['initial_plugins']))
+			unset($this->ini_config['initial_plugins']);
+		    
                     $this->config = array_replace_recursive($this->config, $this->ini_config);
                 }
 


### PR DESCRIPTION
## Here's what I fixed or added:

Unset initial_plugins if present in config, as loaded from the database.

## Here's why I did it:

Not doing this meant that if a plugin was present in the ini but not in the database then the merged array contained the missing setting.

This is ONE PROPOSED solution, another would be to reverse the precedence so that database settings ALWAYS replace config settings, but that might be undesirable in other ways (for example, it's quite often desirable to have ini trump database for many things) 