### PR TITLE
Make input default returns more consistent (replaces #1539).

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -94,15 +94,16 @@
             function getInput($name, $default = null, callable $filter = null)
             {
                 if (!empty($name)) {
+                    $value = null;
                     $request = \Idno\Core\Input::getInput($name, $default, $filter);
                     if (!empty($request)) {
                         $value = $request;
                     } else if (!empty($this->data[$name])) {
                         $value = $this->data[$name];
                     }
-                    if ((empty($value)) && (!empty($default)))
+                    if ((!$value===null) && ($default!==null))
                         $value = $default;
-                    if (!empty($value)) {
+                    if (!$value!==null) {
                         if (isset($filter) && is_callable($filter) && empty($request)) {
                             $value = call_user_func($filter, $name, $value);
                         }
@@ -113,7 +114,7 @@
                     }
                 }
 
-                return false;
+                return null;
             }
 
             function exception($e)

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -101,7 +101,7 @@
                     } else if (!empty($this->data[$name])) {
                         $value = $this->data[$name];
                     }
-                    if ((!$value===null) && ($default!==null))
+                    if (($value===null) && ($default!==null))
                         $value = $default;
                     if (!$value!==null) {
                         if (isset($filter) && is_callable($filter) && empty($request)) {

--- a/Idno/Core/Input.php
+++ b/Idno/Core/Input.php
@@ -31,7 +31,7 @@
                     }
                     if (($value===null) && ($default!==null))
                         $value = $default;
-                    if (!$value!==null) {error_log("$name here");
+                    if (!$value!==null) {
                         if (isset($filter) && is_callable($filter)) {
                             $value = call_user_func($filter, $name, $value);
                         }

--- a/Idno/Core/Input.php
+++ b/Idno/Core/Input.php
@@ -25,12 +25,13 @@
             public static function getInput($name, $default = null, callable $filter = null)
             {
                 if (!empty($name)) {
+                    $value = null;
                     if (!empty($_REQUEST[$name])) {
                         $value = $_REQUEST[$name];
                     }
-                    if ((empty($value)) && (!empty($default)))
+                    if (($value===null) && ($default!==null))
                         $value = $default;
-                    if (!empty($value)) {
+                    if (!$value!==null) {error_log("$name here");
                         if (isset($filter) && is_callable($filter)) {
                             $value = call_user_func($filter, $name, $value);
                         }

--- a/Tests/Core/InputTest.php
+++ b/Tests/Core/InputTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Core {
+
+    class InputTest extends \Tests\KnownTestCase {
+
+        public function testInputDefaults() {
+            
+            $this->assertTrue(null === \Idno\Core\Input::getInput('nulltest', null));
+            $this->assertTrue(false === \Idno\Core\Input::getInput('falsetest', false));
+            $this->assertTrue(true === \Idno\Core\Input::getInput('truetest', true));
+        }
+
+    }
+
+}

--- a/Tests/Core/InputTest.php
+++ b/Tests/Core/InputTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Core {
 
+    class DummyPage extends \Idno\Common\Page {}
+    
     class InputTest extends \Tests\KnownTestCase {
 
         public function testInputDefaults() {
@@ -9,6 +11,12 @@ namespace Tests\Core {
             $this->assertTrue(null === \Idno\Core\Input::getInput('nulltest', null));
             $this->assertTrue(false === \Idno\Core\Input::getInput('falsetest', false));
             $this->assertTrue(true === \Idno\Core\Input::getInput('truetest', true));
+            
+            $page = new DummyPage();
+            
+            $this->assertTrue(null === $page->getInput('nulltest', null));
+            $this->assertTrue(false === $page->getInput('falsetest', false));
+            $this->assertTrue(true === $page->getInput('truetest', true));
         }
 
     }


### PR DESCRIPTION

## Here's what I fixed or added:

Second attempt at making input defaults more consistent.

Now, passing a default of 'null' will not result in a default of 'false', even though these are both empty()

## Here's why I did it:

Was causing problems for some people.

