### PR TITLE
Removing cache control headers from htaccess files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -75,19 +75,6 @@
   Allow from all
 </Files>
 
-<IfModule mod_headers.c>
-# cache images and flash content for one day
-<FilesMatch ".(flv|gif|jpg|jpeg|png|ico|swf)$">
-Header set Cache-Control "max-age=86400"
-</FilesMatch>
-
-# cache text, css, and javascript files for one day
-<FilesMatch ".(js|css|pdf|txt)$">
-Header set Cache-Control "max-age=86400"
-</FilesMatch>
-</IfModule>
-
-
 AddType video/ogg .ogv
 AddType video/mp4 .mp4
 AddType video/webm .webm

--- a/htaccess-2.4.dist
+++ b/htaccess-2.4.dist
@@ -63,19 +63,6 @@
   Require all granted
 </Files>
 
-<IfModule mod_headers.c>
-# cache images and flash content for one day
-<FilesMatch ".(flv|gif|jpg|jpeg|png|ico|swf)$">
-Header set Cache-Control "max-age=86400"
-</FilesMatch>
-
-# cache text, css, and javascript files for one day
-<FilesMatch ".(js|css|pdf|txt)$">
-Header set Cache-Control "max-age=86400"
-</FilesMatch>
-</IfModule>
-
-
 AddType video/ogg .ogv
 AddType video/mp4 .mp4
 AddType video/webm .webm

--- a/htaccess.dist
+++ b/htaccess.dist
@@ -75,19 +75,6 @@
   Allow from all
 </Files>
 
-<IfModule mod_headers.c>
-# cache images and flash content for one day
-<FilesMatch ".(flv|gif|jpg|jpeg|png|ico|swf)$">
-Header set Cache-Control "max-age=86400"
-</FilesMatch>
-
-# cache text, css, and javascript files for one day
-<FilesMatch ".(js|css|pdf|txt)$">
-Header set Cache-Control "max-age=86400"
-</FilesMatch>
-</IfModule>
-
-
 AddType video/ogg .ogv
 AddType video/mp4 .mp4
 AddType video/webm .webm


### PR DESCRIPTION
## Here's what I fixed or added:

Removed header expiry header control from htaccess

## Here's why I did it:

It isn't our place to do this, and often conflicts with server admin's often better cache and proxy settings.

Closes #1791 