### PR TITLE
Distinguish between types

### DIFF
--- a/Idno/Stats/Timer.php
+++ b/Idno/Stats/Timer.php
@@ -42,7 +42,7 @@ namespace Idno\Stats {
          */
         public static function logTimer($timer) {
             
-            \Idno\Core\Idno::site()->logging()->debug("Timer $timer has been running for " . static::value($timer) . ' seconds.');
+            \Idno\Core\Idno::site()->logging()->debug(get_called_class() . " $timer has been running for " . static::value($timer) . ' seconds.');
         }
         
     }


### PR DESCRIPTION
## Here's what I fixed or added:

Logging now shows class

## Here's why I did it:

To distinguish between types of timer