### PR TITLE
fixes bookmark Microformats markup

### DIFF
--- a/IdnoPlugins/Like/templates/default/entity/Like.tpl.php
+++ b/IdnoPlugins/Like/templates/default/entity/Like.tpl.php
@@ -25,7 +25,7 @@
         if (empty($vars['feed_view'])) {
 
             ?>
-            <h2 class="p-bookmark"><?=$icon?><a href="<?= $vars['object']->body; ?>" rel="bookmark"
+            <h2 class="idno-bookmark"><?=$icon?><a href="<?= $vars['object']->body; ?>" class="u-bookmark-of" rel="bookmark"
                                       target="_blank"><?= $this->parseURLs(htmlentities(strip_tags($body)), $rel) ?></a>
             </h2>
         <?php

--- a/IdnoPlugins/Like/templates/default/entity/Like.tpl.php
+++ b/IdnoPlugins/Like/templates/default/entity/Like.tpl.php
@@ -1,15 +1,18 @@
 <?php
 
-    $rel = '';
+    $class = '';
     $icon = '';
 
     if (!empty($vars['object']->likeof)) {
-        $rel = 'rel="like" class="u-like-of"';
+        $class = "u-like-of";
         $icon = '<i class="fa fa-star-o"></i> ';
     }
-    if (!empty($vars['object']->repostof)) {
-        $rel = 'rel="like" class="u-repost-of"';
+    elseif (!empty($vars['object']->repostof)) {
+        $class = "u-repost-of";
         $icon = '<i class="fa fa-retweet"></i> ';
+    }
+    else {
+        $class = "u-bookmark-of";
     }
 
     if (!empty($vars['object']->pageTitle)) {
@@ -25,21 +28,23 @@
         if (empty($vars['feed_view'])) {
 
             ?>
-            <h2 class="idno-bookmark"><?=$icon?><a href="<?= $vars['object']->body; ?>" class="u-bookmark-of" rel="bookmark"
-                                      target="_blank"><?= $this->parseURLs(htmlentities(strip_tags($body)), $rel) ?></a>
+            <h2 class="idno-bookmark"><?=$icon?><a href="<?= $vars['object']->body; ?>" class="<?= $class ?> p-name"
+                target="_blank"><?= $this->parseURLs(htmlentities(strip_tags($body)), $rel) ?></a>
             </h2>
         <?php
 
         }
 
         if (!empty($vars['object']->description)) {
-            echo $this->__(['value' => $vars['object']->description, 'object' => $vars['object'], 'rel' => $rel])->draw('forms/output/richtext');
+            echo '<div class="e-content">';
+                echo $this->__(['value' => $vars['object']->description, 'object' => $vars['object']])->draw('forms/output/richtext');
+            echo '</div>';
         
         }
         
         if (!empty($vars['object']->tags)) {
         ?>
-            <p class="tag-row"><i class="icon-tag"></i><?=$this->parseURLs($this->parseHashtags(htmlentities(strip_tags($vars['object']->tags))),$rel)?></p>
+            <p class="tag-row"><i class="icon-tag"></i><?=$this->parseURLs($this->parseHashtags(htmlentities(strip_tags($vars['object']->tags))))?></p>
         <?php
         }
 

--- a/Themes/Black/css/default.css
+++ b/Themes/Black/css/default.css
@@ -58,16 +58,16 @@ h1, h2, h3, h4, h5, h6 {
 	margin:0; padding: 0;
 }
 
-.idno-body .p-bookmark a, .idno-posts h2.p-bookmark {
+.idno-body .idno-bookmark a, .idno-posts h2.idno-bookmark {
 	font-size: 32px;
 	margin: 0; padding: 0;
 }
 
-h2.p-bookmark a {
+h2.idno-bookmark a {
 	color: #000000;
 }
 
-h2.p-bookmark a:hover, h2.p-bookmark a:focus {
+h2.idno-bookmark a:hover, h2.idno-bookmark a:focus {
 	color: #333333;
 }
 

--- a/Themes/Fauvists/css/default.css
+++ b/Themes/Fauvists/css/default.css
@@ -319,16 +319,16 @@ h1, h2, h3, h4, h5, h6 {
 	margin:0; padding: 0;	
 }
 
-.idno-body .p-bookmark a, .idno-posts h5.p-bookmark {
+.idno-body .idno-bookmark a, .idno-posts h5.idno-bookmark {
 	font-size: 24px;
 	margin: 0; padding: 0;
 }
 
-h5.p-bookmark a {
+h5.idno-bookmark a {
 	color: #000000;
 }
 
-h5.p-bookmark a:hover, h5.p-bookmark a:focus {
+h5.idno-bookmark a:hover, h5.idno-bookmark a:focus {
 	color: #333333;
 }
 

--- a/Themes/Green/css/default.css
+++ b/Themes/Green/css/default.css
@@ -52,8 +52,8 @@ h2 {
     margin: 0; padding: 0;
 }
 
-.idno-body .p-bookmark a,
-.idno-posts h2.p-bookmark {
+.idno-body .idno-bookmark a,
+.idno-posts h2.idno-bookmark {
     font-size: 1.4em;
     margin: 0; padding: 0;
 }
@@ -260,7 +260,7 @@ h3.register {
 	font-size: 1.2em;
 }
 
-.idno-body .p-bookmark a, .idno-posts h2.p-bookmark {
+.idno-body .idno-bookmark a, .idno-posts h2.idno-bookmark {
 	color: #333333;
 	font-size: 1.2em;
 	font-family: "Helvetica Neue","Helvetica",Helvetica,Arial,sans-serif;

--- a/Themes/Kandinsky/css/default.css
+++ b/Themes/Kandinsky/css/default.css
@@ -56,8 +56,8 @@ h2 {
     margin: 0; padding: 0;
 }
 
-.idno-body .p-bookmark a,
-.idno-posts h2.p-bookmark {
+.idno-body .idno-bookmark a,
+.idno-posts h2.idno-bookmark {
     font-size: 1.4em;
     margin: 0; padding: 0;
 }
@@ -279,7 +279,7 @@ h3.register {
 	font-size: 1.2em;
 }
 
-.idno-body .p-bookmark a, .idno-posts h2.p-bookmark {
+.idno-body .idno-bookmark a, .idno-posts h2.idno-bookmark {
 	color: #9f111b;
 	font-size: 1.2em;
 	font-family: "Helvetica Neue","Helvetica",Helvetica,Arial,sans-serif;


### PR DESCRIPTION
## Here's what I fixed or added:

I updated the bookmark template to use `u-bookmark-of` instead of `p-bookmark`. This fixes the parsed version of bookmark posts.

## Here's why I did it:

The bookmark Microformats were setting only the plaintext `bookmark` property which caused bookmarks to not actually reference the URL they are bookmarks of.
