### PR TITLE
We don't need to strip tags if we're encoding html entities

### DIFF
--- a/IdnoPlugins/Status/templates/default/entity/Status.tpl.php
+++ b/IdnoPlugins/Status/templates/default/entity/Status.tpl.php
@@ -11,7 +11,7 @@
     }
 
 ?>
-<p class="p-name e-content entry-content"><?= nl2br($this->parseURLs($this->parseHashtags($this->parseUsers(htmlentities(strip_tags($vars['object']->body), ENT_QUOTES, 'UTF-8') . $tags, $vars['object']->inreplyto)), $rel)) ?></p>
+<p class="p-name e-content entry-content"><?= nl2br($this->parseURLs($this->parseHashtags($this->parseUsers(htmlentities($vars['object']->body, ENT_QUOTES, 'UTF-8') . $tags, $vars['object']->inreplyto)), $rel)) ?></p>
 <?php
     if (!substr_count(strtolower($vars['object']->body), '<img')) {
         echo $this->draw('entity/content/embed');


### PR DESCRIPTION
## Here's what I fixed or added:

Removed strip_tags from status message output

## Here's why I did it:

It was unnecessary since we also pass text through htmlentities, and was resulting with text using a < from being stripped.

