### PR TITLE
Pass sections in the ini file

### DIFF
--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -158,7 +158,7 @@
 
                 if (empty($this->ini_config)) {
                     $this->ini_config = array();
-                    if ($config = @parse_ini_file($this->path . '/config.ini')) {
+                    if ($config = @parse_ini_file($this->path . '/config.ini', true)) {
                         if (!empty($config)) {
                             $this->default_config = false;
                             $this->ini_config     = array_replace_recursive($config, $this->ini_config);
@@ -176,7 +176,7 @@
                     }
 
                     // Per domain configuration
-                    if ($config = @parse_ini_file($this->path . '/' . $this->host . '.ini')) {
+                    if ($config = @parse_ini_file($this->path . '/' . $this->host . '.ini', true)) {
                         unset($this->ini_config['initial_plugins']);  // Don't let plugin settings be merged
                         unset($this->ini_config['alwaysplugins']);
                         unset($this->ini_config['antiplugins']);


### PR DESCRIPTION
## Here's what I fixed or added:

Modify ini file config loader to also parse sections in the config file

## Here's why I did it:

This allows settings to be namespaced, for example:

[MyPlugin]
setting1 = 'foo'
setting2 = 'bar'

Will now be rendered as

$config->MyPlugin['setting1']
$config->MyPlugin['setting2']

etc

