### PR TITLE
Adding troubleshooting section to docs

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -15,3 +15,8 @@
 # Debugging Known
 
 * [Using logs](debugging.md)
+* [Diagnostics](debugging.md)
+
+# Troubleshooting
+
+* [Troubleshooting Known](troubleshooting.md)

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -1,0 +1,3 @@
+# Troubleshooting your Known installation
+
+Here are some previously encountered common installation problems which have been reported, together with their solution:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ pages:
 - ['install/config.md', 'Installing and upgrading Known', 'Using config.ini']
 - ['install/sharedhost.md', 'Installing and upgrading Known', 'Instructions for common shared hosting providers']
 - ['install/debugging.md', 'Installing and upgrading Known', 'Debugging Known']
+- ['install/troubleshooting.md', 'Installing and upgrading Known', 'Troubleshooting your installation']
 - ['plugins/index.md', 'Plugins', 'Plugins']
 - ['plugins/project.md', 'Plugins', 'Known project plugins']
 - ['plugins/community.md', 'Plugins', 'Community plugins']


### PR DESCRIPTION
## Here's what I fixed or added:

Added a troubleshooting section to the docs

## Here's why I did it:

So we have a place to start adding non-bug related common configuration and installation problems.
