### PR TITLE
Updating Erin's website url to her main site, since the domain seems …

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,7 +7,7 @@ Core team
 ---------
 
 * Ben Werdmuller http://werd.io
-* Erin Jo Richey http://erinjo.is
+* Erin Jo Richey http://erinjorichey.com
 
 Homepage: https://withknown.com/
 Team Known site: http://stream.withknown.com/


### PR DESCRIPTION
…to have lapsed.

## Here's what I fixed or added:

Changed the contributors link for erin's site

## Here's why I did it:

It's listed in Known, and appears to point to a lapsed domain

/cc @erinjo 
