### PR TITLE
Handle partial content from non-file sources

### DIFF
--- a/Idno/Pages/File/View.php
+++ b/Idno/Pages/File/View.php
@@ -62,7 +62,7 @@ namespace Idno\Pages\File {
 
                 $size = $object->getSize();
                 $start = 0;
-                $end = $size - 1;
+                $end = $size; // - 1;
 
                 $c_start = $start;
                 $c_end = $end;

--- a/Idno/Pages/File/View.php
+++ b/Idno/Pages/File/View.php
@@ -101,9 +101,18 @@ namespace Idno\Pages\File {
                 header('Content-Length: ' . ($c_end-$c_start));
                 header("Content-Range: bytes $c_start-$c_end/$size");
                 
+                \Idno\Core\Idno::site()->logging()->debug('Content-Length: ' . ($c_end-$c_start));
+                \Idno\Core\Idno::site()->logging()->debug("Content-Range: bytes $c_start-$c_end/$size");
+                
                 if ($stream = $object->getResource()) { 
                     @fseek($stream, $c_start);
-                    echo fread($stream, $c_end-$c_start);
+                    $buffer = "";
+                    while ( strlen($buffer)< $c_end-$c_start) {
+                        $buffer .= fread($stream, $c_end-strlen($buffer));
+                    }
+                    //$data =  fread($stream, $c_end-$c_start); 
+                                    
+                    echo $buffer;
                 }
                 
             } else {

--- a/Idno/Pages/File/View.php
+++ b/Idno/Pages/File/View.php
@@ -101,8 +101,8 @@ namespace Idno\Pages\File {
                 header('Content-Length: ' . ($c_end-$c_start));
                 header("Content-Range: bytes $c_start-$c_end/$size");
                 
-                if ($stream = $object->getResource()) {
-                    fseek($stream, $c_start);
+                if ($stream = $object->getResource()) { 
+                    @fseek($stream, $c_start);
                     echo fread($stream, $c_end-$c_start);
                 }
                 


### PR DESCRIPTION
## Here's what I fixed or added:

* Fixed a by one error in range content
* Suppressed fseek warning for pedantic mode
* Handle constructing bytes from non-file stream resources (which are often chunked to 8192 bytes, see php docs for fread)

## Here's why I did it:

* Range downloads were failing

Closes #1682