### PR TITLE
Prevent decoding errors from stopping execution

### DIFF
--- a/templates/default/file/picker/image.tpl.php
+++ b/templates/default/file/picker/image.tpl.php
@@ -50,9 +50,13 @@
                 $('#photo-filename').html('Choose a different image');
                 $('#photopreview').attr('src', e.target.result);
                 
-                var exif = EXIF.readFromBinaryFile(base64ToArrayBuffer(this.result));
-    
-                Image.exifRotateImg('#photopreview', exif.Orientation, '#photo-preview');
+                try {
+                    var exif = EXIF.readFromBinaryFile(base64ToArrayBuffer(this.result));
+
+                    Image.exifRotateImg('#photopreview', exif.Orientation, '#photo-preview');
+                } catch (error) {
+                    console.error(error);
+                }
                 
                 $('#photopreview').show();
                 $('#upload-button').show();


### PR DESCRIPTION
## Here's what I fixed or added:

Put a try/catch around exif extraction

## Here's why I did it:

Some files, which were images, were causing problems during exif extract and so preventing the upload button from displaying.