### PR TITLE
Closes #1548: Use title for alt tag.

### DIFF
--- a/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
+++ b/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
@@ -38,7 +38,7 @@
 
             ?>
             <div class="photo-view">
-                <a href="<?= $vars['object']->getDisplayURL(); ?>" data-title="<?= htmlentities(strip_tags($vars['object']->getTitle()), ENT_QUOTES, 'UTF-8'); ?>" data-footer="<?= htmlentities(strip_tags($vars['object']->body), ENT_QUOTES, 'UTF-8'); ?>"><img src="<?= $this->makeDisplayURL($src) ?>" class="u-photo"/></a>
+                <a href="<?= $vars['object']->getDisplayURL(); ?>" data-title="<?= htmlentities(strip_tags($vars['object']->getTitle()), ENT_QUOTES, 'UTF-8'); ?>" data-footer="<?= htmlentities(strip_tags($vars['object']->body), ENT_QUOTES, 'UTF-8'); ?>"><img src="<?= $this->makeDisplayURL($src) ?>" class="u-photo" alt="<?= htmlentities(strip_tags($vars['object']->getTitle()), ENT_QUOTES, 'UTF-8'); ?>" /></a>
             </div>
         <?php
         }


### PR DESCRIPTION
## Here's what I fixed or added:

Using photo title as image alt attrib.

## Here's why I did it:

Accessibility 
