### PR TITLE
don't check state parameter on token request

### DIFF
--- a/IdnoPlugins/IndiePub/Pages/IndieAuth/Auth.php
+++ b/IdnoPlugins/IndiePub/Pages/IndieAuth/Auth.php
@@ -60,9 +60,8 @@
                 $code         = $this->getInput('code');
                 $client_id    = $this->getInput('client_id');
                 $redirect_uri = $this->getInput('redirect_uri');
-                $state        = $this->getInput('state');
 
-                $verified = Auth::verifyCode($code, $client_id, $redirect_uri, $state);
+                $verified = Auth::verifyCode($code, $client_id, $redirect_uri);
                 if ($verified['valid']) {
                     $this->setResponse(200);
                     header('Content-Type: application/x-www-form-urlencoded');
@@ -117,7 +116,7 @@
             }
 
             // verify the code from login; note that this is called from the micropub client, so the session won't have any user data
-            static function verifyCode($code, $client_id, $redirect_uri, $state)
+            static function verifyCode($code, $client_id, $redirect_uri)
             {
                 $found = Auth::findUserForCode($code);
                 if (empty($found)) {
@@ -150,12 +149,6 @@
                     return array(
                         'valid'  => false,
                         'reason' => 'client_id does not match',
-                    );
-                }
-                if ($state != $data['state']) {
-                    return array(
-                        'valid'  => false,
-                        'reason' => 'state does not match',
                     );
                 }
                 return array(


### PR DESCRIPTION
## Here's what I fixed or added:

This fixes the token endpoint to not require the `state` parameter when exchanging the authorization code for an access token. https://tools.ietf.org/html/rfc6749#section-4.1.3

## Here's why I did it:

A common mistake in the OAuth flow is expecting the client to send the state parameter in the token request. This means some clients were unable to sign in because they (correctly) were not sending the `state` parameter.

