### PR TITLE
Refs #1754: Clearer mongo upgrade instructions

### DIFF
--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -19,4 +19,5 @@ installation directory, you may need to perform the following additional steps:
 Thanks to [Chris Aldich](http://stream.boffosocko.com/2015/upgrading-withknown-on-ones-own-server) for this point.
 
 !!! warning "MongoDB Users"
-    Previous releases of Known (<0.9.5) used a now deprecated mongo driver. If you are running your site on Mongo, you will first need to make sure that you have installed the new [PHP MongoDB driver](https://secure.php.net/manual/en/set.mongodb.php).
+    * Previous releases of Known (<0.9.5) used a now deprecated mongo driver. If you are running your site on Mongo, you will first need to make sure that you have installed the new [PHP MongoDB driver](https://secure.php.net/manual/en/set.mongodb.php).
+    * Additionally, the latest version changed the default database engine, so you'll need to specify ```database = 'mongo'``` in your config.ini


### PR DESCRIPTION
## Here's what I fixed or added:

Pointed out default database engine change

## Here's why I did it:

It was unclear, caused problems.
