### PR TITLE
Limit image uploads to image types

### DIFF
--- a/IdnoPlugins/Comic/templates/default/entity/Comic/edit.tpl.php
+++ b/IdnoPlugins/Comic/templates/default/entity/Comic/edit.tpl.php
@@ -18,7 +18,7 @@
                                     <span class="btn btn-primary btn-file">
                                         <i class="fa fa-upload"></i>
 										<span id="photo-filename">Select a comic</span> 
-                                        <input type="file" name="comic" id="comic" class="form-control" accept="image/*;capture=camera" onchange="comicPreview(this)"/>
+                                        <input type="file" name="comic" id="comic" class="form-control" accept="image/*" capture="camera" onchange="comicPreview(this)"/>
 
                                     </span>
                             </label>

--- a/IdnoPlugins/Photo/templates/default/entity/Photo/edit.tpl.php
+++ b/IdnoPlugins/Photo/templates/default/entity/Photo/edit.tpl.php
@@ -29,7 +29,8 @@
                                         id="photo-filename">Select a photo</span> <input type="file" name="photo"
                                                                                          id="photo"
                                                                                          class="col-md-9 form-control"
-                                                                                         accept="image/*;capture=camera"
+                                                                                         accept="image/*"
+                                                                                         capture="camera"
                                                                                          onchange="photoPreview(this)"/>
 
                                     </span>

--- a/Themes/Cherwell/templates/default/admin/cherwell.tpl.php
+++ b/Themes/Cherwell/templates/default/admin/cherwell.tpl.php
@@ -36,7 +36,7 @@
                     <span class="btn btn-primary btn-file">
                     <i class="fa fa-camera"></i>
                     <span id="photo-filename">Upload a new image</span>
-                    <input type="file" name="background" id="photo" class="col-md-9" accept="image/*;capture=camera"
+                    <input type="file" name="background" id="photo" class="col-md-9" accept="image/*" capture="camera"
                            onchange="photoPreview(this)"/>
                     </span>
                 </label>

--- a/templates/default/entity/User/edit.tpl.php
+++ b/templates/default/entity/User/edit.tpl.php
@@ -24,7 +24,8 @@
                         <span id="photo-filename">Select a user picture</span>
                             <input type="file" name="avatar" id="photo"
                                    class="form-control"
-                                   accept="image/*;capture=camera"
+                                   accept="image/*"
+                                   capture="camera"
                                    onchange="photoPreview(this)"/>
 
                         </span>

--- a/templates/default/file/picker/image.tpl.php
+++ b/templates/default/file/picker/image.tpl.php
@@ -19,7 +19,8 @@
                                                 id="photo-filename">Select an image</span>
                                             <input type="file" name="file" id="photo"
                                                    class="col-md-9"
-                                                   accept="image/*;capture=camera"
+                                                   accept="image/*"
+                                                   capture="camera"
                                                    onchange="photoPreview(this)"/>
                                         </span>
                 </label>

--- a/templates/default/onboarding/profile.tpl.php
+++ b/templates/default/onboarding/profile.tpl.php
@@ -14,7 +14,7 @@
             <div class="upload">
                 <span class="camera btn-file" type="button" value="Add a photo of yourself">
                     <span id="photo-filename">Add a photo of yourself</span>
-                    <input type="file" name="avatar" id="photo" class="col-md-9" accept="image/*;capture=camera"
+                    <input type="file" name="avatar" id="photo" class="col-md-9" accept="image/*" capture="camera"
                            onchange="photoPreview(this)"/>
                 </span>
             </div>


### PR DESCRIPTION
## Here's what I fixed or added:

Changed accept="" on image file uploads to W3C syntax

## Here's why I did it:

It was possible to upload non-image content types.

