### PR TITLE
Return an array from getallheaders() in Page.php

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -978,7 +978,7 @@
              */
             static function getallheaders()
             {
-                $headers = '';
+                $headers = array();
                 foreach ($_SERVER as $name => $value) {
                     if (substr($name, 0, 14) == 'REDIRECT_HTTP_') {
                         $name = substr($name, 9);


### PR DESCRIPTION
Fixes "Illegal string offset" warnings trying to index into the result of getallheaders().

I'm working on a Known docker image based on alpine, and I am getting 502's with a ton of these warnings trying to index into the result of the function. I changed the initialization of `$headers` to reflect the expected return type.