### PR TITLE
Prompting for some version info

### DIFF
--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -4,3 +4,4 @@
 
 ## Some other notes:
 
+*Give us some context, it'd also be really handy if you could tell us the contents of your ```version.known``` file*


### PR DESCRIPTION
## Here's what I fixed or added:

Added a prompt in the issue template for some clarification and the contents of version.known

## Here's why I did it:

I keep on asking for this information, it'd be helpful for triage if it was just given.
