### PR TITLE
Allow capture or select on ios for file selector

### DIFF
--- a/templates/default/file/picker/image.tpl.php
+++ b/templates/default/file/picker/image.tpl.php
@@ -18,9 +18,8 @@
                                             <i class="fa fa-camera"></i> <span
                                                 id="photo-filename">Select an image</span>
                                             <input type="file" name="file" id="photo"
-                                                   class="col-md-9"
+                                                   class="form-control col-md-9"
                                                    accept="image/*"
-                                                   capture="camera"
                                                    onchange="photoPreview(this)"/>
                                         </span>
                 </label>


### PR DESCRIPTION
## Here's what I fixed or added:

Remove "capture" attribute

## Here's why I did it:

Allow for capture or select on ios. This is the same workaround as in #1730 .
