### PR TITLE
Slightly more useful message for people upgrading from old mongo

### DIFF
--- a/Idno/Data/Mongo.php
+++ b/Idno/Data/Mongo.php
@@ -33,6 +33,15 @@
 
             function __construct($dbstring = null, $dbuser = null, $dbpass = null, $dbname = null, $dbauthsrc = null)
             {
+                // Check for library, and show a more friendly error message
+                if (!extension_loaded('mongodb')) {
+                    
+                    $message = "It looks like you don't have the new mongodb driver installed (<a href=\"https://secure.php.net/manual/en/set.mongodb.php\">https://secure.php.net/manual/en/set.mongodb.php</a>)\n\n";
+                    $message .= "Make sure you have it installed and configured, e.g. by running \"pecl install mongodb;\"";
+                    
+                    throw new \Idno\Exceptions\ConfigurationException($message);
+                }
+                
                 // Add library namespace
                 require_once(dirname(dirname(dirname(__FILE__))) . '/external/mongo-php-library/src/functions.php');
                 spl_autoload_register(function($class) {

--- a/docs/install/instructions.md
+++ b/docs/install/instructions.md
@@ -112,6 +112,10 @@ When using authentication, your MongoDB user will need to be granted the ["readW
       {role: "readWrite", db: "idnosession"}
     ]})
 
+#### Upgrading from old mongo driver
+
+If you're upgrading from an older release (0.9.2 and below) you will need to install the new [PHP mongodb driver](https://secure.php.net/manual/en/set.mongodb.php).
+
 ### Load Known
 
 Launch Known in a web browser.

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -17,3 +17,8 @@ installation directory, you may need to perform the following additional steps:
 7. Hit enter and you'll be taken to your site.
 
 Thanks to [Chris Aldich](http://stream.boffosocko.com/2015/upgrading-withknown-on-ones-own-server) for this point.
+
+## Upgrading Mongo
+
+Previous releases of Known used a now deprecated mongo driver. If you are running your site on Mongo, you will first need to make sure that
+you have installed the new [PHP MongoDB driver](https://secure.php.net/manual/en/set.mongodb.php).

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -8,7 +8,7 @@ listings here do not imply endorsement by the Known project team in any way.
 
 ### Content types
 
-* [Video] (https://github.com/cweiske/withknownVideo) – Post videos to your Known site, by [Christian Weiske][]
+* [Video](https://github.com/cweiske/withknownVideo) – Post videos to your Known site, by [Christian Weiske][]
 * [Video](https://github.com/tjgillies/Video) – Post videos to your Known site, by [Tyler Gillies][]
 * [Recipe](https://github.com/cleverdevil/Known-Recipes) – Post recipes to your Known site, by [Jonathan LaCour][]
 * [Review](https://github.com/cleverdevil/Known-Reviews) – Post reviews to your Known site, by [Jonathan LaCour][]


### PR DESCRIPTION
## Here's what I fixed or added:

Mongo database handler now checks for the existence of the correct mongodb extension on init, throws a more useful exception message to hopefully nudge people forward.

## Here's why I did it:

For folk upgrading from mongo to mongodb the wrapper client would through a very unhelpful message.