### PR TITLE
Xml import enhancements

### DIFF
--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -291,7 +291,8 @@
                             $object->setTitle(html_entity_decode($item->get_title()));
                             $object->created = strtotime(($item->get_date("c")));
                             $object->body    = ($body);
-                            $object->publish(true);
+                            //$object->publish(true);
+                            $object->save();
                             
                             $imported++;
                         }

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -249,6 +249,8 @@
                 $xml_parser->set_raw_data($xml);
                 $xml_parser->init();
 
+                $imported = 0;
+                
                 if ($items = $xml_parser->get_items()) {
 
                     foreach ($items as $item) {
@@ -290,12 +292,15 @@
                             $object->created = strtotime(($item->get_date("c")));
                             $object->body    = ($body);
                             $object->publish(true);
+                            
+                            $imported++;
                         }
 
                     }
 
                     // for now, lets assume a successful save
-                    return true;
+                    if ($imported > 0)
+                        return true;
                 }
 
             }
@@ -373,6 +378,8 @@
 
                     unset($namespace_data);
                     unset($xml);
+                    
+                    $imported = 0;
 
                     if (!empty($data->channel->item)) {
                         foreach ($data->channel->item as $item_structure) {
@@ -428,7 +435,9 @@
                                     $object->created = $published;
                                     $object->body    = ($body);
                                     $object->save();
-                                    //$object->publish(true);
+                                    //$object->publish(true); // Pingig probably a bad idea for imports, plus it is vvvvveeeeeeeerrrrrrrrrryyyyyyy slow
+                                    
+                                    $imported++;
 
                                 } else {
                                     \Idno\Core\Idno::site()->logging()->debug("Creating new Entry from '$title'");
@@ -438,6 +447,8 @@
                                     $object->body    = ($body);
                                     $object->save();
                                     //$object->publish(true);
+                                    
+                                    $imported++;
                                 }
 
                                 if (!empty($item['wp:comment'])) {
@@ -465,8 +476,9 @@
 
                         }
                         
-                        // For now, lets assume that everything saved ok
-                        return true;
+                        // For now, lets assume that everything saved ok, if something was imported
+                        if ($imported > 0)
+                            return true;
                     }
 
                 }

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -484,6 +484,7 @@
 
                 }
                 
+                // Catch and log any XML parsing errors and report them
                 foreach (libxml_get_errors() as $error) {
                     \Idno\Core\Idno::site()->logging()->error($error->message);
                 }

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -363,6 +363,8 @@
                 if (!($text = \Idno\Core\Idno::site()->plugins()->get('Text'))) {
                     return false;
                 }
+                
+                libxml_use_internal_errors(true);
 
                 if ($data = simplexml_load_string($xml, null, LIBXML_NOCDATA)) {
 
@@ -465,6 +467,12 @@
                     }
 
                 }
+                
+                foreach (libxml_get_errors() as $error) {
+                    \Idno\Core\Idno::site()->logging()->error($error->message);
+                }
+
+                libxml_clear_errors();
 
             }
 

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -516,7 +516,7 @@
                             'offset'   => 0,
                             'count'    => sizeof($feed),
                             'subject'  => [],
-                            'nocdata'  => true,
+                            //'nocdata'  => true,
                             'base_url' => $base_url
                         ))->draw('pages/home'),
 

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -423,18 +423,21 @@
 
                                 self::importImagesFromBodyHTML($body, parse_url($item['link'], PHP_URL_HOST));
                                 if (empty($item['title']) && strlen($body) < 600) {
+                                    \Idno\Core\Idno::site()->logging()->debug("Creating new Status post");
                                     $object          = new \IdnoPlugins\Status\Status();
                                     $object->created = $published;
                                     $object->body    = ($body);
-                                    $object->publish(true);
+                                    $object->save();
+                                    //$object->publish(true);
 
                                 } else {
-
+                                    \Idno\Core\Idno::site()->logging()->debug("Creating new Entry from '$title'");
                                     $object = new \IdnoPlugins\Text\Entry();
                                     $object->setTitle(html_entity_decode($title));
                                     $object->created = $published;
                                     $object->body    = ($body);
-                                    $object->publish(true);
+                                    $object->save();
+                                    //$object->publish(true);
                                 }
 
                                 if (!empty($item['wp:comment'])) {
@@ -458,7 +461,7 @@
                                         }
                                     }
                                 }
-                            }
+                            } 
 
                         }
                         

--- a/Idno/Pages/Admin/Import.php
+++ b/Idno/Pages/Admin/Import.php
@@ -54,15 +54,19 @@
                 set_time_limit(0);          // Eliminate time limit - this could take a while
 
                 $imported = false;
