### PR TITLE
UUIDs now exclusively machine generated

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -77,9 +77,9 @@
                 if (!empty($this->uuid)) {
                     return $this->uuid;
                 }
-                if ($url = $this->getURL(true)) {
-                    return $url;
-                }
+//                if ($url = $this->getURL(true)) { // Using URLs here is a bad plan. UUIDs must always be unique
+//                    return $url;
+//                }
                 if (!empty($this->_id)) {
                     return \Idno\Core\Idno::site()->config()->url . 'view/' . $this->_id;
                 }

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -77,7 +77,7 @@
                 if (!empty($this->uuid)) {
                     return $this->uuid;
                 }
-//                if ($url = $this->getURL(true)) { // Using URLs here is a bad plan. UUIDs must always be unique
+//                if ($url = $this->getURL(true)) { // Using URLs here is a bad plan. UUIDs must always be unique, even across time...
 //                    return $url;
 //                }
                 if (!empty($this->_id)) {


### PR DESCRIPTION
## Here's what I fixed or added:

Removed getURL() call from getUUID()

## Here's why I did it:

It was possible, using user set urls, to have a UUID which was generated as being the same as a previously deleted object. Not only did this mean UUIDs could be changed, but it meant that UUIDs, which are often used to address an entity, could take the ownership of a deleted entity.

Major bad times.

Closes #1741 

## Replaces:

This is a 3 line fix that addresses the root cause of #1741, this renders tombstoning unnecessary.

Closes #1742 
Closes #1743
