### PR TITLE
Fixing like

### DIFF
--- a/IdnoPlugins/Like/Like.php
+++ b/IdnoPlugins/Like/Like.php
@@ -59,7 +59,7 @@
             function getTitleFromURL($Url){
                 $str = \Idno\Core\Webservice::file_get_contents($Url);
                 if(strlen($str) > 0){
-                    if ($result = preg_match("/\<title\>(.*)\<\/title\>/siu",$str,$title)) {
+                    if ($result = preg_match("#<title>(.*?)</title>#siu",$str,$title)) {
                         return html_entity_decode($title[1], ENT_QUOTES | ENT_XML1, 'UTF-8');
                     }
                 }

--- a/IdnoPlugins/Like/Pages/Callback.php
+++ b/IdnoPlugins/Like/Pages/Callback.php
@@ -12,8 +12,12 @@
                 $this->gatekeeper();
                 if ($url = $this->getInput('url')) {
 
+                    \Idno\Core\Idno::site()->logging()->debug("Attempting to pull title from $url");
+                    
                     $like = new Like();
                     $title = $like->getTitleFromURL($url);
+                    
+                    \Idno\Core\Idno::site()->logging()->debug("Title has been pulled: $title");
 
                     if (strlen($title) > 128) {
                         $title = '';    // Don't return overlong titles

--- a/IdnoPlugins/Like/templates/default/entity/Like.tpl.php
+++ b/IdnoPlugins/Like/templates/default/entity/Like.tpl.php
@@ -29,7 +29,7 @@
 
             ?>
             <h2 class="idno-bookmark"><?=$icon?><a href="<?= $vars['object']->body; ?>" class="<?= $class ?> p-name"
-                target="_blank"><?= $this->parseURLs(htmlentities(strip_tags($body)), $rel) ?></a>
+                target="_blank"><?= $this->parseURLs(htmlentities(strip_tags($body))) ?></a>
             </h2>
         <?php
 


### PR DESCRIPTION
## Here's what I fixed or added:

Modified the title extraction regex to be less greedy 

## Here's why I did it:

Old regex extracted title from the first <title> tag to the *last* </title> .. so if the content contained malformed content containing a second </title> it'll return everything in between, resulting in a lot of garbage.
