### PR TITLE
Catch exceptions when logging

### DIFF
--- a/Idno/Stats/Timer.php
+++ b/Idno/Stats/Timer.php
@@ -41,8 +41,11 @@ namespace Idno\Stats {
          * @param type $timer
          */
         public static function logTimer($timer) {
-            
-            \Idno\Core\Idno::site()->logging()->debug(get_called_class() . " $timer has been running for " . static::value($timer) . ' seconds.');
+            try {
+                \Idno\Core\Idno::site()->logging()->debug(get_called_class() . " $timer has been running for " . static::value($timer) . ' seconds.');
+            } catch (\Exception $e) {
+                \Idno\Core\Idno::site()->logging()->debug($e->getMessage());
+            }
         }
         
     }


### PR DESCRIPTION
## Here's what I fixed or added:

Catch exception in logTimer()

## Here's why I did it:

In usage, having the exception bubble up was annoying