### PR TITLE
Correctly check type when sending annotation via micropub

### DIFF
--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -451,10 +451,10 @@
                 }
                 $entity = \Idno\Common\Entity::getByUUID($url);
                 if ($entity === false) {
-                    $this->error(400, 'not_found');
+                    $this->error(400, 'not_found', 'Post not found');
                 }
 
-                if (in_array($type, $verbs)) {
+                if (!in_array($type, $verbs)) {
                     $this->error(
                         400,
                         'invalid_request',

--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -449,7 +449,9 @@
                 if (!filter_var($url, FILTER_VALIDATE_URL)) {
                     $this->error(400, 'invalid_request', 'URL is invalid');
                 }
-                $entity = \Idno\Common\Entity::getByUUID($url);
+
+                $slug = end(explode('/', $url));
+                $entity = \Idno\Common\Entity::getBySlug($slug);
                 if ($entity === false) {
                     $this->error(400, 'not_found', 'Post not found');
                 }


### PR DESCRIPTION
Also throw the error correctly.

## Here's what I fixed or added:
- Check if the annotation type is correct
- Call the wrong-type-error function with the correct number of arguments
- Fetch post by slug not UUID, that does not work anymore.

## Here's why I did it:
Adding annotations via micropub (#1535) was broken.

