### PR TITLE
Issue 1725

### DIFF
--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -527,6 +527,42 @@
                                 }
                                 $subwhere[] = $instring;
                             }
+                            if (!empty($value['$<'])) {
+                                $val = $value['$<'];
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "(`{$collection}`.`{$key}` < :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($val)) {
+                                            $val = strtotime($val);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`value` < :value{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $val;
+                                }
+                            }
+                            if (!empty($value['$>'])) {
+                                $val = $value['$>'];
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "(`{$collection}`.`{$key}` > :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($val)) {
+                                            $val = strtotime($val);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $val;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`value` > :value{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $val;
+                                }
+                            }
                             if ($key === '$or') {
                                 $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
                             }

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -473,6 +473,42 @@
                                 }
                                 $subwhere[] = $instring;
                             }
+                            if (!empty($value['$<'])) {
+                                $val = $value['$<'];
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "({$collection}.{$key} < :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($value)) {
+                                            $value = strtotime($value);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $value;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.name = :name{$metadata_joins} and md{$metadata_joins}.value < :value{$metadata_joins} and md{$metadata_joins}.collection = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $value;
+                                }
+                            }
+                            if (!empty($value['$>'])) {
+                                $val = $value['$>'];
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "({$collection}.{$key} > :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($value)) {
+                                            $value = strtotime($value);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $value;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.name = :name{$metadata_joins} and md{$metadata_joins}.value > :value{$metadata_joins} and md{$metadata_joins}.collection = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $value;
+                                }
+                            }
                             if ($key === '$or') {
                                 $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
                             }

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -502,6 +502,40 @@
                                 }
                                 $subwhere[] = $instring;
                             }
+                            if (!empty($value['$<'])) {
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "(`{$collection}`.`{$key}` < :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($value)) {
+                                            $value = strtotime($value);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $value;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`value` < :value{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $value;
+                                }
+                            }
+                            if (!empty($value['$>'])) {
+                                if (in_array($key, $this->getSchemaFields())) {
+                                    $subwhere[] = "(`{$collection}`.`{$key}` > :nonmdvalue{$non_md_variables})";
+                                    if ($key === 'created') {
+                                        if (!is_int($value)) {
+                                            $value = strtotime($value);
+                                        }
+                                    }
+                                    $variables[":nonmdvalue{$non_md_variables}"] = $value;
+                                    $non_md_variables++;
+                                } else {
+                                    $metadata_joins++;
+                                    $subwhere[]                           = "(md{$metadata_joins}.`name` = :name{$metadata_joins} and md{$metadata_joins}.`value` > :value{$metadata_joins} and md{$metadata_joins}.`collection` = '{$collection}')";
+                                    $variables[":name{$metadata_joins}"]  = $key;
+                                    $variables[":value{$metadata_joins}"] = $value;
+                                }
+                            }
                             if ($key === '$or') {
                                 $subwhere[] = "(" . $this->build_where_from_array($value, $variables, $metadata_joins, $non_md_variables, 'or', $collection) . ")";
                             }

--- a/IdnoPlugins/Photo/templates/default/entity/Photo/edit.tpl.php
+++ b/IdnoPlugins/Photo/templates/default/entity/Photo/edit.tpl.php
@@ -53,7 +53,6 @@
                                                                                          id="photo"
                                                                                          class="col-md-9 form-control"
                                                                                          accept="image/*"
-                                                                                         capture="camera"
                                                                                          onchange="photoPreview(this)"/>
 
                                     </span>

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -22,6 +22,7 @@ namespace Tests\Data {
                 $obj->setTitle("Unit Test Search Object");
                 $obj->variable1 = 'test';
                 $obj->variable2 = 'test again';
+		$obj->rangeVariable = 100;		
                 
                 //echo "\n\n\nabout to save"; 
                 $id = $obj->save(); //die($id);
@@ -128,6 +129,28 @@ namespace Tests\Data {
             $this->assertTrue(is_array($objs));
             $this->validateObject($objs[0]);
         }
+	
+	public function testGetByRange() {
+	    $search = array();
+	    $search['rangeVariable'] = array();
+	    $search['rangeVariable']['$lt'] = 150;
+	    $search['rangeVariable']['$gt'] = 50;
+	    
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
+	    $this->assertTrue(is_int($count));
+	    $this->assertTrue($count == 1);
+	}
+
+        public function testGetByRangeNoResults() {
+	    $search = array();
+	    $search['rangeVariable'] = array();
+	    $search['rangeVariable']['$lt'] = 250;
+	    $search['rangeVariable']['$gt'] = 150;
+	    
+            $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
+	    $this->assertTrue(is_int($count));
+	    $this->assertTrue($count == 0);
+	}
 
         public function testSearchShort() {
             $search = array();

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -22,7 +22,7 @@ namespace Tests\Data {
                 $obj->setTitle("Unit Test Search Object");
                 $obj->variable1 = 'test';
                 $obj->variable2 = 'test again';
-		$obj->rangeVariable = 100;		
+		$obj->rangeVariable = 'b';		
                 
                 //echo "\n\n\nabout to save"; 
                 $id = $obj->save(); //die($id);
@@ -130,11 +130,12 @@ namespace Tests\Data {
             $this->validateObject($objs[0]);
         }
 	
+	/* testing range queries – note: metadata variables are strored as TEXT in SQL backends */
 	public function testGetByRange() {
 	    $search = array();
 	    $search['rangeVariable'] = array();
-	    $search['rangeVariable']['$lt'] = 150;
-	    $search['rangeVariable']['$gt'] = 50;
+	    $search['rangeVariable']['$lt'] = 'c';
+	    $search['rangeVariable']['$gt'] = 'a';
 	    
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
 	    $this->assertTrue(is_int($count));
@@ -144,8 +145,8 @@ namespace Tests\Data {
         public function testGetByRangeNoResults() {
 	    $search = array();
 	    $search['rangeVariable'] = array();
-	    $search['rangeVariable']['$lt'] = 250;
-	    $search['rangeVariable']['$gt'] = 150;
+	    $search['rangeVariable']['$lt'] = 'e';
+	    $search['rangeVariable']['$gt'] = 'c';
 	    
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
 	    $this->assertTrue(is_int($count));


### PR DESCRIPTION
## Here's what I fixed or added:

Fixing #1725 by removing `capture` attribute.

## Here's why I did it:

On iOS, tapping "select a photo" when creating a photo post only allows taking a new photo with the camera, not selecting an existing photo.