-                switch (strtolower($import_type)) {
+                try {
+                    switch (strtolower($import_type)) {
 
-                    case 'blogger':
-                        $imported = Migration::importBloggerXML($xml);
-                        break;
-                    case 'wordpress':
-                        $imported = Migration::importWordPressXML($xml);
-                        break;
+                        case 'blogger':
+                            $imported = Migration::importBloggerXML($xml);
+                            break;
+                        case 'wordpress':
+                            $imported = Migration::importWordPressXML($xml);
+                            break;
 
+                    }
+                } catch (\Exception $e) {
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                 }
                 if ($imported) {
                     \Idno\Core\Idno::site()->logging()->info("Completed import successfully, sending email to ". \Idno\Core\Idno::site()->session()->currentUser()->email);

--- a/Idno/Pages/Admin/Import.php
+++ b/Idno/Pages/Admin/Import.php
@@ -77,8 +77,16 @@
                     $mail->addTo(\Idno\Core\Idno::site()->session()->currentUser()->email);
                     $mail->setSubject("Your data import has completed");
                     $mail->send();
-                } else
+                } else {
                     \Idno\Core\Idno::site()->logging()->error("Import completed, but may not have been successful");
+                    
+                    $mail = new \Idno\Core\Email();
+                    $mail->setHTMLBodyFromTemplate('admin/import_failure');
+                    $mail->setTextBodyFromTemplate('admin/import_failure');
+                    $mail->addTo(\Idno\Core\Idno::site()->session()->currentUser()->email);
+                    $mail->setSubject("There was a problem with your data import");
+                    $mail->send();
+                }
                 
                 exit; // prevent forward
             }

--- a/templates/email-text/admin/import_failure.tpl.php
+++ b/templates/email-text/admin/import_failure.tpl.php
@@ -1,0 +1,7 @@
+Sorry, your data import was unsuccessful.
+=========================================
+
+It looks like some or all of the data you provided could not be imported. 
+You could try the import again, or ask your system administrator for help!
+
+Visit your site: <?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>

--- a/templates/email/admin/import_failure.tpl.php
+++ b/templates/email/admin/import_failure.tpl.php
@@ -1,0 +1,13 @@
+<div style="font-weight: bold; font-size: 30px; line-height: 32px; color: #333" align="center">
+    Sorry, your data import was unsuccessful.
+</div><br>
+<hr/>
+<br>
+It looks like some or all of the data you provided could not be imported. You could try the import again, or ask your system administrator for help!
+<br><br>
+<div align="center">
+    <a href="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>" style="background-color:#73B2E3;border:1px solid #73B2E3;border-radius:4px;color:#ffffff;display:inline-block;font-family:sans-serif;font-size:17px;font-weight:normal;line-height:40px;text-align:center;text-decoration:none;width:200px;-webkit-text-size-adjust:none;mso-hide:all;">Visit your site</a>
+</div>
+<br>
+<br>
+<br>

--- a/templates/rss/shell.tpl.php
+++ b/templates/rss/shell.tpl.php
@@ -85,6 +85,10 @@
             $rssItem->appendChild($page->createElement('guid',$item->getUUID()));
             $rssItem->appendChild($page->createElement('pubDate',date(DATE_RSS,$item->created)));
 
+            // Needed for WP import into Known
+            $rssItem->appendChild($page->createElement('wp:post_type', 'post'));
+            $rssItem->appendChild($page->createElement('wp:status', 'publish'));
+            
             $owner = $item->getOwner();
             if (!empty($owner)) {
                 $rssItem->appendChild($page->createElement('author', "{$owner->title}"));

--- a/templates/rss/shell.tpl.php
+++ b/templates/rss/shell.tpl.php
@@ -80,7 +80,7 @@
                 }
             }
             $rssItem = $page->createElement('item');
-            $rssItem->appendChild($page->createElement('title', htmlentities(strip_tags($title), ENT_QUOTES, 'UTF-8')));
+            $rssItem->appendChild($page->createElement('title', strip_tags($title)));
             $rssItem->appendChild($page->createElement('link',$item->getSyndicationURL()));
             $rssItem->appendChild($page->createElement('guid',$item->getUUID()));
             $rssItem->appendChild($page->createElement('pubDate',date(DATE_RSS,$item->created)));


### PR DESCRIPTION
## Here's what I fixed or added:

* Fixed some encoding issues with RSS export
* Made Wordpress RSS import more resilient 
* Improved debugging
* Changed from $object->publish() to $object->save(), since import pings were probably undesirable, but certainly VEEEERRRRY slow
* Added failure email, so the user always hears something back

## Here's why I did it:

* Wordpress generated imports were working, but known generated wordpress exports could not then be imported.
