### PR TITLE
Mongo dot encoding

### DIFF
--- a/Idno/Data/Mongo.php
+++ b/Idno/Data/Mongo.php
@@ -273,14 +273,18 @@
                     
                     $obj = (array)$obj;
                     foreach ($obj as $k => $v) {
+                        $orig_k = $k;
                         $k          = str_replace(array_values(self::$ESCAPE_SEQUENCES), array_keys(self::$ESCAPE_SEQUENCES), $k);
                         $obj[$k] = $this->unsanitizeFields($v);
+                        if ($k!=$orig_k) unset($obj[$orig_k]);
                     }
                 } else if (is_array($obj)) {
                     $result = [];
                     foreach ($obj as $k => $v) {
+                        $orig_k = $k;
                         $k          = str_replace(array_values(self::$ESCAPE_SEQUENCES), array_keys(self::$ESCAPE_SEQUENCES), $k);
                         $result[$k] = $this->unsanitizeFields($v);
+                        if ($k!=$orig_k) unset($obj[$orig_k]);
                     }
                     
                     return $result;

--- a/Idno/Data/Mongo.php
+++ b/Idno/Data/Mongo.php
@@ -257,13 +257,11 @@
 //                }
 //                
 //                return $obj;
-                if ($obj instanceof \MongoDB\Model\BSONArray) {
-                    return (array)$obj;
-                }
-                else if ($obj instanceof \MongoDB\Model\BSONDocument) {
+                if (($obj instanceof \MongoDB\Model\BSONArray) || ($obj instanceof \MongoDB\Model\BSONDocument)) {
                     
                     $obj = (array)$obj;
                     foreach ($obj as $k => $v) {
+                        $k          = str_replace(array_values(self::$ESCAPE_SEQUENCES), array_keys(self::$ESCAPE_SEQUENCES), $k);
                         $obj[$k] = $this->unsanitizeFields($v);
                     }
                 } else if (is_array($obj)) {

--- a/Idno/Data/Mongo.php
+++ b/Idno/Data/Mongo.php
@@ -207,7 +207,7 @@
                     
                     $result = [];
                     foreach ($obj as $k => $v) {
-                        // Attempt to prevent double encoding
+                        // Attempt to prevent double encoding (open question: can this be done better?)
                         $encoded = false;
                         foreach (array_values(self::$ESCAPE_SEQUENCES) as $esc) {
                             if (strpos($k, $esc)!==false) {$encoded = true; error_log("Is encoded");}

--- a/Idno/Data/Mongo.php
+++ b/Idno/Data/Mongo.php
@@ -203,10 +203,22 @@
                     // TODO maybe avoid unnecessary object churn by only creating a new
                     // array if a key (or nested array) is found that needs encoding.
                     // The vast majority won't.
+                    
+                    
                     $result = [];
                     foreach ($obj as $k => $v) {
-                        $k          = str_replace(array_keys(self::$ESCAPE_SEQUENCES), array_values(self::$ESCAPE_SEQUENCES), $k);
+                        // Attempt to prevent double encoding
+                        $encoded = false;
+                        foreach (array_values(self::$ESCAPE_SEQUENCES) as $esc) {
+                            if (strpos($k, $esc)!==false) {$encoded = true; error_log("Is encoded");}
+                        }
+                                                
+                        if (!$encoded) {
+                            $k          = str_replace(array_keys(self::$ESCAPE_SEQUENCES), array_values(self::$ESCAPE_SEQUENCES), $k);
+                        }
+                        
                         $result[$k] = $this->sanitizeFields($v);
+                        
                     }
 
                     return $result;


### PR DESCRIPTION
## Here's what I fixed or added:

* Prevent encoded values appearing in decoded object
* Prevent multiple double encoding (and corresponding bloat of object size)
* Now possible to retrieve dotted values

## Here's why I did it:

They were all broken