### PR TITLE
Remove link to non-working video plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -9,7 +9,6 @@ listings here do not imply endorsement by the Known project team in any way.
 ### Content types
 
 * [Video](https://github.com/cweiske/withknownVideo) – Post videos to your Known site, by [Christian Weiske][]
-* [Video](https://github.com/tjgillies/Video) – Post videos to your Known site, by [Tyler Gillies][]
 * [Recipe](https://github.com/cleverdevil/Known-Recipes) – Post recipes to your Known site, by [Jonathan LaCour][]
 * [Review](https://github.com/cleverdevil/Known-Reviews) – Post reviews to your Known site, by [Jonathan LaCour][]
 * [Food](https://github.com/cleverdevil/Known-Food) – Log your eating and drinking to your Known site, by [Jonathan LaCour][]


### PR DESCRIPTION
As far as I can tell, this plugin never really had any true functionality, it certainly never worked as a video plugin, wasn't supported, and has since been replaced by a working version by Christian Weiske

* [Video](https://github.com/tjgillies/Video) – Post videos to your Known site, by [Tyler Gillies][]

## Here's what I fixed or added:

## Here's why I did it:

