### PR TITLE
Since this is a proxied image, we do not need to encode entities

### DIFF
--- a/templates/default/entity/UnfurledUrl.tpl.php
+++ b/templates/default/entity/UnfurledUrl.tpl.php
@@ -27,7 +27,7 @@ if (!empty($object->data['og']['og:image']))
 <div class="row unfurled-url" id="<?= $vars['id']; ?>" data-url="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>">
     <div class="basics">
         <?php if (!empty($image)) { ?>
-            <div class="image"><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><img src="<?= $this->getProxiedImageUrl(htmlentities($image)); ?>"/></a></div>
+            <div class="image"><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><img src="<?= $this->getProxiedImageUrl($image); ?>"/></a></div>
         <?php } ?>
         <h3><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlentities($title, ENT_QUOTES, 'UTF-8'); ?></a></h3>
         <?php if (!empty($description)) { ?><blockquote class="description"><?= htmlentities($description, ENT_QUOTES, 'UTF-8'); ?></blockquote><?php } ?>


### PR DESCRIPTION
## Here's what I fixed or added:

Removed htmlentities call on UnfurledUrl

## Here's why I did it:

It was unnecessary, and has caused problems for some proxied image urls
