### PR TITLE
Allow an email address as secondary API identifier

### DIFF
--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -474,7 +474,9 @@
                         \Idno\Core\Idno::site()->template()->setTemplateType('json');
                     }
 
-                    if ($user = \Idno\Entities\User::getByHandle($_SERVER['HTTP_X_KNOWN_USERNAME'])) {
+                    $user = \Idno\Entities\User::getByHandle($_SERVER['HTTP_X_KNOWN_USERNAME']);
+                    if (empty($user)) \Idno\Entities\User::getByEmail($_SERVER['HTTP_X_KNOWN_USERNAME']);
+                    if (!empty($user)) {
                         \Idno\Core\Idno::site()->logging()->debug("API auth found user by username: {$_SERVER['HTTP_X_KNOWN_USERNAME']} - " . $user->getName());
                         
                         $key  = $user->getAPIkey();


### PR DESCRIPTION
## Here's what I fixed or added:

Allow api users to be identified by email address in addition to username

## Here's why I did it:

Some authentication systems identify by email address and leave handle hidden.