### PR TITLE
Unfurl encoding

### DIFF
--- a/Idno/Entities/UnfurledUrl.php
+++ b/Idno/Entities/UnfurledUrl.php
@@ -71,8 +71,6 @@ namespace Idno\Entities {
             foreach (['title'] as $basic) {
                 if (preg_match("#<$basic>(.*?)</$basic>#siu", $content, $matches))
                     $ogp[$basic] = trim($matches[1], " \n");
-//                $items = $doc->getElementsByTagName($basic);
-//                $ogp[$basic] = $items->item(0)->nodeValue;
             }
             $metas = $doc->getElementsByTagName('meta');
             if (!empty($metas)) {

--- a/Idno/Entities/UnfurledUrl.php
+++ b/Idno/Entities/UnfurledUrl.php
@@ -12,6 +12,10 @@ namespace Idno\Entities {
          */
         private static function parseHeaders($content) {
             $doc = new \DOMDocument();
+            
+            if (strpos($content, 'xml encoding=')===false)
+                $content = '<?xml encoding="utf-8" ?>' . $content;
+                    
             @$doc->loadHTML($content);
 
             $interested_in = ['og', 'fb', 'twitter']; // Open graph namespaces we're interested in (open graph + extensions)
@@ -67,6 +71,8 @@ namespace Idno\Entities {
             foreach (['title'] as $basic) {
                 if (preg_match("#<$basic>(.*?)</$basic>#siu", $content, $matches))
                     $ogp[$basic] = trim($matches[1], " \n");
+//                $items = $doc->getElementsByTagName($basic);
+//                $ogp[$basic] = $items->item(0)->nodeValue;
             }
             $metas = $doc->getElementsByTagName('meta');
             if (!empty($metas)) {

--- a/templates/default/entity/UnfurledUrl.tpl.php
+++ b/templates/default/entity/UnfurledUrl.tpl.php
@@ -29,8 +29,8 @@ if (!empty($object->data['og']['og:image']))
         <?php if (!empty($image)) { ?>
             <div class="image"><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><img src="<?= $this->getProxiedImageUrl(htmlentities($image)); ?>"/></a></div>
         <?php } ?>
-        <h3><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlentities(utf8_decode($title), ENT_QUOTES, 'UTF-8'); ?></a></h3>
-        <?php if (!empty($description)) { ?><blockquote class="description"><?= htmlentities(utf8_decode($description), ENT_QUOTES, 'UTF-8'); ?></blockquote><?php } ?>
+        <h3><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlentities($title, ENT_QUOTES, 'UTF-8'); ?></a></h3>
+        <?php if (!empty($description)) { ?><blockquote class="description"><?= htmlentities($description, ENT_QUOTES, 'UTF-8'); ?></blockquote><?php } ?>
 
         <!--<div class="byline"><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlentities(parse_url($object->source_url, PHP_URL_HOST), ENT_QUOTES, 'UTF-8'); ?></a></div>-->
     

--- a/templates/default/entity/UnfurledUrl.tpl.php
+++ b/templates/default/entity/UnfurledUrl.tpl.php
@@ -29,8 +29,8 @@ if (!empty($object->data['og']['og:image']))
         <?php if (!empty($image)) { ?>
             <div class="image"><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><img src="<?= $this->getProxiedImageUrl(htmlentities($image)); ?>"/></a></div>
         <?php } ?>
-        <h3><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlentities($title, ENT_QUOTES, 'UTF-8'); ?></a></h3>
-        <?php if (!empty($description)) { ?><blockquote class="description"><?= htmlentities($description, ENT_QUOTES, 'UTF-8'); ?></blockquote><?php } ?>
+        <h3><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlentities(utf8_decode($title), ENT_QUOTES, 'UTF-8'); ?></a></h3>
+        <?php if (!empty($description)) { ?><blockquote class="description"><?= htmlentities(utf8_decode($description), ENT_QUOTES, 'UTF-8'); ?></blockquote><?php } ?>
 
         <!--<div class="byline"><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlentities(parse_url($object->source_url, PHP_URL_HOST), ENT_QUOTES, 'UTF-8'); ?></a></div>-->
     


### PR DESCRIPTION
## Here's what I fixed or added:

If not otherwise specified, interpret a remote page as UTF-8 during unfurling.

## Here's why I did it:

The dom document was being corrupted meaning certain links that had UTF-8 characters were being incorrectly handled. 
