### PR TITLE
Set content type for webhook pings correctly

### DIFF
--- a/IdnoPlugins/Webhooks/Main.php
+++ b/IdnoPlugins/Webhooks/Main.php
@@ -55,7 +55,7 @@
                             $payload['text'] = $object->getTitle() . ' <' . $object->getURL() . '>';
                             $payload['title'] = $object->getTitle();
 
-                            Webservice::post($hook_url, json_encode($payload));
+                            Webservice::post($hook_url, json_encode($payload), ['Content-Type: application/json']);
 
                         }
                     }


### PR DESCRIPTION
## Here's what I fixed or added:

Set content-type header for webhook pings

## Here's why I did it:

Speculative fix for reported webhook problems, although i've not been able to replicate them myself