### PR TITLE
Closes #1651: Using url safe base64 encoded urls instead of urlencoding

### DIFF
--- a/Idno/Pages/Session/Login.php
+++ b/Idno/Pages/Session/Login.php
@@ -20,7 +20,7 @@
                     $this->forward();
                 }
 
-                $fwd = $this->getInput('fwd'); // Forward to a new page?
+                $fwd = \Idno\Core\Webservice::base64UrlDecode($this->getInput('fwd')); // Forward to a new page?
                 if ($fwd == \Idno\Core\Idno::site()->config()->url . 'session/login') {
                     $fwd = '';
                 }
@@ -36,7 +36,7 @@
                 $fwd = $this->getInput('fwd'); // Forward to a new page?
                 if (empty($fwd)) {
                     $fwd = \Idno\Core\Idno::site()->config()->url;
-                }
+                } 
 
                 $this->referrerGatekeeper();
 
@@ -50,16 +50,16 @@
                 if ($user instanceof \Idno\Entities\User) {
                     if ($user->checkPassword(trim($this->getInput('password')))) {
                         \Idno\Core\Idno::site()->triggerEvent('login/success', array('user' => $user)); // Trigger an event for auditing
-                        \Idno\Core\Idno::site()->session()->logUserOn($user);
+                        \Idno\Core\Idno::site()->session()->logUserOn($user); 
                         $this->forward($fwd);
                     } else {
                         \Idno\Core\Idno::site()->session()->addErrorMessage("Oops! It looks like your password isn't correct. Please try again.");
                         \Idno\Core\Idno::site()->triggerEvent('login/failure', array('user' => $user));
-                        $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login/?fwd=' . urlencode($fwd));
+                        $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login/?fwd=' . \Idno\Core\Webservice::base64UrlEncode($fwd));
                     }
                 } else {
                     \Idno\Core\Idno::site()->session()->addErrorMessage("Oops! We couldn't find your username or email address. Please check you typed it correctly and try again.");
-                    $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login/?fwd=' . urlencode($fwd));
+                    $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login/?fwd=' . \Idno\Core\Webservice::base64UrlEncode($fwd));
                 }
             }
 

--- a/templates/default/pages/403.tpl.php
+++ b/templates/default/pages/403.tpl.php
@@ -4,7 +4,7 @@
     if (!\Idno\Core\Idno::site()->session()->isLoggedIn()) {
         ?>
         <a id="soft-forward"
-           href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login?fwd=' . urlencode($_SERVER['REQUEST_URI']); ?>">Click
+           href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login?fwd=' . Idno\Core\Webservice::base64UrlEncode($_SERVER['REQUEST_URI']); ?>">Click
             here to log in.</a>
         <script>
             $('#soft-forward').hide();  // JS users will be forwarded anyway


### PR DESCRIPTION
## Here's what I fixed or added:

Switched for url encoding to base64 encoding for fwd parameter

## Here's why I did it:

urlencoding a urlencoded link in sharing caused modsecurity to have a hissy fit, I'm hoping that base64 is safer.
