### PR TITLE
More language

### DIFF
--- a/Idno/Common/Component.php
+++ b/Idno/Common/Component.php
@@ -51,6 +51,13 @@
             function registerPages()
             {
             }
+            
+            /**
+             * Register any translation strings or language files for the current language.
+             */
+            function registerTranslations() 
+            {   
+            }
 
             /**
              * Helper function that gets the full class name of this entity

--- a/Idno/Common/Component.php
+++ b/Idno/Common/Component.php
@@ -17,6 +17,7 @@
                 $this->init();
                 $this->registerEventHooks();
                 $this->registerPages();
+                $this->registerTranslations();
             }
 
             /**

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -410,8 +410,7 @@
              * Return the language handler associated with this site
              * @return \Idno\Core\Language
              */
-
-            function language()
+            function &language()
             {
                 if (empty($this->language)) {
                     $this->language = new Language();

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -54,6 +54,15 @@
 
                 return false;
             }
+            
+            /**
+             * Simplify adding translation strings.
+             * @param array $strings Associated array of "string" => "translation"
+             */
+            function addTranslations(array $strings) {
+                foreach ($strings as $string => $translation)
+                    $this->add($string, $translation);
+            }
 
             /**
              * Shortcut for getTranslation.

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -84,6 +84,20 @@ namespace Idno\Core {
             foreach ($strings as $string => $translation)
                 $this->add($string, $translation);
         }
+        
+        /**
+         * Load translations from a .ini formatted string=translation file.
+         * @param type $filename
+         */
+        function load($filename) {
+            if (!file_exists($filename))
+                throw new \RuntimeException("Language file '$filename' could not be found");
+            
+            $language = parse_ini_file($filename);
+            
+            return $this->addTranslations($language);
+            
+        }
 
         /**
          * Shortcut for getTranslation.

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -93,10 +93,9 @@ namespace Idno\Core {
             if (!file_exists($filename))
                 throw new \RuntimeException("Language file '$filename' could not be found");
             
-            $language = parse_ini_file($filename);
+            $language = @parse_ini_file($filename);
             
             return $this->addTranslations($language);
-            
         }
 
         /**

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -95,6 +95,18 @@ namespace Idno\Core {
         }
         
         /**
+         * Register a translation.
+         * Register translation strings. It is safe to provide Translation objects for multiple languages, only translations for
+         * $this->getLanguage() will be loaded.
+         * @param \Idno\Core\Translation $translation
+         */
+        public function register(Translation $translation) {
+            if ($translation->getLanguage() == $this->getLanguage()) {
+                $this->addTranslations($translation->getStrings());
+            }
+        }
+        
+        /**
          * Shortcut for getTranslation.
          * @param $string
          * @param bool|true $failover

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -95,19 +95,6 @@ namespace Idno\Core {
         }
         
         /**
-         * Load translations from a .ini formatted string=translation file.
-         * @param type $filename
-         */
-        function load($filename) {
-            if (!file_exists($filename))
-                throw new \RuntimeException("Language file '$filename' could not be found");
-            
-            $language = @parse_ini_file($filename);
-            
-            return $this->addTranslations($language);
-        }
-
-        /**
          * Shortcut for getTranslation.
          * @param $string
          * @param bool|true $failover

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -51,6 +51,15 @@ namespace Idno\Core {
         }
 
         /**
+         * Alias for $this->write();
+         * @param string $string String to translate
+         * @param array $subs Substitutions in the
+         */
+        function _($string, array $subs = []) {
+            return $this->write($string, $subs);
+        }
+        
+        /**
          * Shortcut for addTranslation
          * @param $string
          * @param $translation
@@ -182,9 +191,11 @@ namespace Idno\Core {
         }
 
         /**
-         * Detect current language from browser string
+         * Detect current language from browser string.
+         * 
+         * TODO: Put more logic here, with better fallbacks.
          */
-        public static function detectBrowserLanguage() {
+        public static function detectBrowserLanguage() { 
             return substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
         }
 

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -90,8 +90,7 @@ namespace Idno\Core {
          * @param array $strings Associated array of "string" => "translation"
          */
         function addTranslations(array $strings) {
-            foreach ($strings as $string => $translation)
-                $this->add($string, $translation);
+            $this->strings = array_merge($this->strings, $strings);
         }
         
         /**

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -7,7 +7,25 @@
         class Language extends Component
         {
 
-            public $strings = [];
+            private $strings = [];
+            private $language;
+            
+            /**
+             * Construct a language object
+             * @param type $language
+             */
+            public function __construct($language = null) {
+                
+                if (empty($language))
+                    $language = self::detectBrowserLanguage ();
+                
+                if (empty($language))
+                    $language = 'en';
+                
+                $this->language = strtolower($language);
+                
+                parent::__construct();
+            }
 
             /**
              * Shortcut for addTranslation
@@ -66,6 +84,13 @@
 
                 return false;
             }
+            
+            /**
+             * Return the current language code for this object.
+             */
+            public function getLanguage() {
+                return $this->language;
+            }
 
             /**
              * Replace curly quotes with uncurly quotes
@@ -107,6 +132,12 @@
                 return $string;
             }
 
+            /**
+             * Detect current language from browser string
+             */
+            public static function detectBrowserLanguage() {
+                return substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+            }
         }
 
     }

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -194,7 +194,8 @@ namespace Idno\Core {
          * TODO: Put more logic here, with better fallbacks.
          */
         public static function detectBrowserLanguage() { 
-            return substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+            if (!empty($_SERVER['HTTP_ACCEPT_LANGUAGE']))
+                return substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
         }
 
     }

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -1,152 +1,170 @@
 <?php
 
-    namespace Idno\Core {
+namespace Idno\Core {
 
-        use Idno\Common\Component;
+    use Idno\Common\Component;
 
-        class Language extends Component
-        {
+    class Language extends Component {
 
-            private $strings = [];
-            private $language;
-            
-            /**
-             * Construct a language object
-             * @param type $language
-             */
-            public function __construct($language = null) {
-                
-                if (empty($language))
-                    $language = self::detectBrowserLanguage ();
-                
-                if (empty($language))
-                    $language = 'en';
-                
-                $this->language = strtolower($language);
-                
-                parent::__construct();
-            }
+        private $strings = [];
+        private $language;
 
-            /**
-             * Shortcut for addTranslation
-             * @param $string
-             * @param $translation
-             * @return bool
-             */
-            function add($string, $translation)
-            {
-                return $this->addTranslation($string, $translation);
-            }
+        /**
+         * Construct a language object
+         * @param type $language
+         */
+        public function __construct($language = null) {
 
-            /**
-             * Adds a translation to this language's corpus
-             * @param $string
-             * @param $translation
-             * @return bool
-             */
-            function addTranslation($string, $translation)
-            {
-                if (!empty($string) && is_string($string)) {
-                    $this->strings[$string] = $translation;
+            if (empty($language))
+                $language = self::detectBrowserLanguage();
 
-                    return true;
-                }
+            if (empty($language))
+                $language = 'en';
 
-                return false;
-            }
-            
-            /**
-             * Simplify adding translation strings.
-             * @param array $strings Associated array of "string" => "translation"
-             */
-            function addTranslations(array $strings) {
-                foreach ($strings as $string => $translation)
-                    $this->add($string, $translation);
-            }
+            $this->language = strtolower($language);
 
-            /**
-             * Shortcut for getTranslation.
-             * @param $string
-             * @param bool|true $failover
-             * @return bool|string
-             */
-            function get($string, $failover = true)
-            {
-                return $this->getTranslation($string, $failover);
-            }
+            parent::__construct();
+        }
 
-            /**
-             * Retrieves a translation for a given string. If $failover is true (as set by default), the function will
-             * return the original string if no translation exists. Otherwise it will return false.
-             * @param $string
-             * @param bool|true $failover
-             * @return string|bool
-             */
-            function getTranslation($string, $failover = true)
-            {
-                if (!empty($this->strings[$string])) {
-                    return $this->strings[$string];
-                }
-                if ($failover) {
-                    return $string;
-                }
-
-                return false;
-            }
-            
-            /**
-             * Return the current language code for this object.
-             */
-            public function getLanguage() {
-                return $this->language;
-            }
-
-            /**
-             * Replace curly quotes with uncurly quotes
-             * @param $string
-             * @return mixed
-             */
-            function uncurlQuotes($string)
-            {
-                $chr_map = array(
-                    // Windows codepage 1252
-                    "\xC2\x82"     => "'", // U+0082⇒U+201A single low-9 quotation mark
-                    "\xC2\x84"     => '"', // U+0084⇒U+201E double low-9 quotation mark
-                    "\xC2\x8B"     => "'", // U+008B⇒U+2039 single left-pointing angle quotation mark
-                    "\xC2\x91"     => "'", // U+0091⇒U+2018 left single quotation mark
-                    "\xC2\x92"     => "'", // U+0092⇒U+2019 right single quotation mark
-                    "\xC2\x93"     => '"', // U+0093⇒U+201C left double quotation mark
-                    "\xC2\x94"     => '"', // U+0094⇒U+201D right double quotation mark
-                    "\xC2\x9B"     => "'", // U+009B⇒U+203A single right-pointing angle quotation mark
-
-                    // Regular Unicode     // U+0022 quotation mark (")
-                    // U+0027 apostrophe     (')
-                    "\xC2\xAB"     => '"', // U+00AB left-pointing double angle quotation mark
-                    "\xC2\xBB"     => '"', // U+00BB right-pointing double angle quotation mark
-                    "\xE2\x80\x98" => "'", // U+2018 left single quotation mark
-                    "\xE2\x80\x99" => "'", // U+2019 right single quotation mark
-                    "\xE2\x80\x9A" => "'", // U+201A single low-9 quotation mark
-                    "\xE2\x80\x9B" => "'", // U+201B single high-reversed-9 quotation mark
-                    "\xE2\x80\x9C" => '"', // U+201C left double quotation mark
-                    "\xE2\x80\x9D" => '"', // U+201D right double quotation mark
-                    "\xE2\x80\x9E" => '"', // U+201E double low-9 quotation mark
-                    "\xE2\x80\x9F" => '"', // U+201F double high-reversed-9 quotation mark
-                    "\xE2\x80\xB9" => "'", // U+2039 single left-pointing angle quotation mark
-                    "\xE2\x80\xBA" => "'", // U+203A single right-pointing angle quotation mark
-                );
-                $chr     = array_keys($chr_map); // but: for efficiency you should
-                $rpl     = array_values($chr_map); // pre-calculate these two arrays
-                $string  = str_replace($chr, $rpl, html_entity_decode($string, ENT_QUOTES, "UTF-8"));
-
-                return $string;
-            }
-
-            /**
-             * Detect current language from browser string
-             */
-            public static function detectBrowserLanguage() {
-                return substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+        /**
+         * Magic method to set language variables
+         */
+        function __set($string, $translation) {
+            if (!empty($string)) {
+                $this->add($string, $translation);
             }
         }
 
+        /**
+         * Magic method to get stored language variable
+         */
+        function __get($string) {
+            return $this->get($string);
+        }
+
+        /**
+         * Chainable function to allow variables to be added as an array.
+         * @param $vars array Associated array of "string" => "translation"
+         */
+        function __($strings) {
+            $this->addTranslations($strings);
+        }
+
+        /**
+         * Shortcut for addTranslation
+         * @param $string
+         * @param $translation
+         * @return bool
+         */
+        function add($string, $translation) {
+            return $this->addTranslation($string, $translation);
+        }
+
+        /**
+         * Adds a translation to this language's corpus
+         * @param $string
+         * @param $translation
+         * @return bool
+         */
+        function addTranslation($string, $translation) {
+            if (!empty($string) && is_string($string)) {
+                $this->strings[$string] = $translation;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /**
+         * Simplify adding translation strings.
+         * @param array $strings Associated array of "string" => "translation"
+         */
+        function addTranslations(array $strings) {
+            foreach ($strings as $string => $translation)
+                $this->add($string, $translation);
+        }
+
+        /**
+         * Shortcut for getTranslation.
+         * @param $string
+         * @param bool|true $failover
+         * @return bool|string
+         */
+        function get($string, $failover = true) {
+            return $this->getTranslation($string, $failover);
+        }
+
+        /**
+         * Retrieves a translation for a given string. If $failover is true (as set by default), the function will
+         * return the original string if no translation exists. Otherwise it will return false.
+         * @param $string
+         * @param bool|true $failover
+         * @return string|bool
+         */
+        function getTranslation($string, $failover = true) {
+            if (!empty($this->strings[$string])) {
+                return $this->strings[$string];
+            }
+            if ($failover) {
+                return $string;
+            }
+
+            return false;
+        }
+
+        /**
+         * Return the current language code for this object.
+         */
+        public function getLanguage() {
+            return $this->language;
+        }
+
+        /**
+         * Replace curly quotes with uncurly quotes
+         * @param $string
+         * @return mixed
+         */
+        function uncurlQuotes($string) {
+            $chr_map = array(
+                // Windows codepage 1252
+                "\xC2\x82" => "'", // U+0082⇒U+201A single low-9 quotation mark
+                "\xC2\x84" => '"', // U+0084⇒U+201E double low-9 quotation mark
+                "\xC2\x8B" => "'", // U+008B⇒U+2039 single left-pointing angle quotation mark
+                "\xC2\x91" => "'", // U+0091⇒U+2018 left single quotation mark
+                "\xC2\x92" => "'", // U+0092⇒U+2019 right single quotation mark
+                "\xC2\x93" => '"', // U+0093⇒U+201C left double quotation mark
+                "\xC2\x94" => '"', // U+0094⇒U+201D right double quotation mark
+                "\xC2\x9B" => "'", // U+009B⇒U+203A single right-pointing angle quotation mark
+                // Regular Unicode     // U+0022 quotation mark (")
+                // U+0027 apostrophe     (')
+                "\xC2\xAB" => '"', // U+00AB left-pointing double angle quotation mark
+                "\xC2\xBB" => '"', // U+00BB right-pointing double angle quotation mark
+                "\xE2\x80\x98" => "'", // U+2018 left single quotation mark
+                "\xE2\x80\x99" => "'", // U+2019 right single quotation mark
+                "\xE2\x80\x9A" => "'", // U+201A single low-9 quotation mark
+                "\xE2\x80\x9B" => "'", // U+201B single high-reversed-9 quotation mark
+                "\xE2\x80\x9C" => '"', // U+201C left double quotation mark
+                "\xE2\x80\x9D" => '"', // U+201D right double quotation mark
+                "\xE2\x80\x9E" => '"', // U+201E double low-9 quotation mark
+                "\xE2\x80\x9F" => '"', // U+201F double high-reversed-9 quotation mark
+                "\xE2\x80\xB9" => "'", // U+2039 single left-pointing angle quotation mark
+                "\xE2\x80\xBA" => "'", // U+203A single right-pointing angle quotation mark
+            );
+            $chr = array_keys($chr_map); // but: for efficiency you should
+            $rpl = array_values($chr_map); // pre-calculate these two arrays
+            $string = str_replace($chr, $rpl, html_entity_decode($string, ENT_QUOTES, "UTF-8"));
+
+            return $string;
+        }
+
+        /**
+         * Detect current language from browser string
+         */
+        public static function detectBrowserLanguage() {
+            return substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+        }
+
     }
+
+}

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -119,6 +119,16 @@ namespace Idno\Core {
         public function getLanguage() {
             return $this->language;
         }
+        
+        /**
+         * Return a translated string, substituting variables in subs in the format of sprintf.
+         * @param type $string String to translate
+         * @param array $subs List of substitution variables to be used in the translated string
+         * @return string
+         */
+        public function write($string, array $subs = []) {
+            return sprintf($this->get($string), $subs);
+        }
 
         /**
          * Replace curly quotes with uncurly quotes

--- a/Idno/Core/Translation.php
+++ b/Idno/Core/Translation.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace Idno\Core {
+    
+    use Idno\Common\Component;
+    
+    /**
+     * Register translation strings for a specific language.
+     */
+    abstract class Translation 
+        extends Component 
+    {
+        
+        /**
+         * Language this translation is for.
+         * @var type 
+         */
+        protected $language;
+        
+        /**
+         * Create this translation, for the defined language.
+         * @param type $language Which language is this for? Default 'en'
+         */
+        public function __construct($language = 'en') {
+            $this->language = $language;
+        }
+        
+        public function getLanguage() {
+            return $this->language;
+        }
+        
+        /**
+         * @return array An associative array of "string" => "translation"
+         */
+        abstract public function getStrings();
+        
+    }
+    
+}

--- a/Tests/Core/LanguageTest.php
+++ b/Tests/Core/LanguageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Core {
+
+    class EnglishTest extends \Idno\Core\Translation {
+
+        public function getStrings() {
+            return [
+                'Hello!' => 'Hello!'
+            ];
+        }
+
+    }
+
+    class FrenchTest extends \Idno\Core\Translation {
+
+        public function getStrings() {
+            return [
+                'Hello!' => 'Bonjour!'
+            ];
+        }
+
+    }
+
+    class LanguageTest extends \Tests\KnownTestCase {
+
+        public function testLanguageString() {
+
+            $english = new \Idno\Core\Language('en');
+            $french = new \Idno\Core\Language('fr');
+            
+            $english->register(new EnglishTest('en'));
+            $english->register(new FrenchTest('fr'));
+            
+            $french->register(new EnglishTest('en'));
+            $french->register(new FrenchTest('fr'));
+            
+            
+            echo "English: " . $english->_('Hello!');
+            echo "\nFrench: " . $french->_('Hello!');
+            
+            $this->assertFalse(empty($english->_('Hello!')));
+            $this->assertFalse(empty($french->_('Hello!')));
+            $this->assertFalse($french->_('Hello!') == $english->_('Hello!'));
+        }
+
+    }
+
+}

--- a/Tests/Core/LanguageTest.php
+++ b/Tests/Core/LanguageTest.php
@@ -39,8 +39,10 @@ namespace Tests\Core {
             echo "English: " . $english->_('Hello!');
             echo "\nFrench: " . $french->_('Hello!');
             
-            $this->assertFalse(empty($english->_('Hello!')));
-            $this->assertFalse(empty($french->_('Hello!')));
+            $txt = $english->_('Hello!');
+            $this->assertFalse(empty($txt));
+            $txt2 = $french->_('Hello!');
+            $this->assertFalse(empty($txt2));
             $this->assertFalse($french->_('Hello!') == $english->_('Hello!'));
         }
 

--- a/docs/developers/languages/index.md
+++ b/docs/developers/languages/index.md
@@ -1,0 +1,31 @@
+# Translating Known
+
+Known has a mechanism for translating strings used into other languages. When Known boots, 
+it creates a new Language() object on the Idno object for the current language, which is addressable 
+by ```\Idno\Core\Idno::site()->language();```.
+
+Your code/plugin can add strings to this object for later use, usually by registering them on the ```registerTranslations()``` 
+method hook.
+
+## Adding a translation for a language
+
+It is possible to add single strings, one by one, for the current language, however the easiest way to register multiple strings is to extend ```Idno/Core/Translation``` for each language you want to translate, and then implement it's ```getStrings()``` method.
+
+It is then possible to add them all at once for each language (this way, Known will automatically select the appropriate translation for the loaded language).
+
+E.g.
+
+```
+\Idno\Core\Idno::site()->language()->register(new \IdnoPlugins\Example\Languages\English('en'));
+\Idno\Core\Idno::site()->language()->register(new \IdnoPlugins\Example\Languages\French('fr'));
+```
+
+## Using a translation
+
+Once a string has been registered, it is possible to echo the string, and have it translated:
+
+E.g.
+
+```
+echo \Idno\Core\Idno::site()->language()->write('This is the string to translate');
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ pages:
 - ['developers/templating/index.md', 'Known for developers', 'Templating']
 - ['developers/templating/extending.md', 'Known for developers', 'Extending templates']
 - ['developers/themes/index.md', 'Known for developers', 'Themes']
+- ['developers/languages/index.md', 'Known for developers', 'Translating Known']
 - ['community/index.md', 'Open Source community', 'Introduction']
 - ['community/contributors.md', 'Open Source community', 'Contributors']
 - ['community/harassment.md', 'Open Source community', 'Anti-harassment policy']


### PR DESCRIPTION
## Here's what I fixed or added:

Added a few things I saw as missing from the initial Language() mechanism as written by @benwerd 

* Added some candy to make it easier to load one or more translations
* Detect and set the current language based on passed parameter, or from browser string
* Added an actual way to get translation string, with parameters, suitable for echo (as it was you could only translate static strings, this now allows sprintf substitution)

## Here's why I did it:

The initial take on this looked somewhat incomplete, however I don't know what Ben had in mind with this

Closes #1871 