### PR TITLE
Adding PHPUnit shim for 5.6 travis builds

### DIFF
--- a/Tests/_bootstrap.php
+++ b/Tests/_bootstrap.php
@@ -1,5 +1,8 @@
 <?php
 
+
+require_once(dirname(__FILE__) . '/_shims.php');
+
 define('KNOWN_UNIT_TEST', true);
 
 // Set some environment: Use export KNOWN_DOMAIN / KNOWN_PORT to override from the command line

--- a/Tests/_shims.php
+++ b/Tests/_shims.php
@@ -1,0 +1,12 @@
+<?php
+
+
+if (!class_exists('PHPUnit_Framework_TestCase')) {
+    
+    /**
+     * Travis CI has moved to PHPUnit 5.6, but we still need comptibility with older versions for local testing.
+     * See the conversation here (https://github.com/travis-ci/travis-ci/issues/7226) for details.
+     */
+    class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
+    
+}


### PR DESCRIPTION
## Here's what I fixed or added:

Added some shims to get travis unit tests working again

## Here's why I did it:

Travis changed their build environment recently, which is causing unit tests to fail
