### PR TITLE
Json exception

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -704,6 +704,15 @@
             }
 
             /**
+             * Ensure this can only be called via xhr.
+             */
+            function xhrGatekeeper() {
+                if (!$this->xhr) {
+                    $this->deniedContent();
+                }
+            }
+            
+            /**
              * Placed in pages to ensure that only logged-in users can
              * get at them. Sets response code 401 and tries to forward
              * to the front page.

--- a/templates/json/shell.tpl.php
+++ b/templates/json/shell.tpl.php
@@ -4,4 +4,14 @@
     header("Access-Control-Allow-Origin: *");
     unset($vars['body']);
     
+    if (!empty($vars['exception'])) {
+        $e = [
+            'class' => get_class($vars['exception']),
+            'message' => $vars['exception']->getMessage(),
+            'file' => $vars['exception']->getFile(),
+            'line' => $vars['exception']->getLine()
+        ];
+        $vars['exception'] = $e;
+    }
+    
     echo json_encode($vars);


### PR DESCRIPTION
## Here's what I fixed or added:

Explicitly parse out exceptions in JSON shell

## Here's why I did it:

The json encoded version of exception was pretty much useless...
