### PR TITLE
Closes #1707: Remove explicit mysql pdo check

### DIFF
--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -97,7 +97,7 @@
 
                 // Check installed extensions
                 $basics['report']['php-extensions'] = ['status' => 'Ok', 'message' => 'PHP Extension(s): '];
-                foreach (['curl', 'date', 'dom', 'gd', 'json', 'libxml', 'mbstring', 'pdo', 'pdo_mysql', 'reflection', 'session', 'simplexml', 'openssl'] as $extension) {
+                foreach (['curl', 'date', 'dom', 'gd', 'json', 'libxml', 'mbstring', 'pdo', 'reflection', 'session', 'simplexml', 'openssl'] as $extension) {
                     if (!extension_loaded($extension)) {
                         $basics['report']['php-extensions']['message'] .= "$extension, ";
                         $basics['report']['php-extensions']['status'] = 'Failure';


### PR DESCRIPTION
## Here's what I fixed or added:

Removed explicit pdo_mysql check in diagnostics

## Here's why I did it:

It is implicit that you've got the pdo driver for your current engine installed in order to get as far as the admin diagnostics page, and the mysql check was causing errors for those on other engines.