### PR TITLE
Temporarily removing X-Frame-Options

### DIFF
--- a/templates/default/shell/headers.tpl.php
+++ b/templates/default/shell/headers.tpl.php
@@ -3,13 +3,13 @@
     header('Content-type: text/html');
     header("Access-Control-Allow-Origin: *");
 
-    $page = \Idno\Core\Idno::site()->currentPage();
-    if (!empty($page)) {
-        $page = $page->currentUrl(true);
-        
-        if (strpos($page['path'], '/share?')===false) {
-            // Some clickjacking defence (and to quiet ModSecurity)
-            // https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet
-            header("X-Frame-Options: SAMEORIGIN");
-        }
-    }
+//    $page = \Idno\Core\Idno::site()->currentPage();
+//    if (!empty($page)) {
+//        $page = $page->currentUrl(true);
+//        
+//        if (strpos($page['path'], '/share?')===false) {
+//            // Some clickjacking defence (and to quiet ModSecurity)
+//            // https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet
+//            header("X-Frame-Options: SAMEORIGIN");
+//        }
+//    }


### PR DESCRIPTION
## Here's what I fixed or added:

Disabled X-Frame-Options clickjacking defence, instead leaving it to admins.

## Here's why I did it:

It was causing problems for some, as well as chrome / Firefox plugin

Closes #1797 