### PR TITLE
No "untitled"

### DIFF
--- a/IdnoPlugins/Text/Entry.php
+++ b/IdnoPlugins/Text/Entry.php
@@ -9,7 +9,7 @@
 
             function getTitle()
             {
-                if (empty($this->title)) return 'Untitled';
+                if (empty($this->title)) return '';
 
                 return $this->title;
             }

--- a/IdnoPlugins/Text/templates/default/entity/Entry/edit.tpl.php
+++ b/IdnoPlugins/Text/templates/default/entity/Entry/edit.tpl.php
@@ -48,7 +48,7 @@
 
                 <div class="content-form">
                     <label for="title">Title</label>
-                    <input type="text" name="title" id="title" placeholder="Give it a title" value="<?= htmlspecialchars($title) ?>" class="form-control"/>
+                    <input type="text" name="title" id="title" placeholder="Give it a title" value="<?= htmlspecialchars($title) ?>" class="form-control" required />
                 </div>
 
                 <?= $this->__([


### PR DESCRIPTION
## Here's what I fixed or added:

* Blog posts now no longer return "Untitled" when no title is set
* Titles set as a "required" attribute on forms to encourage proper titles

## Here's why I did it:

* "Untitled" posts caused unhelpful slug generation, and caused a lot of #1858 to be seen a lot in the wild. This goes some way to mitigating - since empty titled slugs are now generated from content or failing that are random.