### PR TITLE
Preserve annotation urls in array sort

### DIFF
--- a/templates/default/entity/annotations/mentions.tpl.php
+++ b/templates/default/entity/annotations/mentions.tpl.php
@@ -1,7 +1,7 @@
 <?php
 
     if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
-        usort($vars['annotations'], function($a, $b) {
+        uasort($vars['annotations'], function($a, $b) {
             return ($a['time'] < $b['time']) ? -1 : 1;
         });
         foreach($vars['annotations'] as $locallink => $annotation) {

--- a/templates/default/entity/annotations/replies.tpl.php
+++ b/templates/default/entity/annotations/replies.tpl.php
@@ -1,7 +1,7 @@
 <?php
 
     if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
-        usort($vars['annotations'], function($a, $b) {
+        uasort($vars['annotations'], function($a, $b) {
             return ($a['time'] < $b['time']) ? -1 : 1;
         });
         foreach ($vars['annotations'] as $locallink => $annotation) {

--- a/templates/default/entity/annotations/shares.tpl.php
+++ b/templates/default/entity/annotations/shares.tpl.php
@@ -1,7 +1,7 @@
 <?php
 
     if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
-        usort($vars['annotations'], function($a, $b) {
+        uasort($vars['annotations'], function($a, $b) {
             return ($a['time'] < $b['time']) ? -1 : 1;
         });
         foreach($vars['annotations'] as $locallink => $annotation) {


### PR DESCRIPTION
## Here's what I fixed or added:

s/usort/uasort

## Here's why I did it:

Permalink is used as array index, so needed to be preserved
