### PR TITLE
Closes #1704: Encode entities in output

### DIFF
--- a/templates/rss/shell.tpl.php
+++ b/templates/rss/shell.tpl.php
@@ -81,7 +81,7 @@
                 }
             }
             $rssItem = $page->createElement('item');
-            $rssItem->appendChild($page->createElement('title', strip_tags($title)));
+            $rssItem->appendChild($page->createElement('title', htmlspecialchars($title)));
             $rssItem->appendChild($page->createElement('link',$item->getSyndicationURL()));
             $rssItem->appendChild($page->createElement('guid',$item->getUUID()));
             $rssItem->appendChild($page->createElement('pubDate',date(DATE_RSS,$item->created)));


### PR DESCRIPTION
## Here's what I fixed or added:

Replaced strip_tags with htmlspecialchars

## Here's why I did it:

So that title on certain elements weren't lost
