### PR TITLE
Fixing travis pedantic mode build error

### DIFF
--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -384,7 +384,7 @@
             {
                 
                 \Idno\Core\Idno::site()->triggerEvent("user/logoff", array(
-                    "user"   => $this->user,
+                    "user"   => !empty($this->user) ? $this->user : null,
                 ));
                 
                 unset($_SESSION['user_uuid']);


### PR DESCRIPTION
## Here's what I fixed or added:

Remove a notice error

## Here's why I did it:

When called from unit tests logoff is called sometimes without a user being logged on, this causes a notice error (which is fatal with pedantic mode on)