### PR TITLE
Extend name column size in metadata table

### DIFF
--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -72,7 +72,8 @@
                                 2015061501,
                                 2016013101,
                                 2016102601,
-                                2016110301
+                                2016110301,
+                                2017032001,
                             ] as $date) {
                                 if ($basedate < $date) {
                                     if ($sql = @file_get_contents($schema_dir . $date . '.sql')) {

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -71,7 +71,8 @@
                             foreach ([
                                 // List upgrades, add yours to the end
                                 2016102601,
-                                2016110301
+                                2016110301,
+                                2017032001,
                             ] as $date) {
                                 if ($basedate < $date) {
                                     if ($sql = @file_get_contents($schema_dir . $date . '.sql')) {

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -77,7 +77,8 @@
                             foreach ([
                                 // List upgrades, add yours to the end
                                 2016102601,
-                                2016110301
+                                2016110301,
+                                2017032001,
                             ] as $date) {
                                 if ($basedate < $date) {
                                     if ($sql = @file_get_contents($schema_dir . $date . '.sql')) {

--- a/schemas/mysql/2017032001.sql
+++ b/schemas/mysql/2017032001.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE `metadata` MODIFY `name` varchar(64) NOT NULL;
+REPLACE INTO `versions` VALUES('schema', '2017032001');

--- a/schemas/mysql/mysql.sql
+++ b/schemas/mysql/mysql.sql
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS `metadata` (
   `entity` varchar(255) NOT NULL,
   `_id` varchar(32) NOT NULL,
   `collection` varchar(64) NOT NULL,
-  `name` varchar(32) NOT NULL,
+  `name` varchar(64) NOT NULL,
   `value` text NOT NULL,
   KEY `entity` (`entity`,`name`),
   KEY `value` (`value`(255)),
@@ -110,4 +110,4 @@ CREATE TABLE IF NOT EXISTS `session` (
     PRIMARY KEY (`session_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-REPLACE INTO `versions` VALUES('schema', '2016110301');
+REPLACE INTO `versions` VALUES('schema', '2017032001');

--- a/schemas/postgres/2017032001.sql
+++ b/schemas/postgres/2017032001.sql
@@ -1,5 +1,3 @@
 
-ALTER TABLE metadata ALTER COLUMN name TYPE varchar(64);
-
-DELETE FROM versions WHERE label = 'schema';
-INSERT INTO versions VALUES('schema', '2017032001');
+ALTER TABLE `metadata` MODIFY `name` varchar(64) NOT NULL;
+REPLACE INTO `versions` VALUES('schema', '2017032001');

--- a/schemas/postgres/2017032001.sql
+++ b/schemas/postgres/2017032001.sql
@@ -1,0 +1,5 @@
+
+ALTER TABLE metadata ALTER COLUMN name TYPE varchar(64);
+
+DELETE FROM versions WHERE label = 'schema';
+INSERT INTO versions VALUES('schema', '2017032001');

--- a/schemas/postgres/postgres.sql
+++ b/schemas/postgres/postgres.sql
@@ -80,7 +80,7 @@ CREATE TABLE IF NOT EXISTS metadata (
   entity varchar(255) NOT NULL,
   _id varchar(32) NOT NULL,
   collection varchar(64) NOT NULL,
-  name varchar(32) NOT NULL,
+  name varchar(64) NOT NULL,
   value text NOT NULL
 );
 
@@ -105,7 +105,7 @@ CREATE TABLE IF NOT EXISTS versions (
 );
 
 DELETE FROM versions WHERE label = 'schema';
-INSERT INTO versions VALUES('schema', '2016110301');
+INSERT INTO versions VALUES('schema', '2017032001');
 
 --
 -- Session handling table

--- a/schemas/sqlite3/2017032001.sql
+++ b/schemas/sqlite3/2017032001.sql
@@ -1,0 +1,20 @@
+
+ALTER TABLE metadata RENAME TO metadata_2017032001;
+
+CREATE TABLE IF NOT EXISTS metadata (
+  entity varchar(255) NOT NULL,
+  _id varchar(32) NOT NULL,
+  collection varchar(64) NOT NULL,
+  name varchar(64) NOT NULL,
+  value text NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS entity ON metadata (entity,name);
+CREATE INDEX IF NOT EXISTS value ON metadata (value);
+CREATE INDEX IF NOT EXISTS name ON metadata (name);
+CREATE INDEX IF NOT EXISTS collection ON metadata (collection);
+CREATE INDEX IF NOT EXISTS _id ON metadata (_id);
+
+INSERT INTO metadata entity,_id,collection,name,value FROM metadata_2017032001;
+
+REPLACE INTO `versions` VALUES('schema', '2017032001');

--- a/schemas/sqlite3/sqlite3.sql
+++ b/schemas/sqlite3/sqlite3.sql
@@ -88,7 +88,7 @@ CREATE TABLE IF NOT EXISTS metadata (
   entity varchar(255) NOT NULL,
   _id varchar(32) NOT NULL,
   collection varchar(64) NOT NULL,
-  name varchar(32) NOT NULL,
+  name varchar(64) NOT NULL,
   value text NOT NULL
 );
 
@@ -119,4 +119,4 @@ CREATE TABLE IF NOT EXISTS session (
     session_time int(11) NOT NULL
 );
 
-REPLACE INTO `versions` VALUES('schema', '2016110301');
+REPLACE INTO `versions` VALUES('schema', '2017032001');


### PR DESCRIPTION
## Here's what I fixed or added:

Extended the name column to 64 characters

## Here's why I did it:

To allow longer keys to be searchable.