### PR TITLE
(temporarily?) removing fragmentions library.

### DIFF
--- a/templates/default/shell/javascript.tpl.php
+++ b/templates/default/shell/javascript.tpl.php
@@ -6,4 +6,4 @@
 <script
     src="<?= \Idno\Core\Idno::site()->config()->getStaticURL() ?>external/bootstrap-toggle/js/bootstrap-toggle.js"></script>
 
-<script src="<?= \Idno\Core\Idno::site()->config()->getStaticURL() ?>external/fragmention/fragmention.min.js"></script>
+<?php /*<script src="<?= \Idno\Core\Idno::site()->config()->getStaticURL() ?>external/fragmention/fragmention.min.js"></script> */ ?>


### PR DESCRIPTION
## Here's what I fixed or added:

Disabled fragmentions

## Here's why I did it:

There appear to be instances where this library causes script execution
failures:

```Empty string passed to getElementById(). fragmention.min.js:1:735```

Since nobody(?) really uses this, and the project appears to no longer be
maintained, I'm removing it for now.

Refs chapmanu/fragmentions#14