### PR TITLE
Advanced stats

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -127,6 +127,7 @@
                 $stats = \Idno\Core\Idno::site()->statistics();
                 if (!empty($stats)) {
                     $stats->increment("error.exception");
+                }
 
                 try {
                     \Idno\Core\Logging::oopsAlert($e->getMessage() . " [".$e->getFile().":".$e->getLine()."]", get_class($e));

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -124,6 +124,11 @@
                 
                 \Idno\Core\Idno::site()->logging()->critical($e->getMessage() . " [".$e->getFile().":".$e->getLine()."]");
                 
+                $stats = \Idno\Core\Idno::site()->statistics();
+                if (!empty($stats)) {
+                    $stats->increment("error.exception");
+                }
+                
                 $t = \Idno\Core\Idno::site()->template();
                 $t->__(array('body' => $t->__(array('exception' => $e))->draw('pages/500'), 'title' => 'Exception'))->drawPage();
                 exit;

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -118,11 +118,11 @@
                 $this->statistics   = $this->componentFactory($this->config->statistics_collector, "Idno\\Stats\\StatisticsCollector", "Idno\\Stats\\", "Idno\\Stats\\DummyStatisticsCollector");
                 
                 // Log some page statistics
-                \Idno\Stats\Timer::start('page');
+                \Idno\Stats\Timer::start('script');
                 register_shutdown_function(function () {
                     $stats = \Idno\Core\Idno::site()->statistics();
                     if (!empty($stats)) {
-                        $stats->timing('timer.page', \Idno\Stats\Timer::value('page'));
+                        $stats->timing('timer.script', \Idno\Stats\Timer::value('script'));
                     }
                 });
                 

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -117,6 +117,15 @@
                 $this->queue        = $this->componentFactory($this->config->event_queue, "Idno\\Core\\EventQueue", "Idno\\Core\\", "Idno\\Core\\SynchronousQueue");
                 $this->statistics   = $this->componentFactory($this->config->statistics_collector, "Idno\\Stats\\StatisticsCollector", "Idno\\Stats\\", "Idno\\Stats\\DummyStatisticsCollector");
                 
+                // Log some page statistics
+                \Idno\Stats\Timer::start('page');
+                register_shutdown_function(function () {
+                    $stats = \Idno\Core\Idno::site()->statistics();
+                    if (!empty($stats)) {
+                        $stats->timing('timer.page', \Idno\Stats\Timer::value('page'));
+                    }
+                });
+                
                 // Attempt to create a cache object, making use of support present on the system
                 if (extension_loaded('apc') && ini_get('apc.enabled'))
                     $this->cache = new \Idno\Caching\APCuCache();

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -116,7 +116,7 @@
                 $this->helper_robot = new HelperRobot();
                 $this->queue        = $this->componentFactory($this->config->event_queue, "Idno\\Core\\EventQueue", "Idno\\Core\\", "Idno\\Core\\SynchronousQueue");
                 $this->statistics   = $this->componentFactory($this->config->statistics_collector, "Idno\\Stats\\StatisticsCollector", "Idno\\Stats\\", "Idno\\Stats\\DummyStatisticsCollector");
-
+                
                 // Attempt to create a cache object, making use of support present on the system
                 if (extension_loaded('apc') && ini_get('apc.enabled'))
                     $this->cache = new \Idno\Caching\APCuCache();

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -37,6 +37,7 @@
             public $helper_robot;
             public $reader;
             public $cache;
+            public $statistics;
 
             function __construct()
             {
@@ -114,6 +115,7 @@
                 $this->reader       = new Reader();
                 $this->helper_robot = new HelperRobot();
                 $this->queue        = $this->componentFactory($this->config->event_queue, "Idno\\Core\\EventQueue", "Idno\\Core\\", "Idno\\Core\\SynchronousQueue");
+                $this->statistics   = $this->componentFactory($this->config->statistics_collector, "Idno\\Stats\\StatisticsCollector", "Idno\\Stats\\", "Idno\\Stats\\DummyStatisticsCollector");
 
                 // Attempt to create a cache object, making use of support present on the system
                 if (extension_loaded('apc') && ini_get('apc.enabled'))
@@ -251,6 +253,7 @@
             /**
              * Access to the EventQueue for dispatching events
              * asynchronously
+             * @return \Idno\Core\EventQueue
              */
             function &queue()
             {
@@ -291,6 +294,15 @@
             function &cache()
             {
                 return $this->cache;
+            }
+            
+            /**
+             * Return a statistics collector
+             * @return \Idno\Stats\StatisticsCollector
+             */
+            function &statistics()
+            {
+                return $this->statistics;
             }
 
             /**

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -317,6 +317,11 @@
 
             function triggerEvent($eventName, $data = array(), $default = true)
             {
+                $stats = $this->statistics();
+                if (!empty($stats)) {
+                    $stats->increment ("event.$eventName");
+                }
+                
                 $event = new Event($data);
                 $event->setResponse($default);
                 $event = $this->events()->dispatch($eventName, $event);

--- a/Idno/Core/Logging.php
+++ b/Idno/Core/Logging.php
@@ -134,6 +134,11 @@ namespace Idno\Core {
             // See if this message isn't filtered out
             if ($this->passesFilter($level)) {
 
+                $stats = \Idno\Core\Idno::site()->statistics();
+                if (!empty($stats)) {
+                    $stats->increment("log.$level");
+                }
+                
                 // Construct log message
                 // Trace for debug (when filtering is set to debug, always add a trace)
                 $trace = "";

--- a/Idno/Stats/DummyStatisticsCollector.php
+++ b/Idno/Stats/DummyStatisticsCollector.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Null implementation of StatisticsCollector, so that the system always has one available.
+ *
+ * @package idno
+ * @subpackage core
+ */
+
+namespace Idno\Stats {
+    
+    class DummyStatisticsCollector {
+        
+        
+    }
+}

--- a/Idno/Stats/DummyStatisticsCollector.php
+++ b/Idno/Stats/DummyStatisticsCollector.php
@@ -9,8 +9,17 @@
 
 namespace Idno\Stats {
     
-    class DummyStatisticsCollector {
+    class DummyStatisticsCollector extends StatisticsCollector {
         
-        
+        public function decrement($stat) { return true; }
+            
+        public function gauge($stat, $value) { return true; }
+
+        public function increment($stat) { return true; }
+
+        public function set($stat, $value) { return true; }
+
+        public function timing($stat, $time) { return true; }
+
     }
 }

--- a/Idno/Stats/StatisticsCollector.php
+++ b/Idno/Stats/StatisticsCollector.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Interface defining a mechanism to collect statistics about your known site.
+ *
+ * @package idno
+ * @subpackage core
+ */
+
+namespace Idno\Stats {
+    
+    abstract class StatisticsCollector extends \Idno\Common\Component {
+        
+        
+    }
+}

--- a/Idno/Stats/StatisticsCollector.php
+++ b/Idno/Stats/StatisticsCollector.php
@@ -8,9 +8,48 @@
  */
 
 namespace Idno\Stats {
-    
+
     abstract class StatisticsCollector extends \Idno\Common\Component {
-        
-        
+
+        /**
+         * Set timing values
+         *
+         * @param string $stat The metric(s) to set.
+         * @param float $time The elapsed time (ms) to log
+         * */
+        abstract public function timing($stat, $time);
+
+        /**
+         * Set gauge to a value
+         *
+         * @param string $stat The metric(s) to set.
+         * @param float $value The value for the stats.
+         * */
+        abstract public function gauge($stat, $value);
+
+        /**
+         * A "Set" is a count of unique events.
+         * 
+         * @param string $stat The metric to set.
+         * @param float $value The value for the stats.
+         * */
+        abstract public function set($stat, $value);
+
+        /**
+         * Increments stats counters
+         *
+         * @param string $stat The metric to increment.
+         * @return boolean
+         * */
+        abstract public function increment($stat);
+
+        /**
+         * Decrements stats counters.
+         *
+         * @param string $stat The metric to decrement.
+         * @return boolean
+         * */
+        abstract public function decrement($stat);
     }
+
 }

--- a/Idno/start.php
+++ b/Idno/start.php
@@ -40,6 +40,11 @@
             } else {
                 echo '<p>If you continue to have problems, <a href="https://withknown.com/opensource" target="_blank">open source users have a number of resources available</a></p>.';
             }
+            
+            $stats = \Idno\Core\Idno::site()->statistics();
+            if (!empty($stats)) {
+                $stats->increment("error.fatal");
+            }
 
             if (isset(\Idno\Core\Idno::site()->logging) && \Idno\Core\Idno::site()->logging)
                 \Idno\Core\Idno::site()->logging->error($error_message);


### PR DESCRIPTION
## Here's what I fixed or added:

* Hooks to collect stats of a running system
* Added some initial stats for counting events (which gives us object saves, log ins etc for free), log messages (gives us errors and warnings), fatal errors and a timer for overall page construction (so we can see cases when a change causes a overall slow down
* Dummy stats collector designed to be replaced with a functional back end

## Here's why I did it:

In a nutshell: https://codeascraft.com/2011/02/15/measure-anything-measure-everything/

But more, to give more data of running systems, and to make it easier to track down problems.