### PR TITLE
Advanced docs

### DIFF
--- a/docs/install/advanced.md
+++ b/docs/install/advanced.md
@@ -1,0 +1,35 @@
+# Advanced Options
+
+Here are some configuration options which are available, but not really necessary
+for most users.
+
+## Asynchronous Event Queue
+
+Known uses event queues to dispatch things like Webmention pings. 
+
+By default, this dispatching is synchronous. However, you it is possible to enqueue events and have them dispatched later in an asynchronous fashion, enabling faster page loading.
+
+### Enabling asynchronous queues
+
+To use something the asynchronous queue, add the following line to your ```config.ini```:
+
+```
+event_queue = 'AsynchronousQueue'
+```
+
+### Running the dispatch service
+
+Next, you need to run the Known event queue dispatching service using the Known console tool:
+
+```
+./known service-event-queue
+```
+
+!!! note "Per-domain configuration"
+    If you’re using per-domain configuration you’ll need to set an environment variable in order for everything to work as expected:
+
+    ```
+    export KNOWN_DOMAIN='your.domain.name'
+    ```
+
+service queue

--- a/docs/install/config.md
+++ b/docs/install/config.md
@@ -7,8 +7,11 @@ However, sometimes you may wish to add values here.
 
 Config.ini files use the [INI file format](https://en.wikipedia.org/wiki/INI_file).
 
-You can also use yourdomain.ini: for example, if your site was stored at yourdomain.com, you could have a supplemental
-config.ini file at yourdomain.com.ini. This is most useful in combination with the **multitenant** setting.
+!!! note "Per-domain configuration"
+    You can also use ```yourdomain.ini```, in addition to ```config.ini```: for example, if your site was stored at yourdomain.com, you could have a supplemental
+    config.ini file at yourdomain.com.ini. This is most useful in combination with the **multitenant** setting. 
+
+    Per domain configuration files are loaded after ```config.ini``` is processed.
 
 ## Example config.ini file
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ pages:
 - ['install/upgrade.md', 'Installing and upgrading Known', 'Upgrading Known']
 - ['install/config.md', 'Installing and upgrading Known', 'Using config.ini']
 - ['install/sharedhost.md', 'Installing and upgrading Known', 'Instructions for common shared hosting providers']
+- ['install/advanced.md', 'Installing and upgrading Known', 'Advanced Options']
 - ['install/debugging.md', 'Installing and upgrading Known', 'Debugging Known']
 - ['install/troubleshooting.md', 'Installing and upgrading Known', 'Troubleshooting your installation']
 - ['plugins/index.md', 'Plugins', 'Plugins']


### PR DESCRIPTION
## Here's what I fixed or added:

Introduced an advanced options section to the installation guide, included documentation of the asynchronous event queue

## Here's why I did it:

Needed documenting.

