### PR TITLE
Avoid notice / pedantic mode failure where accept headers are missing

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -898,25 +898,27 @@
                             if (substr_count($headers['Accept'], $contentType)) return true;
                         }
                     } else {
-                        $types = [];
-                        $accepts = explode(',', $headers['Accept']);
+                        if (!empty($headers['Accept'])) { 
+                            $types = [];
+                            $accepts = explode(',', $headers['Accept']);
 
-                        foreach ($accepts as $accept) {
-                            $q = 1; // default value
-                            
-                            if (strpos($accept, ';q=')) {
-                                list($accept, $q) = explode(';q=', $accept);
+                            foreach ($accepts as $accept) {
+                                $q = 1; // default value
+
+                                if (strpos($accept, ';q=')) {
+                                    list($accept, $q) = explode(';q=', $accept);
+                                }
+
+                                while (in_array($q, $types)) { $q -= 000000000001;} // fudge to give equal values order priority. TODO: do this a better way
+
+                                $types[$accept] = $q;
                             }
-                            
-                            while (in_array($q, $types)) { $q -= 000000000001;} // fudge to give equal values order priority. TODO: do this a better way
-                            
-                            $types[$accept] = $q;
-                        }
-                        
-                        arsort($types);
-                        
-                        foreach ($types as $type => $value) {
-                            return $type == $contentType;
+
+                            arsort($types);
+
+                            foreach ($types as $type => $value) {
+                                return $type == $contentType;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Here's what I fixed or added:

Test for existence of $headers['Accept']

## Here's why I did it:

Pedantic mode unit tests were failing