### PR TITLE
Updating CSRF token generation to a more secure mechanism 

### DIFF
--- a/Tests/CryptoTest.php
+++ b/Tests/CryptoTest.php
@@ -23,6 +23,9 @@ namespace Tests {
             $this->assertTrue($cstrong);
         }
         
+        /**
+         * Some platforms (Windows I'm looking at you) only return a 32 bit randmax.
+         */
         public function testRandomEntropy() {
             $this->assertTrue(getrandmax() > 32767);
         }
@@ -32,6 +35,18 @@ namespace Tests {
          */
         public function testSiteSecret() {
             $this->assertTrue((strlen(\Idno\Core\Idno::site()->config()->site_secret)>=64));
+        }
+        
+        /**
+         * Some configurations seem to advertise algorithms which they don't support, this causes problems.
+         */
+        public function testAlgortihms() {
+            
+            foreach (hash_algos() as $algo) {
+                $secret = "secret";
+                
+                $this->assertTrue(!empty(hash($algo, $secret)));
+            }
         }
     }
 }

--- a/Tests/CryptoTest.php
+++ b/Tests/CryptoTest.php
@@ -37,6 +37,15 @@ namespace Tests {
             $this->assertTrue((strlen(\Idno\Core\Idno::site()->config()->site_secret)>=64));
         }
         
+        
+        /**
+         * Bonita now requires sha256
+         */
+        public function testAssertSha256() {
+            
+            $this->assertTrue(in_array('sha256', hash_algos()));
+        }
+        
         /**
          * Some configurations seem to advertise algorithms which they don't support, this causes problems.
          */
@@ -48,5 +57,6 @@ namespace Tests {
                 $this->assertTrue(!empty(hash($algo, $secret)));
             }
         }
+        
     }
 }

--- a/external/bonita/includes/Bonita/Forms.php
+++ b/external/bonita/includes/Bonita/Forms.php
@@ -105,7 +105,11 @@
              */
             public static function token($action, $time)
             {
-                return sha1($action . $time . \Bonita\Main::getSiteSecret());
+                $hmac = hash_hmac('sha256', $action, \Bonita\Main::getSiteSecret(), true);
+                $hmac = hash_hmac('sha256', $time, $hmac);
+                
+                return $hmac;
+                //return sha1($action . $time . \Bonita\Main::getSiteSecret());
             }
 
         }

--- a/external/bonita/includes/Bonita/Forms.php
+++ b/external/bonita/includes/Bonita/Forms.php
@@ -29,7 +29,7 @@
             {
 
                 $time        = time();
-                $this->token = sha1($this->targetURL . $time . \Bonita\Main::getSiteSecret());
+                $this->token = static::token($this->targetURL, $time); //sha1($this->targetURL . $time . \Bonita\Main::getSiteSecret());
                 $this->time  = $time;
                 parent::draw($templateName, $returnBlank);
 


### PR DESCRIPTION
## Here's what I fixed or added:

Moved from sha1() hash to sha256 hmac

## Here's why I did it:

hmacs are cryptographically secure, so it's harder to fix the site secret (public key).

Holding off merge until status of #1772 has been decided.