### PR TITLE
Introducing capture_logs config setting

### DIFF
--- a/Idno/Core/Admin.php
+++ b/Idno/Core/Admin.php
@@ -29,6 +29,10 @@
                 site()->addPageHandler('/admin/export/rss/?', '\Idno\Pages\Admin\Export\RSS');
                 site()->addPageHandler('/admin/import/?', '\Idno\Pages\Admin\Import');
                 site()->addPageHandler('/admin/diagnostics/?', '\Idno\Pages\Admin\Diagnostics');
+                
+                if (!empty(\Idno\Core\Idno::site()->config()->capture_logs) && \Idno\Core\Idno::site()->config()->capture_logs) { 
+                    site()->addPageHandler('/admin/logs/?', '\Idno\Pages\Admin\Logs');
+                }
             }
 
         }

--- a/Idno/Core/Logging.php
+++ b/Idno/Core/Logging.php
@@ -159,7 +159,22 @@ namespace Idno\Core {
                     $message .= ' ' . $context;
                 }
 
-                error_log("Known ({$this->identifier}): $level - $message{$trace}");
+                $logline = "Known ({$this->identifier}): $level - $message{$trace}";
+                error_log($logline);
+                
+                // Have we enabled local capture (not recommended, but handy for debugging situations where you can't retrieve apache/php logs)
+                if (!empty(\Idno\Core\Idno::site()->config()->capture_logs) && \Idno\Core\Idno::site()->config()->capture_logs) {
+                    $f = fopen(\Idno\Core\Idno::site()->config()->getTempDir() . \Idno\Core\Idno::site()->config()->host . '.log', 'a');
+                    
+                    // Make threadsafe
+                    if (flock($f, LOCK_EX)) {
+                        fwrite($f, date('r') . ": $logline\n");
+                        fflush($f);
+                        flock($f, LOCK_UN);
+                    }
+                    
+                    fclose($f);
+                }
             }
         }
 

--- a/Idno/Pages/Admin/Logs.php
+++ b/Idno/Pages/Admin/Logs.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Idno\Pages\Admin {
+
+    class Logs extends \Idno\Common\Page {
+
+        function getContent() {
+            $this->adminGatekeeper(); // Admins only
+            // Retrieved via API, so just dump logs
+            if ($this->xhr || \Idno\Core\Idno::site()->session()->isAPIRequest()) {
+
+                echo file_get_contents(\Idno\Core\Idno::site()->config()->getTempDir() . \Idno\Core\Idno::site()->config()->host . '.log');
+            } else {
+
+                $t = \Idno\Core\Idno::site()->template();
+                $t->body = $t->__([])->draw('admin/logs');
+                $t->title = 'Log capture';
+                $t->drawPage();
+            }
+        }
+
+    }
+
+}

--- a/templates/default/admin/logs.tpl.php
+++ b/templates/default/admin/logs.tpl.php
@@ -1,0 +1,37 @@
+<div class="row">
+    <div class="col-md-10 col-md-offset-1">
+        <?= $this->draw('admin/menu') ?>
+        <h1>Log capture</h1>
+
+
+        <div class="explanation">
+            <p>
+                This page provides you with captured PHP logs. These contain sensitive information, so be very careful how you disclose the information and to whom.
+            </p>
+        </div>
+        
+    
+        <div id="logs-report" style="display: none; ">
+            <small><pre style="height: 600px; overflow:auto;">
+                </pre></small>
+        </div>
+
+        <span class="btn btn-primary" id="logs-report-run">Refresh...</span>
+
+    </div>
+
+</div>
+
+<script>
+    $(document).ready(function(){
+        $('#logs-report pre').load('<?= \Idno\Core\Idno::site()->currentPage()->currentUrl(); ?>', function(){
+                $('#logs-report').fadeIn();
+            });
+            
+        $('#logs-report-run').click(function(){
+            
+            $('#logs-report pre').load('<?= \Idno\Core\Idno::site()->currentPage()->currentUrl(); ?>', function(){
+            });
+        });
+    });
+</script>

--- a/templates/default/admin/menu.tpl.php
+++ b/templates/default/admin/menu.tpl.php
@@ -9,5 +9,8 @@
   <li <?php if (\Idno\Core\Idno::site()->currentPage()->doesPathMatch('/admin/export/')) echo 'class="active"'; ?> role="presentation"><a href="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>admin/export/" >Export</a></li>
   <li <?php if (\Idno\Core\Idno::site()->currentPage()->doesPathMatch('/admin/import/')) echo 'class="active"'; ?> role="presentation"><a href="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>admin/import/" >Import</a></li>
   <li <?php if (\Idno\Core\Idno::site()->currentPage()->doesPathMatch('/admin/diagnostics/')) echo 'class="active"'; ?> role="presentation"><a href="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>admin/diagnostics/">Diagnostics</a></li>
+  <?php if (!empty(\Idno\Core\Idno::site()->config()->capture_logs) && \Idno\Core\Idno::site()->config()->capture_logs) { ?>
+    <li <?php if (\Idno\Core\Idno::site()->currentPage()->doesPathMatch('/admin/logs/')) echo 'class="active"'; ?> role="presentation"><a href="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>admin/logs/">Captured Logs</a></li>
+  <?php } ?>
   <li <?php if (\Idno\Core\Idno::site()->currentPage()->doesPathMatch('/admin/about/')) echo 'class="active"'; ?> role="presentation"><a href="<?=\Idno\Core\Idno::site()->config()->getDisplayURL()?>admin/about/">About</a></li>
 </ul>


### PR DESCRIPTION
## Here's what I fixed or added:

Added a setting to turn on native log capture, whereby Known generated log messages will be output to a temporary file visible from the admin interface, as well as being outputted to the apache php logs

## Here's why I did it:

Sometimes it was unnecessarily hard/impossible to get vital debug information from certain platforms. This provides a workaround...