### PR TITLE
Current page helpers on Known JS object

### DIFF
--- a/templates/default/js/known.tpl.php
+++ b/templates/default/js/known.tpl.php
@@ -17,7 +17,11 @@ $known = [
     ],
     'config' => [
         'displayUrl' => \Idno\Core\Idno::site()->config()->getDisplayURL()
-    ]
+    ],
+    'page' => [
+        'currentUrl' => \Idno\Core\Idno::site()->currentPage()->currentUrl(),
+        'currentUrlFragments' => \Idno\Core\Idno::site()->currentPage()->currentUrl(true),
+    ],
 ];
 
 ?>


### PR DESCRIPTION
## Here's what I fixed or added:

Added currentURL and currentURLFragments to the known environment object

## Here's why I did it:

Provide an easy way to access these from javascript libraries