### PR TITLE
Link to original image on permalink

### DIFF
--- a/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
+++ b/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
@@ -38,7 +38,7 @@
 
             ?>
             <div class="photo-view">
-                <a href="<?= $vars['object']->getDisplayURL(); ?>" 
+                <a href="<?= \Idno\Core\Idno::site()->currentPage()->isPermalink() ? $this->makeDisplayURL($mainsrc) : $vars['object']->getDisplayURL(); ?>" 
                    data-original-img="<?= $this->makeDisplayURL($mainsrc) ?>"
                    data-title="<?= htmlentities(strip_tags($vars['object']->getTitle()), ENT_QUOTES, 'UTF-8'); ?>" 
                    data-footer="<?= htmlentities(strip_tags($vars['object']->body), ENT_QUOTES, 'UTF-8'); ?>"><img src="<?= $this->makeDisplayURL($src) ?>" class="u-photo" alt="<?= htmlentities(strip_tags($vars['object']->getTitle()), ENT_QUOTES, 'UTF-8'); ?>" /></a>


### PR DESCRIPTION
## Here's what I fixed or added:

When a photo is clicked on on a permalink page, the original image is displayed

## Here's why I did it:

While having title and image go to the permalink page in a feed view, it makes sense for the original image to be referenced in the permalink page.