### PR TITLE
Assume last content-type is correct when we get multiple

### DIFF
--- a/Idno/Pages/Entity/Share.php
+++ b/Idno/Pages/Entity/Share.php
@@ -40,6 +40,11 @@
                         $headers = http_parse_headers($head['header']);
                     }
 
+                    // In cases where there's a 30x redirect, it is possible to get multiple content type headers, for now let's assume the final destination is valid. (#1596)
+                    if (is_array($headers['Content-Type'])) {
+                        $headers['Content-Type'] = end($headers['Content-Type']);
+                    }
+                    
                     // Only MF2 Parse supported types
                     if (isset($headers['Content-Type']) && preg_match('/text\/(html|plain)+/', $headers['Content-Type'])) {
 


### PR DESCRIPTION
## Here's what I fixed or added:

In cases where content-type is an array, use the last entry when determining whether a page is something we can mine for MF2.

## Here's why I did it:

When sharing some urls, it is possible (although rare) that you get multiple Content-Type headers back. This caused the regex on the share page to throw an error.

What seems to be happening is that if you share a URL which performs a 30x redirect, on some servers, both the 301 and the 200 return a Content-Type header, which curl captures and is then returned to us as an array of Content-Type headers. 

It makes no sense for a redirect to return a content type, so I'm thinking the sites who's urls are being shared are misconfigured in some way, but, we should handle this gracefully.

Since the 200 response should always be the last, lets assume that the last entry in the array is the canonical content-type for the page. 

