### PR TITLE
Adding the ability to query with "<" and ">" operators to MySQL.

### DIFF
--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -527,6 +527,42 @@
                                 }
                                 $subwhere[] = $instring;
                             }
+                            if (!empty($value['$<'])) {
+                                $val = $value['$<'];
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "(`{$collection}`.`{$key}` < :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($val)) {
+                                            $val = strtotime($val);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`value` < :value{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $val;
+                                }
+                            }
+                            if (!empty($value['$>'])) {
+                                $val = $value['$>'];
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "(`{$collection}`.`{$key}` > :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($val)) {
+                                            $val = strtotime($val);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`value` > :value{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $val;
+                                }
+                            }
                             if ($key === '$or') {
                                 $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
                             }

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -473,6 +473,42 @@
                                 }
                                 $subwhere[] = $instring;
                             }
+                            if (!empty($value['$<'])) {
+                                $val = $value['$<'];
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "({$collection}.{$key} < :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($value)) {
+                                            $value = strtotime($value);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $value;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.name = :name{$metadata_joins} and md{$metadata_joins}.value < :value{$metadata_joins} and md{$metadata_joins}.collection = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $value;
+                                }
+                            }
+                            if (!empty($value['$>'])) {
+                                $val = $value['$>'];
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "({$collection}.{$key} > :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($value)) {
+                                            $value = strtotime($value);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $value;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.name = :name{$metadata_joins} and md{$metadata_joins}.value > :value{$metadata_joins} and md{$metadata_joins}.collection = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $value;
+                                }
+                            }
                             if ($key === '$or') {
                                 $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
                             }

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -502,6 +502,40 @@
                                 }
                                 $subwhere[] = $instring;
                             }
+                            if (!empty($value['$<'])) {
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "(`{$collection}`.`{$key}` < :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($value)) {
+                                            $value = strtotime($value);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $value;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`value` < :value{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $value;
+                                }
+                            }
+                            if (!empty($value['$>'])) {
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "(`{$collection}`.`{$key}` > :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($value)) {
+                                            $value = strtotime($value);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $value;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`value` > :value{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $value;
+                                }
+                            }
                             if ($key === '$or') {
                                 $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
                             }

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -22,6 +22,7 @@ namespace Tests\Data {
                 $obj->setTitle("Unit Test Search Object");
                 $obj->variable1 = 'test';
                 $obj->variable2 = 'test again';
+		$obj->rangeVariable = 100;		
                 
                 //echo "\n\n\nabout to save"; 
                 $id = $obj->save(); //die($id);
@@ -128,6 +129,28 @@ namespace Tests\Data {
             $this->assertTrue(is_array($objs));
             $this->validateObject($objs[0]);
         }
+	
+	public function testGetByRange() {
+	    $search = array();
+	    $search['rangeVariable'] = array();
+	    $search['rangeVariable']['$lt'] = 150;
+	    $search['rangeVariable']['$gt'] = 50;
+	    
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
+	    $this->assertTrue(is_int($count));
+	    $this->assertTrue($count == 1);
+	}
+
+        public function testGetByRangeNoResults() {
+	    $search = array();
+	    $search['rangeVariable'] = array();
+	    $search['rangeVariable']['$lt'] = 250;
+	    $search['rangeVariable']['$gt'] = 150;
+	    
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
+	    $this->assertTrue(is_int($count));
+	    $this->assertTrue($count == 0);
+	}
 
         public function testSearchShort() {
             $search = array();

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -22,7 +22,7 @@ namespace Tests\Data {
                 $obj->setTitle("Unit Test Search Object");
                 $obj->variable1 = 'test';
                 $obj->variable2 = 'test again';
-		$obj->rangeVariable = 100;		
+		$obj->rangeVariable = 'b';		
                 
                 //echo "\n\n\nabout to save"; 
                 $id = $obj->save(); //die($id);
@@ -130,11 +130,12 @@ namespace Tests\Data {
             $this->validateObject($objs[0]);
         }
 	
+	/* testing range queries – note: metadata variables are strored as TEXT in SQL backends */
 	public function testGetByRange() {
 	    $search = array();
 	    $search['rangeVariable'] = array();
-	    $search['rangeVariable']['$lt'] = 150;
-	    $search['rangeVariable']['$gt'] = 50;
+	    $search['rangeVariable']['$lt'] = 'c';
+	    $search['rangeVariable']['$gt'] = 'a';
 	    
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
 	    $this->assertTrue(is_int($count));
@@ -144,8 +145,8 @@ namespace Tests\Data {
         public function testGetByRangeNoResults() {
 	    $search = array();
 	    $search['rangeVariable'] = array();
-	    $search['rangeVariable']['$lt'] = 250;
-	    $search['rangeVariable']['$gt'] = 150;
+	    $search['rangeVariable']['$lt'] = 'e';
+	    $search['rangeVariable']['$gt'] = 'c';
 	    
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
 	    $this->assertTrue(is_int($count));


### PR DESCRIPTION
## Here's what I fixed or added:

I added the capability to query with "<" and ">" operators to the MySQL backend. If I also need to add support for other database backends to get this PR merged, please do let me know, and I'll try and work on those too. From what I could tell, the only supported backend at this point is MySQL, but I could be wrong!

## Here's why I did it:

To enable me to create an "On This Day" feature for my website. You can find my implementation here:

    https://github.com/cleverdevil/CleverCustomize/blob/master/Pages/OnThisDay.php

... you can see it in action here:

    https://cleverdevil.io/onthisday/
    https://cleverdevil.io/onthisday/04/18