### PR TITLE
Version file

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -56,7 +56,7 @@
                 if (!defined('KNOWN_UNIT_TEST')) { // Don't do header stuff in unit tests
                     header('X-Powered-By: https://withknown.com');
                     header('X-Clacks-Overhead: GNU Terry Pratchett');
-                    header('X-Known-Build-Fingerprint: ' . \Idno\Core\Idno::site()->getBuildFingerprint());
+                    header('X-Known-Build-Fingerprint: ' . \Idno\Core\Version::fingerprint());
                 }
                 if ($template = $this->getInput('_t')) {
                     if (\Idno\Core\Idno::site()->template()->templateTypeExists($template)) {

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -627,69 +627,33 @@
             }
 
             /**
-             * Parse version details from version file.
-             */
-            protected function parseVersionFile() {
-                
-                $versionfile = dirname(dirname(dirname(__FILE__))) . '/version.known';
-                
-                if (!file_exists($versionfile))
-                    throw new \Idno\Exceptions\ConfigurationException("Version file $versionfile could not be found, Known doesn't appear to be installed correctly.");
-                
-                return @parse_ini_file($versionfile);
-                
-            }
-            
-            /**
              * Retrieve this version of Known's version number
              * @return string
+             * @deprecated Use Version::version();
              */
-            function version()
-            {
-                $version = $this->parseVersionFile();
-                
-                return $version['version'];
-            }
+            function version() { return Version::version(); }
 
             /**
              * Alias for version()
              * @return string
+             * @deprecated Use Version::version();
              */
-            function getVersion()
-            {
-                return $this->version();
-            }
+            function getVersion() { return $this->version(); }
 
             /**
              * Retrieve a machine-readable version of Known's version number
              * @return string
+             * @deprecated Use Version::build();
              */
-            function machineVersion()
-            {
-                $version = $this->parseVersionFile();
-                
-                return $version['build'];
-            }
+            function machineVersion() { return Version::build(); }
 
             /**
              * Alias for machineVersion
              * @return string
+             * @deprecated Use Version::build();
              */
-            function getMachineVersion()
-            {
-                return $this->machineVersion();
-            }
+            function getMachineVersion() { return $this->machineVersion(); }
             
-            /**
-             * Retrieve a unique fingerprint for the site and the build version, without 
-             * giving away the detailed version number
-             */
-            function getBuildFingerprint() {
-                $hmac = hash_hmac('sha256', $this->getMachineVersion(), \Idno\Core\Idno::site()->config()->site_secret, true);
-                $hmac = hash_hmac('sha256', $this->getVersion(), $hmac);
-                
-                return $hmac;
-            }
 
             /**
              * Can a specified user (either an explicitly specified user ID

--- a/Idno/Core/Version.php
+++ b/Idno/Core/Version.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Idno\Core {
+
+    class Version extends \Idno\Common\Component {
+
+        private static $details = [];
+
+        /**
+         * Parse version details from version file.
+         */
+        protected static function parse() {
+
+            if (!empty(static::$details))
+                return static::$details;
+
+            $versionfile = dirname(dirname(dirname(__FILE__))) . '/version.known';
+
+            if (!file_exists($versionfile))
+                throw new \Idno\Exceptions\ConfigurationException("Version file $versionfile could not be found, Known doesn't appear to be installed correctly.");
+
+            static::$details = @parse_ini_file($versionfile);
+
+            return static::$details;
+        }
+
+        /**
+         * Retrieve a field from the version.
+         * @param string $field
+         * @return boolean|string
+         */
+        public static function get($field) {
+
+            $version = static::parse();
+
+            if (isset($version[$field]))
+                return $version[$field];
+
+            return false;
+        }
+
+        /**
+         * Return the human readable version.
+         * @return type
+         */
+        public static function version() {
+            return static::get('version');
+        }
+
+        /**
+         * Return the machine version.
+         * @return type
+         */
+        public static function build() {
+            return static::get('build');
+        }
+
+        /**
+         * Retrieve a unique fingerprint for the site and the build version, without 
+         * giving away the detailed version number
+         */
+        public static function fingerprint() {
+            $hmac = hash_hmac('sha256', static::build(), \Idno\Core\Idno::site()->config()->site_secret, true);
+            $hmac = hash_hmac('sha256', static::version(), $hmac);
+
+            return $hmac;
+        }
+
+    }
+
+}

--- a/Idno/Core/Version.php
+++ b/Idno/Core/Version.php
@@ -25,7 +25,7 @@ namespace Idno\Core {
         }
 
         /**
-         * Retrieve a field from the version.
+         * Retrieve a field from the version file.
          * @param string $field
          * @return boolean|string
          */


### PR DESCRIPTION
## Here's what I fixed or added:

Moved version build and fingerprint stuff into it's own component

## Here's why I did it:

The central Idno class is starting to become a little bulky, this tidies things up a bit as well as makes is easier to use version.known for more than just build and version.
