### PR TITLE
Bumping human version

### DIFF
--- a/version.known
+++ b/version.known
@@ -1,2 +1,2 @@
-version = "0.9.2"
-build = 2017033001
+version = "0.9.5"
+build = 2017033101


### PR DESCRIPTION
## Here's what I fixed or added:

Changed human readable version from 0.9.2 to 0.9.5

## Here's why I did it:

Because the perpetual 0.9.2 is making triage very frustrating, and is starting to feel like that episode of Buffy with the mummy hand.
