### PR TITLE
Valid rss

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   # Update and install base system
   - sudo apt-get update
   - sudo apt-get install -y --force-yes apache2 libapache2-mod-fastcgi make
-  - sudo apt-get install -y --force-yes php5-dev php-pear php5-mysql php5-curl php5-gd php5-json php5-sqlite php5-pgsql
+  - sudo apt-get install -y --force-yes php5-dev php-pear php5-mysql php5-curl php5-gd php5-json php5-sqlite php5-pgsql libxml2-utils curl
   - sudo a2enmod headers
   # Enable php-fpm and Mongodb
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then sudo cp Tests/build/www.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi

--- a/Tests/Pages/RSSTest.php
+++ b/Tests/Pages/RSSTest.php
@@ -9,6 +9,10 @@
                 $output = [];
                 exec("curl -L --silent '".\Idno\Core\Idno::site()->config()->url."?_t=rss' | xmllint --noout - 2>&1", $output);
                 
+                if (!empty($output)) {
+                    var_export($output);
+                }
+                
                 $this->assertTrue(empty($output));
             }
 

--- a/Tests/Pages/RSSTest.php
+++ b/Tests/Pages/RSSTest.php
@@ -11,6 +11,13 @@
                 
                 if (!empty($output)) {
                     var_export($output);
+                    
+                    // Hack to handle travis' old build environment
+                    foreach ($output as $k => $v) {
+                        if (strpos($v, 'Warning: program compiled against libxml')!==false) {
+                            unset($output[$k]);
+                        }
+                    }
                 }
                 
                 $this->assertTrue(empty($output));

--- a/Tests/Pages/RSSTest.php
+++ b/Tests/Pages/RSSTest.php
@@ -1,0 +1,17 @@
+<?php
+
+    namespace Tests\Pages {
+
+        class RSSTest extends \Tests\KnownTestCase {
+
+            function testValid()
+            {
+                $output = [];
+                exec("curl -L --silent '".\Idno\Core\Idno::site()->config()->url."?_t=rss' | xmllint --noout - 2>&1", $output);
+                
+                $this->assertTrue(empty($output));
+            }
+
+        }
+
+    }

--- a/templates/rss/shell.tpl.php
+++ b/templates/rss/shell.tpl.php
@@ -26,7 +26,7 @@
     $rss->setAttribute('xmlns:geo', 'http://www.w3.org/2003/01/geo/wgs84_pos#');
     $rss->setAttribute('xmlns:dc', 'http://purl.org/dc/elements/1.1/');
     $rss->setAttribute('xmlns:itunes', 'http://www.itunes.com/dtds/podcast-1.0.dtd');
-    //$rss->setAttribute('xmlns:wp', 'http://wordpress.org/export/1.2/');
+    $rss->setAttribute('xmlns:wp', 'http://wordpress.org/export/1.2/');
     $channel = $page->createElement('channel');
     $channel->appendChild($page->createElement('title',$vars['title']));
     if (!empty(\Idno\Core\Idno::site()->config()->description)) {
@@ -87,8 +87,8 @@
             $rssItem->appendChild($page->createElement('pubDate',date(DATE_RSS,$item->created)));
 
             // Needed for WP import into Known
-            //$rssItem->appendChild($page->createElement('wp:post_type', 'post'));
-            //$rssItem->appendChild($page->createElement('wp:status', 'publish'));
+            $rssItem->appendChild($page->createElement('wp:post_type', 'post'));
+            $rssItem->appendChild($page->createElement('wp:status', 'publish'));
             
             $owner = $item->getOwner();
             if (!empty($owner)) {


### PR DESCRIPTION
## Here's what I fixed or added:

* Bring back the wp:xxxx elements, since they're needed for import. Added namespace.
* Added a unit test to validate rss feed via xmllint (which is what the w3c validator uses)

## Here's why I did it:

* the wp elements are needed if you want to be able to use the rss feed for import as well
* but without the namespace it broke in some less forgiving readers
* added a test so we don't accidentally break things again.