### PR TITLE
Self documenting API

### DIFF
--- a/Idno/Core/Template.php
+++ b/Idno/Core/Template.php
@@ -158,7 +158,14 @@
                     $vars = $this->vars['form-fields'];
                 }
                 
-                $vars[$name] = $values;
+                if (isset($vars[$name])) {
+                    $tmp = [$vars[$name]];
+                    $tmp[] = $values;
+                    
+                    $vars[$name] = $tmp;
+                } else {
+                    $vars[$name] = $values;
+                }
                 
                 $this->__(['form-fields' => $vars]);
             }

--- a/Idno/Core/Template.php
+++ b/Idno/Core/Template.php
@@ -146,6 +146,22 @@
                 }
 
             }
+            
+            /**
+             * Document a form control and make it easily discoverable by the API.
+             * @param type $name
+             * @param type $values
+             */
+            function documentFormControl($name, $values = []) {
+                $vars = [];
+                if (!empty($this->vars['api-fields'])) {
+                    $vars = $this->vars['api-fields'];
+                }
+                
+                $vars[$name] = $values;
+                
+                $this->__(['api-fields' => $vars]);
+            }
 
             /**
              * Extend a template with another template. eg, template "plugin/atemplate"

--- a/Idno/Core/Template.php
+++ b/Idno/Core/Template.php
@@ -149,8 +149,8 @@
             
             /**
              * Document a form control and make it easily discoverable by the API.
-             * @param type $name
-             * @param type $values
+             * @param type $name Name of the control 
+             * @param type $values Array of form value. Common are 'type', 'description', 'id'
              */
             function documentFormControl($name, $values = []) {
                 $vars = [];

--- a/Idno/Core/Template.php
+++ b/Idno/Core/Template.php
@@ -154,13 +154,13 @@
              */
             function documentFormControl($name, $values = []) {
                 $vars = [];
-                if (!empty($this->vars['api-fields'])) {
-                    $vars = $this->vars['api-fields'];
+                if (!empty($this->vars['form-fields'])) {
+                    $vars = $this->vars['form-fields'];
                 }
                 
                 $vars[$name] = $values;
                 
-                $this->__(['api-fields' => $vars]);
+                $this->__(['form-fields' => $vars]);
             }
 
             /**

--- a/IdnoPlugins/Checkin/templates/default/entity/Checkin/edit.tpl.php
+++ b/IdnoPlugins/Checkin/templates/default/entity/Checkin/edit.tpl.php
@@ -33,17 +33,34 @@
                         <label for="placename">
                             Location<br>
                         </label>
-                        <input type="text" name="placename" id="placename" class="form-control" placeholder="Where are you?" value="<?= htmlspecialchars($vars['object']->placename) ?>" />
-                        <input type="hidden" name="lat" id="lat" value="<?= $vars['object']->lat ?>"/>
-                        <input type="hidden" name="long" id="long" value="<?= $vars['object']->long ?>"/>
+                        <?= $this->__([
+                            'name' => 'placename', 
+                            'id' => 'placename', 
+                            'placeholder' => "Where are you?",
+                            'value' => $vars['object']->placename, 
+                            'class' => 'form-control'])->draw('forms/input/input'); ?>
+                        <?= $this->__([
+                            'name' => 'lat', 
+                            'id' => 'lat',
+                            'value' => $vars['object']->lat])->draw('forms/input/hidden'); ?>
+                        <?= $this->__([
+                            'name' => 'long', 
+                            'id' => 'long',
+                            'value' => $vars['object']->long])->draw('forms/input/hidden'); ?>
                     </p>
 
                     <p>
                         <label for="user_address">Address<br>
                             <small>You can edit the address if it's wrong.</small>
                         </label>
-                        <input type="text" name="user_address" id="user_address" class="form-control" value="<?= htmlspecialchars($vars['object']->address) ?>"/>
-                        <input type="hidden" name="address" id="address" />
+                        <?= $this->__([
+                            'name' => 'user_address', 
+                            'id' => 'user_address', 
+                            'value' => $vars['object']->address, 
+                            'class' => 'form-control'])->draw('forms/input/input'); ?>
+                        <?= $this->__([
+                            'name' => 'address', 
+                            'id' => 'address'])->draw('forms/input/hidden'); ?>
                     </p>
 
                     <div id="checkinMap" style="height: 250px" ></div>
@@ -59,7 +76,9 @@
                 'placeholder' => '',
                 'label' => 'Description'
             ])->draw('forms/input/richtext')?>
-            <?php if (empty($vars['object']->_id)) { ?><input type="hidden" name="forward-to" value="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'; ?>" /><?php } ?>
+            <?php if (empty($vars['object']->_id)) { 
+                $this->__(['name' => 'forward-to', 'value' => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'])->draw('forms/input/hidden');
+            } ?>
             <?=$this->draw('entity/tags/input');?>
             <?php echo $this->drawSyndication('place', $vars['object']->getPosseLinks()); ?>
             <?= $this->draw('content/extra'); ?>

--- a/IdnoPlugins/Event/templates/default/entity/Event/edit.tpl.php
+++ b/IdnoPlugins/Event/templates/default/entity/Event/edit.tpl.php
@@ -19,7 +19,12 @@
             <div class="content-form">
                 <label for="title">
                     Event name</label>
-                    <input type="text" name="title" id="title" placeholder="Give it a name" value="<?=htmlspecialchars($vars['object']->title)?>" class="form-control" />
+                    <?= $this->__([
+                            'name' => 'title', 
+                            'id' => 'title', 
+                            'placeholder' => 'Give it a name', 
+                            'value' => $vars['object']->title, 
+                            'class' => 'form-control'])->draw('forms/input/input'); ?>
 
             </div>
         </div>
@@ -28,20 +33,34 @@
             <div class="content-form">
                 <label for="location">
                     Location</label>
-                    <input type="text" name="location" id="location" placeholder="Where will it take place?" value="<?=htmlspecialchars($vars['object']->location)?>" class="form-control" />
+                     <?= $this->__([
+                            'name' => 'location', 
+                            'id' => 'location', 
+                            'placeholder' => 'Where will it take place?', 
+                            'value' => $vars['object']->location, 
+                            'class' => 'form-control'])->draw('forms/input/input'); ?>
 
             </div>
             <div class="content-form">
                 <label for="starttime">
                     Start day and time</label>
-                <input type="datetime-local" name="starttime" id="starttime" placeholder="Type in the start day and time" value="<?=htmlspecialchars($vars['object']->starttime)?>" class="form-control" />
-
+                <?= $this->__([
+                            'name' => 'starttime', 
+                            'id' => 'starttime', 
+                            'placeholder' => 'Type in the start day and time?', 
+                            'value' => $vars['object']->starttime, 
+                            'class' => 'form-control'])->draw('forms/input/datetime-local'); ?>
             </div>
             <div class="content-form">
                 <label for="endtime">
                     End day and time</label>
-                    <input type="datetime-local" name="endtime" id="endtime" placeholder="Type in the end day and time" value="<?=htmlspecialchars($vars['object']->endtime)?>" class="form-control" />
-
+                <?= $this->__([
+                            'name' => 'endtime', 
+                            'id' => 'endtime', 
+                            'placeholder' => 'Type in the end day and time', 
+                            'value' => $vars['object']->endtime, 
+                            'class' => 'form-control'])->draw('forms/input/datetime-local'); ?>
+                    
             </div>
             <?php echo $this->drawSyndication('event', $vars['object']->getPosseLinks()); ?>
 
@@ -51,7 +70,12 @@
 	        <div class="content-form">
                 <label for="summary">
                     Brief summary</label>
-                    <input type="text" name="summary" id="summary" placeholder="What's this about?" value="<?=htmlspecialchars($vars['object']->summary)?>" class="form-control" />
+                    <?= $this->__([
+                            'name' => 'summary', 
+                            'id' => 'summary', 
+                            'placeholder' => 'What\'s this about?', 
+                            'value' => $vars['object']->summary, 
+                            'class' => 'form-control'])->draw('forms/input/input'); ?>
 
             </div>
 

--- a/IdnoPlugins/Event/templates/default/entity/Event/edit.tpl.php
+++ b/IdnoPlugins/Event/templates/default/entity/Event/edit.tpl.php
@@ -87,7 +87,9 @@
                     ])->draw('forms/input/richtext');?>
             </div>
             <?=$this->draw('entity/tags/input');?>
-            <?php if (empty($vars['object']->_id)) { ?><input type="hidden" name="forward-to" value="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'; ?>" /><?php } ?>
+            <?php if (empty($vars['object']->_id)) { 
+                $this->__(['name' => 'forward-to', 'value' => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'])->draw('forms/input/hidden');
+            } ?>
         </div>
 
         <div class="col-md-8 col-md-offset-2">

--- a/IdnoPlugins/Event/templates/default/entity/RSVP/edit.tpl.php
+++ b/IdnoPlugins/Event/templates/default/entity/RSVP/edit.tpl.php
@@ -20,7 +20,19 @@
             <div class="content-form">
                 <label id="in-reply-to" for="reply">
                     What's the URL of the event you're responding to?</label>
-                    <input type="text" id="reply" name="inreplyto" placeholder="The website address of the event" class="form-control" value="<?php if (empty($vars['url'])) { echo htmlspecialchars($vars['object']->inreplyto); } else { echo htmlspecialchars($vars['url']); } ?>" />
+                    <?php 
+                        $value = "";
+                        if (empty($vars['url'])) { 
+                            $value = $vars['object']->inreplyto;
+                        } else { 
+                            $value = $vars['url']; 
+                        } ?>
+                    <?= $this->__([
+                            'name' => 'inreplyto', 
+                            'id' => 'reply', 
+                            'placeholder' => 'The website address of the event', 
+                            'value' => $value, 
+                            'class' => 'form-control'])->draw('forms/input/url'); ?>
             </div>
             <div class="content-form">
                 <label for="rsvp">
@@ -30,15 +42,31 @@
                         <option value="no" <?php if ($vars['object']->rsvp == 'no') echo "checked"; ?>>No: I am not attending this event</option>
                         <option value="maybe" <?php if ($vars['object']->rsvp == 'maybe') echo "checked"; ?>>Maybe: I might attend this event</option>
                     </select>
+                    <?php
+                    // Not got a select control just yet, lets just publish for now
+                    $this->documentFormControl('rsvp', [
+                        'description' => 'Are you going?',
+                        'id' => 'rsvp',
+                        'type' => 'select'
+                    ]);
+                    ?>
             </div>
 
             <div class="content-form">
                 <label for="body">
                     Any comments?</label>
-                    <textarea name="body" id="body" class="form-control event" /><?=htmlspecialchars($vars['object']->body)?></textarea>
+                    <?= $this->__([
+                        'name' => 'body', 
+                        'id' => 'body', 
+                        'placeholder' => 'Say something here...', 
+                        'height' => 126,
+                        'value' => $vars['object']->body, 
+                        'class' => 'form-control event'])->draw('forms/input/longtext'); ?>
             </div>
             <?=$this->draw('entity/tags/input');?>
-            <?php if (empty($vars['object']->_id)) { ?><input type="hidden" name="forward-to" value="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'; ?>" /><?php } ?>
+            <?php if (empty($vars['object']->_id)) { 
+                $this->__(['name' => 'forward-to', 'value' => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'])->draw('forms/input/hidden');
+            } ?>
             <?php echo $this->drawSyndication('note', $vars['object']->getPosseLinks()); ?>
             <?= $this->draw('content/extra'); ?>
             <?= $this->draw('content/access'); ?>

--- a/IdnoPlugins/Event/templates/default/entity/RSVP/edit.tpl.php
+++ b/IdnoPlugins/Event/templates/default/entity/RSVP/edit.tpl.php
@@ -37,19 +37,19 @@
             <div class="content-form">
                 <label for="rsvp">
                     Are you going?</label>
-                    <select class="form-control" name="rsvp" id="rsvp">
-                        <option value="yes" <?php if ($vars['object']->rsvp == 'yes') echo "checked"; ?>>Yes: I am attending this event</option>
-                        <option value="no" <?php if ($vars['object']->rsvp == 'no') echo "checked"; ?>>No: I am not attending this event</option>
-                        <option value="maybe" <?php if ($vars['object']->rsvp == 'maybe') echo "checked"; ?>>Maybe: I might attend this event</option>
-                    </select>
-                    <?php
-                    // Not got a select control just yet, lets just publish for now
-                    $this->documentFormControl('rsvp', [
-                        'description' => 'Are you going?',
-                        'id' => 'rsvp',
-                        'type' => 'select'
-                    ]);
-                    ?>
+                    
+                    <?= $this->__([
+                            'name' => 'rsvp', 
+                            'id' => 'rsvp', 
+                            'placeholder' => 'Are you going?', 
+                            'value' => $vars['object']->rsvp , 
+                            'class' => 'form-control',
+                            'options' => [
+                                'yes' => 'Yes: I am attending this event',
+                                'no' => 'No: I am not attending this event',
+                                'maybe' => 'Maybe: I might attend this event'
+                            ]
+                        ])->draw('forms/input/select'); ?>
             </div>
 
             <div class="content-form">

--- a/IdnoPlugins/Like/templates/default/entity/Like/edit.tpl.php
+++ b/IdnoPlugins/Like/templates/default/entity/Like/edit.tpl.php
@@ -19,12 +19,22 @@
             <div class="content-form">
                 <label for="body">
                     Link Address</label>
-                <input required type="url" name="body" id="body" placeholder="http://...."
-                       value="<?php if (empty($vars['url'])) {
-                           echo htmlspecialchars($vars['object']->body);
-                       } else {
-                           echo htmlspecialchars($vars['url']);
-                       } ?>" class="form-control bookmark-url"/>
+                <?php
+                $value = "";
+                if (empty($vars['url'])) {
+                    $value = $vars['object']->body;
+                } else {
+                    $value = $vars['url'];
+                }
+                echo $this->__([
+                    'name' => 'body',
+                    'id' => 'body',
+                    'placeholder' => "http://....",
+                    'class' => "form-control bookmark-url",
+                    'value' => $value,
+                    'required' => true
+                ])->draw('forms/input/url');
+                ?>
                 </label>
                 <?php
 
@@ -50,10 +60,14 @@
                     <label for="title">
                         Title<br/>
                     </label>
-                    <input required type="text" name="title" id="title" placeholder="Page name"
-                           value="<?php
-                               echo htmlspecialchars($vars['object']->pageTitle);
-                           ?>" class="form-control bookmark-title"/>
+                    <?= $this->__([
+                            'name' => 'title', 
+                            'id' => 'title', 
+                            'placeholder' => 'Page name', 
+                            'value' => $vars['object']->pageTitle, 
+                            'required' => true,
+                            'class' => 'form-control bookmark-title'])->draw('forms/input/input'); ?>
+                    
                 </div>
 
                 <?= $this->__([

--- a/IdnoPlugins/Like/templates/default/entity/Like/edit.tpl.php
+++ b/IdnoPlugins/Like/templates/default/entity/Like/edit.tpl.php
@@ -82,8 +82,9 @@
             </div>
             <?= $this->draw('entity/tags/input'); ?>
             <?php echo $this->drawSyndication('bookmark', $vars['object']->getPosseLinks()); ?>
-            <?php if (empty($vars['object']->_id)) { ?><input type="hidden" name="forward-to"
-                                                              value="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'; ?>" /><?php } ?>
+            <?php if (empty($vars['object']->_id)) { 
+                $this->__(['name' => 'forward-to', 'value' => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'])->draw('forms/input/hidden');
+            } ?>
             <?= $this->draw('content/extra'); ?>
             <?= $this->draw('content/access'); ?>
             <p class="button-bar">

--- a/IdnoPlugins/Media/templates/default/entity/Media/edit.tpl.php
+++ b/IdnoPlugins/Media/templates/default/entity/Media/edit.tpl.php
@@ -26,7 +26,13 @@
                 ?>
                 <label>
                     <span class="btn btn-primary btn-file">
-                        <i class="fa fa-play-circle"></i> <span id="media-filename">Upload audio</span> <input type="file" name="media" id="media" class="col-md-9" accept="audio/*;video/*;capture=microphone" onchange="$('#media-filename').html($(this).val())" />
+                        <i class="fa fa-play-circle"></i> <span id="media-filename">Upload audio</span> 
+                        <?= $this->__([
+                                            'name' => 'media', 
+                                            'id' => 'media', 
+                                            'accept' => 'audio/*;video/*;capture=microphone',
+                                            'onchange' => "$('#media-filename').html($(this).val())",
+                                            'class' => 'col-md-9'])->draw('forms/input/file'); ?>
                     </span>
                 </label>
                 <?php
@@ -38,7 +44,12 @@
             <div class="content-form">
                 <label for="title">
                     Title</label>
-                    <input type="text" name="title" id="title" placeholder="Give it a title" value="<?=htmlspecialchars($vars['object']->title)?>" class="form-control" />
+                    <?= $this->__([
+                            'name' => 'title', 
+                            'id' => 'title', 
+                            'placeholder' => 'Give it a title', 
+                            'value' => $vars['object']->title, 
+                            'class' => 'form-control'])->draw('forms/input/input'); ?>
 
             </div>
 

--- a/IdnoPlugins/Photo/templates/default/entity/Photo/edit.tpl.php
+++ b/IdnoPlugins/Photo/templates/default/entity/Photo/edit.tpl.php
@@ -49,12 +49,13 @@
                         <p>
                                 <span class="btn btn-primary btn-file">
                                         <i class="fa fa-camera"></i> <span
-                                        id="photo-filename"><?php if (empty($vars['object']->_id)) { ?>Select a photo<?php } else { ?>Choose different photo<?php } ?></span> <input type="file" name="photo"
-                                                                                         id="photo"
-                                                                                         class="col-md-9 form-control"
-                                                                                         accept="image/*"
-                                                                                         <?php /* capture="camera" */ ?>
-                                                                                         onchange="photoPreview(this)"/>
+                                        id="photo-filename"><?php if (empty($vars['object']->_id)) { ?>Select a photo<?php } else { ?>Choose different photo<?php } ?></span> 
+                                        <?= $this->__([
+                                            'name' => 'photo', 
+                                            'id' => 'photo', 
+                                            'accept' => 'image/*',
+                                            'onchange' => 'photoPreview(this)',
+                                            'class' => 'form-control col-md-9'])->draw('forms/input/file'); ?>
 
                                     </span>
                         </p>
@@ -76,9 +77,12 @@
                     <div class="content-form">
                         <label for="title">
                             Title</label>
-                        <input type="text" name="title" id="title"
-                               value="<?= htmlspecialchars($vars['object']->title) ?>" class="form-control"
-                               placeholder="Give it a title"/>
+                        <?= $this->__([
+                            'name' => 'title', 
+                            'id' => 'title', 
+                            'placeholder' => 'Give it a title', 
+                            'value' => $vars['object']->title, 
+                            'class' => 'form-control'])->draw('forms/input/input'); ?>
                     </div>
 
                     <?= $this->__([
@@ -128,10 +132,14 @@
                 reader.onload = function (e) {
                     $('#photo-preview').html('<img src="" id="photopreview" style="display:none; width: 400px;">');
                     $('#photo-filename').html('Choose different photo');
-                    
-                    var exif = EXIF.readFromBinaryFile(base64ToArrayBuffer(this.result));
-    
-                    exifRotateImg('#photopreview', exif.Orientation, '#photo-preview');
+                 
+                    try {
+                        var exif = EXIF.readFromBinaryFile(base64ToArrayBuffer(this.result));
+
+                        exifRotateImg('#photopreview', exif.Orientation, '#photo-preview');
+                    } catch (error) {
+                        console.error(error);
+                    }
                 
                     $('#photopreview').attr('src', e.target.result);
                     $('#photopreview').show();

--- a/IdnoPlugins/Photo/templates/default/entity/Photo/edit.tpl.php
+++ b/IdnoPlugins/Photo/templates/default/entity/Photo/edit.tpl.php
@@ -109,8 +109,9 @@
                 </div>
                 
                 <?php echo $this->drawSyndication('image', $vars['object']->getPosseLinks()); ?>
-                <?php if (empty($vars['object']->_id)) { ?><input type="hidden" name="forward-to"
-                                                                  value="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'; ?>" /><?php } ?>
+                <?php if (empty($vars['object']->_id)) { 
+                    $this->__(['name' => 'forward-to', 'value' => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'])->draw('forms/input/hidden');
+                } ?>
                 <?= $this->draw('content/extra'); ?>
                 <?= $this->draw('content/access'); ?>
                 <p class="button-bar ">

--- a/IdnoPlugins/Status/templates/default/entity/Status/edit.tpl.php
+++ b/IdnoPlugins/Status/templates/default/entity/Status/edit.tpl.php
@@ -100,7 +100,9 @@
                 ?>
             </div>
 
-            <?php if (empty($vars['object']->_id)) { ?><input type="hidden" name="forward-to" value="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'; ?>" /><?php } ?>
+            <?php if (empty($vars['object']->_id)) { 
+                $this->__(['name' => 'forward-to', 'value' => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'])->draw('forms/input/hidden');
+            } ?>
             <?php echo $this->drawSyndication('note', $vars['object']->getPosseLinks()); ?>
             <?= $this->draw('content/extra'); ?>
             <?= $this->draw('content/access'); ?>

--- a/IdnoPlugins/Status/templates/default/entity/Status/edit.tpl.php
+++ b/IdnoPlugins/Status/templates/default/entity/Status/edit.tpl.php
@@ -35,13 +35,22 @@
                 ?>
             </h4>
 
-            <textarea required name="body" id="body" class="content-entry mentionable form-control ctrl-enter-submit" placeholder="Share a quick note or comment. You can use links and #hashtags."><?php
-
+            <?php 
+                $body = ""; 
                 if (!empty($vars['body'])) {
-                    echo htmlspecialchars($vars['body']);
+                    $body = $vars['body'];
                 } else {
-                    echo htmlspecialchars($vars['object']->body);
-                } ?></textarea>
+                    $body = $vars['object']->body;
+                } ?>
+            <?= $this->__([
+                'unique_id' => 'body',
+                'name' => 'body',
+                'placeholder' => "Share a quick note or comment. You can use links and #hashtags.",
+                'required' => true,
+                'class' => 'content-entry ctrl-enter-submit',
+                'value' => $body,
+                'height' => 140
+            ])->draw('forms/input/longtext'); ?>
             <?php
 
                 echo $this->draw('entity/tags/input');

--- a/IdnoPlugins/Text/templates/default/entity/Entry/edit.tpl.php
+++ b/IdnoPlugins/Text/templates/default/entity/Entry/edit.tpl.php
@@ -48,7 +48,7 @@
 
                 <div class="content-form">
                     <label for="title">Title</label>
-                    <input type="text" name="title" id="title" placeholder="Give it a title" value="<?= htmlspecialchars($title) ?>" class="form-control" required />
+                    <?= $this->__(['name' => 'title', 'placeholder' => 'Give it a title', 'id' => 'title', 'value' => $title, 'required' => true, 'class' => 'form-control'])->draw('forms/input/input'); ?>
                 </div>
 
                 <?= $this->__([
@@ -61,7 +61,9 @@
                 <?= $this->draw('entity/tags/input'); ?>
 
                 <?php echo $this->drawSyndication('article', $vars['object']->getPosseLinks()); ?>
-                <?php if (empty($vars['object']->_id)) { ?><input type="hidden" name="forward-to" value="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'; ?>" /><?php } ?>
+                <?php if (empty($vars['object']->_id)) { 
+                    $this->__(['name' => 'forward-to', 'value' => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'content/all/'])->draw('forms/input/hidden');
+                } ?>
 
                 <?= $this->draw('content/extra'); ?>
                 <?= $this->draw('content/access'); ?>

--- a/templates/default/content/access.tpl.php
+++ b/templates/default/content/access.tpl.php
@@ -68,9 +68,14 @@
     } else {
 
         ?>
-        <input type="hidden" name="access" id="access-control-id" value="<?= htmlspecialchars($access); ?>"/>
+        <input type="hidden" name="access" id="access-control-id-<?= $id_code; ?>" value="<?= htmlspecialchars($access); ?>"/>
         <?php
 
     }
 
+    /** Document the control for the api */
+    $this->documentFormControl('access', [
+        'id' => 'access-control-id-' .$id_code,
+        'description' => 'Access control',
+    ]);
 ?>

--- a/templates/default/content/syndication/account.tpl.php
+++ b/templates/default/content/syndication/account.tpl.php
@@ -21,4 +21,12 @@
         </span>
     <?php
 
+        $this->documentFormControl("syndication[]", [
+            'type' => 'checkbox',
+            'disabled' => !empty($vars['disabled']),
+            'id' => "syndication_{$vars['service']}_{$identifier}_toggle",
+            'service' => $vars['service'],
+            'username' => htmlentities($vars['username']),   
+            'checked' => $vars['selected'] == true
+        ]);
     }

--- a/templates/default/forms/input/datetime-local.tpl.php
+++ b/templates/default/forms/input/datetime-local.tpl.php
@@ -1,0 +1,6 @@
+<?php
+
+	if (!$vars['class']) $vars['class'] = "input-datetime-local";
+	$vars['type'] = 'datetime-local';
+	echo $this->__($vars)->draw('forms/input/input');
+ 

--- a/templates/default/forms/input/file.tpl.php
+++ b/templates/default/forms/input/file.tpl.php
@@ -1,0 +1,6 @@
+<?php
+
+	if (!$vars['class']) $vars['class'] = "input-file";
+	$vars['type'] = 'file';
+	echo $this->__($vars)->draw('forms/input/input');
+ 

--- a/templates/default/forms/input/hidden.tpl.php
+++ b/templates/default/forms/input/hidden.tpl.php
@@ -1,0 +1,5 @@
+<?php
+
+	$vars['type'] = 'hidden';
+	echo $this->__($vars)->draw('forms/input/input');
+ 

--- a/templates/default/forms/input/input.tpl.php
+++ b/templates/default/forms/input/input.tpl.php
@@ -34,19 +34,28 @@ if (!isset($vars['id'])) {
 ?>
 <input
 <?php
+
+$published = [];
+
 foreach ($fields_and_defaults as $field => $default) {
     if (isset($vars[$field])) {
-        if ($vars[$field] === true)
+        if ($vars[$field] === true) {
             echo "$field ";
-        else
-            echo "$field=\"{$vars[$field]}\" ";
+            $published[$field] = true;
+        } else {
+            echo "$field=\"{$vars[$field]}\" "; 
+            $published[$field] = $vars[$field];
+        }
     }
     else {
         if ($default !== false) {
-            if ($default === true)
+            if ($default === true) {
                 echo "$field ";
-            else
+                $published[$field] = true;
+            } else {
                 echo "$field=\"$default\" ";
+                $published[$field] = $default;
+            }
         }
     }
 }
@@ -56,3 +65,14 @@ foreach ($fields_and_defaults as $field => $default) {
 <?php if (isset($vars['alt'])) { ?>alt="<?php echo htmlentities($vars['alt'], ENT_QUOTES, 'UTF-8'); ?>" <?php } // Alt is a special case ?>
     value="<?php echo htmlentities($vars['value'], ENT_QUOTES, 'UTF-8'); ?>"
     /> 
+<?php
+// Ensure this is documented in the api get
+if (!empty($published['alt'])) {
+    $published['description'] = $published['alt'];
+    unset($published['alt']); unset($published['placeholder']);
+} else if (!empty($published['placeholder'])) {
+    $published['description'] = $published['placeholder'];
+    unset($published['alt']); unset($published['placeholder']);
+}
+$this->documentFormControl($vars['name'], $published);
+?>

--- a/templates/default/forms/input/input.tpl.php
+++ b/templates/default/forms/input/input.tpl.php
@@ -24,6 +24,7 @@ $fields_and_defaults = array(
     'onclick' => false,
     'onfocus' => false,
     'onblur' => false,
+    'onchange' => false,
 );
 
 // We always want a unique ID

--- a/templates/default/forms/input/input.tpl.php
+++ b/templates/default/forms/input/input.tpl.php
@@ -38,6 +38,10 @@ if (!isset($vars['id'])) {
 <?php
 
 $published = [];
+if (isset($vars['placeholder']))
+    $published['placeholder'] = $vars['placeholder'];
+if (isset($vars['alt']))
+    $published['alt'] = $vars['alt'];
 
 foreach ($fields_and_defaults as $field => $default) {
     if (isset($vars[$field])) {

--- a/templates/default/forms/input/input.tpl.php
+++ b/templates/default/forms/input/input.tpl.php
@@ -64,7 +64,7 @@ foreach ($fields_and_defaults as $field => $default) {
     class="input <?php echo isset($vars['class']) ? $vars['class'] : 'input-' . (isset($vars['type']) ? $vars['type'] : 'text'); ?>"
 <?php if (isset($vars['placeholder'])) { ?>placeholder="<?php echo htmlentities($vars['placeholder'], ENT_QUOTES, 'UTF-8'); ?>" <?php } // Placeholder is a special case ?>
 <?php if (isset($vars['alt'])) { ?>alt="<?php echo htmlentities($vars['alt'], ENT_QUOTES, 'UTF-8'); ?>" <?php } // Alt is a special case ?>
-    value="<?php echo htmlentities($vars['value'], ENT_QUOTES, 'UTF-8'); ?>"
+    value="<?php if (isset($vars['value'])) echo htmlentities($vars['value'], ENT_QUOTES, 'UTF-8'); ?>"
     /> 
 <?php
 // Ensure this is documented in the api get

--- a/templates/default/forms/input/input.tpl.php
+++ b/templates/default/forms/input/input.tpl.php
@@ -6,6 +6,7 @@ $fields_and_defaults = array(
     'id' => false,
     'autocomplete' => false,
     'autofocus' => false,
+    'accept' => false,
     'checked' => false,
     'disabled' => false,
     'min' => false,

--- a/templates/default/forms/input/input.tpl.php
+++ b/templates/default/forms/input/input.tpl.php
@@ -75,10 +75,10 @@ if (!empty($published['alt'])) {
     unset($published['alt']); unset($published['placeholder']);
 }
 
-// Prevent bonita polution
-foreach ($fields_and_defaults as $field) 
-    unset($this->vars[$field]);
-
 // Document form
 $this->documentFormControl($vars['name'], $published);
+
+// Prevent bonita polution
+foreach (array_merge($fields_and_defaults, ['placeholder' => false, 'value' => '']) as $field => $default) 
+    unset($this->vars[$field]);
 ?>

--- a/templates/default/forms/input/input.tpl.php
+++ b/templates/default/forms/input/input.tpl.php
@@ -74,5 +74,11 @@ if (!empty($published['alt'])) {
     $published['description'] = $published['placeholder'];
     unset($published['alt']); unset($published['placeholder']);
 }
+
+// Prevent bonita polution
+foreach ($fields_and_defaults as $field) 
+    unset($this->vars[$field]);
+
+// Document form
 $this->documentFormControl($vars['name'], $published);
 ?>

--- a/templates/default/forms/input/longtext.tpl.php
+++ b/templates/default/forms/input/longtext.tpl.php
@@ -34,4 +34,17 @@
 <br class="clearall">
 <textarea name="<?=$vars['name']?>"  placeholder="<?=htmlspecialchars($placeholder);?>" style="height:<?=$height?>px"
           class="bodyInput mentionable form-control <?=$class?>" id="<?=$unique_id?>" <?= $required; ?>><?= (htmlspecialchars($value)) ?></textarea>
+<?php
 
+// Prevent bonita leakage
+foreach (['unique_id', 'class', 'height', 'placeholder', 'value', 'required'] as $var)
+    unset($this->vars[$var]);
+
+// Expose this control to the api
+$this->documentFormControl($name, [
+    'type' => 'longtext',
+    'id' => $unique_id,
+    'required' => !empty($required),
+    'description' => $placeholder
+]);
+?>

--- a/templates/default/forms/input/longtext.tpl.php
+++ b/templates/default/forms/input/longtext.tpl.php
@@ -36,10 +36,6 @@
           class="bodyInput mentionable form-control <?=$class?>" id="<?=$unique_id?>" <?= $required; ?>><?= (htmlspecialchars($value)) ?></textarea>
 <?php
 
-// Prevent bonita leakage
-foreach (['unique_id', 'class', 'height', 'placeholder', 'value', 'required'] as $var)
-    unset($this->vars[$var]);
-
 // Expose this control to the api
 $this->documentFormControl($name, [
     'type' => 'longtext',
@@ -47,4 +43,10 @@ $this->documentFormControl($name, [
     'required' => !empty($required),
     'description' => $placeholder
 ]);
+
+
+// Prevent bonita leakage
+foreach (['unique_id', 'class', 'height', 'placeholder', 'value', 'required', 'name', 'value'] as $var)
+    unset($this->vars[$var]);
+
 ?>

--- a/templates/default/forms/input/richtext.tpl.php
+++ b/templates/default/forms/input/richtext.tpl.php
@@ -65,6 +65,7 @@
     }
 
 ?>
+    
 
 <script>
 
@@ -150,3 +151,16 @@
 
     }
 </script>
+<?php
+// Prevent bonita leakage
+foreach (['unique_id', 'class', 'height', 'placeholder', 'value', 'required'] as $var)
+    unset($this->vars[$var]);
+
+// Expose this control to the api
+$this->documentFormControl($name, [
+    'type' => 'richtext',
+    'id' => $unique_id,
+    'required' => !empty($vars['required']),
+    'description' => $placeholder
+]);
+?>

--- a/templates/default/forms/input/richtext.tpl.php
+++ b/templates/default/forms/input/richtext.tpl.php
@@ -152,9 +152,6 @@
     }
 </script>
 <?php
-// Prevent bonita leakage
-foreach (['unique_id', 'class', 'height', 'placeholder', 'value', 'required'] as $var)
-    unset($this->vars[$var]);
 
 // Expose this control to the api
 $this->documentFormControl($name, [
@@ -163,4 +160,8 @@ $this->documentFormControl($name, [
     'required' => !empty($vars['required']),
     'description' => $placeholder
 ]);
+
+// Prevent bonita leakage
+foreach (['unique_id', 'class', 'height', 'placeholder', 'value', 'required', 'wordcount', 'name', 'value'] as $var)
+    unset($this->vars[$var]);
 ?>

--- a/templates/default/forms/input/select.tpl.php
+++ b/templates/default/forms/input/select.tpl.php
@@ -1,0 +1,95 @@
+<?php
+// Define possible fields and their defaults, a boolean FALSE means don't show if not present
+$fields_and_defaults = array(
+    'name' => false,
+    'id' => false,
+    'autocomplete' => false,
+    'autofocus' => false,
+    'accept' => false,
+    'checked' => false,
+    'disabled' => false,
+    'min' => false,
+    'max' => false,
+    'step' => false,
+    'maxlength' => false,
+    'multiple' => false,
+    'pattern' => false,
+    'readonly' => false,
+    'required' => false,
+    'src' => false,
+    'spellcheck' => false,
+    //'placeholder' => false,
+    'accept' => false,
+    'onclick' => false,
+    'onfocus' => false,
+    'onblur' => false,
+    'onchange' => false,
+);
+
+// We always want a unique ID
+global $input_id;
+if (!isset($vars['id'])) {
+    $input_id ++;
+    $vars['id'] = $vars['name'] . "_$input_id";
+}
+?>
+<select
+<?php
+
+$published = [
+    'type' => 'select'
+];
+if (isset($vars['placeholder']))
+    $published['placeholder'] = $vars['placeholder'];
+if (isset($vars['alt']))
+    $published['alt'] = $vars['alt'];
+if (isset($vars['description']))
+    $published['description'] = $vars['description'];
+
+foreach ($fields_and_defaults as $field => $default) {
+    if (isset($vars[$field])) {
+        if ($vars[$field] === true) {
+            echo "$field ";
+            $published[$field] = true;
+        } else {
+            echo "$field=\"{$vars[$field]}\" "; 
+            $published[$field] = $vars[$field];
+        }
+    }
+    else {
+        if ($default !== false) {
+            if ($default === true) {
+                echo "$field ";
+                $published[$field] = true;
+            } else {
+                echo "$field=\"$default\" ";
+                $published[$field] = $default;
+            }
+        }
+    }
+}
+?>
+    class="input <?php echo isset($vars['class']) ? $vars['class'] : 'input-select'; ?>"
+    value="<?php if (isset($vars['value'])) echo htmlentities($vars['value'], ENT_QUOTES, 'UTF-8'); ?>"> 
+    <?php 
+    foreach ($vars['options'] as $option => $label) {
+        ?>
+    <option value="<?= $option; ?>" <?php if ($value == $option) echo 'selected' ?>><?= htmlentities($label, ENT_QUOTES, 'UTF-8'); ?></option>
+    <?php
+    }
+    ?>
+</select>    
+<?php
+// Ensure this is documented in the api get
+if (!empty($published['placeholder'])) {
+    $published['description'] = $published['placeholder'];
+    unset($published['alt']); unset($published['placeholder']);
+}
+
+// Document form
+$this->documentFormControl($vars['name'], $published);
+
+// Prevent bonita polution
+foreach (array_merge($fields_and_defaults, ['placeholder' => false, 'value' => '', 'options' => '']) as $field => $default) 
+    unset($this->vars[$field]);
+?>


### PR DESCRIPTION
## Here's what I fixed or added:

* Added a form control documentation method (documentFormControl()) to Template
* Extended standard form controls to automatically document themselves
* Extended bundled thingies to use form controls
* Introduced a couple of new form control templates
* Extended form controls to clear up their own variables to prevent ongoing polution (benwerd/bonita#2)
* Fixed a few other bugs I found along the way

## Here's why I did it:

Now possible to make an API get call to establish what form fields are available, and what values the endpoint is expecting.

