### PR TITLE
Token updating

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -686,6 +686,10 @@
             {
                 $this->setResponse(403);
                 http_response_code($this->response);
+                
+                header_remove('X-Known-CSRF-Ts');
+                header_remove('X-Known-CSRF-Token');
+                
                 $t = \Idno\Core\Idno::site()->template();
                 $t->__(array('body' => $t->draw('pages/403'), 'title' => $title))->drawPage();
                 exit;

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -636,6 +636,10 @@
             {
                 $this->setResponse(410);
                 http_response_code($this->response);
+                
+                header_remove('X-Known-CSRF-Ts');
+                header_remove('X-Known-CSRF-Token');
+                
                 $t = \Idno\Core\Idno::site()->template();
                 $t->__(array('body' => $t->draw('pages/410'), 'title' => 'This page is gone.'))->drawPage();
                 exit;
@@ -648,6 +652,10 @@
             {
                 $this->setResponse(404);
                 http_response_code($this->response);
+                
+                header_remove('X-Known-CSRF-Ts');
+                header_remove('X-Known-CSRF-Token');
+                
                 $t = \Idno\Core\Idno::site()->template();
                 $t->__(array('body' => $t->draw('pages/404'), 'title' => 'This page can\'t be found.'))->drawPage();
                 exit;

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -142,6 +142,26 @@
                 http_response_code($this->response);
             }
 
+            function head_xhr() {
+                \Idno\Core\Idno::site()->session()->publicGatekeeper();
+
+                \Idno\Core\Idno::site()->template()->autodetectTemplateType();
+
+                $arguments = func_get_args();
+                if (!empty($arguments)) $this->arguments = $arguments;
+                $this->xhr = true;
+                
+                // Generate CSRF token for javascript queries (see #1727)
+                $action = '/' . trim($this->currentUrl(true)['path'], ' /');
+                $time = time();
+                $token = \Bonita\Forms::token($action, $time);
+
+                header('X-Known-CSRF-Ts: ' . $time);
+                header('X-Known-CSRF-Token: ' . $token);
+                
+                $this->head();
+            }
+            
             function head()
             {
                 \Idno\Core\Idno::site()->session()->publicGatekeeper();
@@ -154,11 +174,11 @@
                 if (!empty($arguments)) $this->arguments = $arguments;
 
                 \Idno\Core\Idno::site()->triggerEvent('page/head', array('page_class' => get_called_class(), 'arguments' => $arguments));
-
+                
                 // Triggering GET content to call all the appropriate headers (web server should truncate the head request from body).
                 // This is the only way we can generate accurate expires and content length etc, but could be done more efficiently
                 $this->getContent();
-
+                
                 //if (http_response_code() != 200)
                 http_response_code($this->response);
             }

--- a/js/default.js
+++ b/js/default.js
@@ -14,6 +14,25 @@
 
 var isCreateFormVisible = false;
 
+/** Known object */
+function Security() {}
+
+/** Perform a HEAD request on the current page and pass the token to a given callback */
+Security.getCSRFToken = function(callback) {
+    
+    $.ajax({
+        type: "HEAD",
+        url: known.currentPageUrl,
+    }).done(function(message,text,jqXHR){
+        var token = jqXHR.getResponseHeader('X-Known-CSRF-Token');
+	var ts = jqXHR.getResponseHeader('X-Known-CSRF-Ts');
+	
+	callback(token, ts);
+    });
+}
+
+
+
 /**
  *** Content creation
  */

--- a/js/default.js
+++ b/js/default.js
@@ -18,11 +18,14 @@ var isCreateFormVisible = false;
 function Security() {}
 
 /** Perform a HEAD request on the current page and pass the token to a given callback */
-Security.getCSRFToken = function(callback) {
+Security.getCSRFToken = function(callback, pageurl) {
+    
+    if (pageurl == undefined)
+	pageurl = known.currentPageUrl;
     
     $.ajax({
         type: "HEAD",
-        url: known.currentPageUrl,
+        url: pageurl,
     }).done(function(message,text,jqXHR){
         var token = jqXHR.getResponseHeader('X-Known-CSRF-Token');
 	var ts = jqXHR.getResponseHeader('X-Known-CSRF-Ts');

--- a/js/default.js
+++ b/js/default.js
@@ -14,7 +14,7 @@
 
 var isCreateFormVisible = false;
 
-/** Known object */
+/** Known security object */
 function Security() {}
 
 /** Perform a HEAD request on the current page and pass the token to a given callback */


### PR DESCRIPTION
## Here's what I fixed or added:

* When calling a page via XHR, a HEAD request will now return a new CSRF token.
* Added a helper JS function to use it.

## Here's why I did it:

To allow javascript only pages.

NOTE: Please check this through and read ticket discussion before merging, just incase I'm missing something and opening a horrible security hole...