### PR TITLE
Prevent notice error when unlinking non-existent cache

### DIFF
--- a/Idno/Caching/FilesystemCache.php
+++ b/Idno/Caching/FilesystemCache.php
@@ -28,7 +28,7 @@ namespace Idno\Caching {
         }
         
         public function delete($key) {
-            unlink(self::$path . '/' . sha1($key));
+            @unlink(self::$path . '/' . sha1($key));
         }
 
         public function load($key) {


### PR DESCRIPTION
## Here's what I fixed or added:

@ on the unlink

## Here's why I did it:

Prevent notice error, and pedantic mode crash