### PR TITLE
Increase entropy / use more reliable random number generator

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -517,7 +517,7 @@
                 if (!$this->getSlug() && empty($this->_id)) {
                     if (!($title = $this->getTitle())) {
                         if (!($title = $this->getDescription())) {
-                            $title = md5(rand() . microtime(true));
+                            $title = md5(mt_rand() . microtime(true));
                         }
                     }
                     //\Idno\Core\Idno::site()->logging()->debug("Setting resilient slug");
@@ -1221,10 +1221,10 @@
                     return $short;
                 }
 
-                $seed = rand(0, 99999999);
+                $seed = mt_rand(); //rand(0, 99999999);
                 $code = shorten($seed);
                 while ($entity = static::getByShortURL($code)) {
-                    $code = shorten(rand(0, 99999999));
+                    $code = shorten(mt_rand()); //shorten(rand(0, 99999999));
                 }
                 $this->shorturl = $code;
                 $this->save();
@@ -1725,7 +1725,8 @@
             {
                 $url = $this->getURL();
                 if (\Idno\Core\Idno::site()->config()->unique_urls) {
-                    $url = \Idno\Core\Idno::site()->template()->getURLWithVar('rnd', rand(0, 999999), $url);
+                    //$url = \Idno\Core\Idno::site()->template()->getURLWithVar('rnd', rand(0, 999999), $url);
+                    $url = \Idno\Core\Idno::site()->template()->getURLWithVar('rnd', mt_rand(), $url);
                 }
 
                 return $url;

--- a/Idno/Core/SynchronousQueue.php
+++ b/Idno/Core/SynchronousQueue.php
@@ -9,7 +9,7 @@ class SynchronousQueue extends EventQueue
 
     function enqueue($queueName, $eventName, array $eventData)
     {
-        $id     = md5(time() . rand(0,9999) . $eventName);
+        $id     = md5(microtime(true) . mt_rand() . $eventName);
         $result = Idno::site()->triggerEvent($eventName, $eventData);
         $this->results[$id] = $result;
         return $id;

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -159,7 +159,7 @@
                 $collection = $this->sanitiseCollection($collection);
 
                 if (empty($array['_id'])) {
-                    $array['_id'] = md5(rand() . microtime(true));
+                    $array['_id'] = md5(mt_rand() . microtime(true));
                 }
                 if (empty($array['uuid'])) {
                     $array['uuid'] = \Idno\Core\Idno::site()->config()->getURL() . 'view/' . $array['_id'];

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -121,7 +121,7 @@
                 $collection = $this->sanitiseCollection($collection);
 
                 if (empty($array['_id'])) {
-                    $array['_id'] = md5(rand() . microtime(true));
+                    $array['_id'] = md5(mt_rand() . microtime(true));
                 }
                 if (empty($array['uuid'])) {
                     $array['uuid'] = \Idno\Core\Idno::site()->config()->getURL() . 'view/' . $array['_id'];

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -148,7 +148,7 @@
                 $collection = $this->sanitiseCollection($collection);
 
                 if (empty($array['_id'])) {
-                    $array['_id'] = md5(rand() . microtime(true));
+                    $array['_id'] = md5(mt_rand() . microtime(true));
                 }
                 if (empty($array['uuid'])) {
                     $array['uuid'] = \Idno\Core\Idno::site()->config()->getURL() . 'view/' . $array['_id'];

--- a/Idno/Files/LocalFileSystem.php
+++ b/Idno/Files/LocalFileSystem.php
@@ -66,7 +66,7 @@
                     $metadata = json_encode($metadata);
 
                     // Generate a random ID
-                    $id = md5(rand() . microtime(true) . $metadata);
+                    $id = md5(mt_rand() . microtime(true) . $metadata);
 
                     // Generate save path
                     if ($path[sizeof($path) - 1] != '/') {

--- a/Tests/CryptoTest.php
+++ b/Tests/CryptoTest.php
@@ -23,6 +23,10 @@ namespace Tests {
             $this->assertTrue($cstrong);
         }
         
+        public function testRandomEntropy() {
+            $this->assertTrue(getrandmax() > 32767);
+        }
+        
         /**
          * Site secret initialised and reasonably long. (Note, we can't check entropy here)
          */


### PR DESCRIPTION
## Here's what I fixed or added:

Switched to using mt_rand() instead of rand()

## Here's why I did it:

Spotted a few places where rand() was passed with parameters resulting in low entropy, in addition on certain platforms (e.g. windows) getrandmax() was unreliably low. 

mt_rand() is both more reliable and faster, so switching to use this for instances where rand() was called.