### PR TITLE
Asynchronous Queues on mongo

### DIFF
--- a/ConsolePlugins/EventQueueService/Main.php
+++ b/ConsolePlugins/EventQueueService/Main.php
@@ -36,7 +36,7 @@ namespace ConsolePlugins\EventQueueService {
                 }
                
             } else {
-                \Idno\Core\Idno::site()->logging()->info('Starting Asynchronous event processor on queue: ' . $queue. ", polling ever $pollperiod seconds");
+                \Idno\Core\Idno::site()->logging()->info('Starting Asynchronous event processor on queue: ' . $queue. ", polling every $pollperiod seconds");
                 
                 while(self::$run) {
                 

--- a/ConsolePlugins/EventQueueService/Main.php
+++ b/ConsolePlugins/EventQueueService/Main.php
@@ -68,7 +68,7 @@ namespace ConsolePlugins\EventQueueService {
         public function getParameters() {
             return [
                 new \Symfony\Component\Console\Input\InputArgument('queue', \Symfony\Component\Console\Input\InputArgument::OPTIONAL, 'Queue to process', 'default'),
-                new \Symfony\Component\Console\Input\InputArgument('pollperiod', \Symfony\Component\Console\Input\InputArgument::OPTIONAL, 'How often should the service poll the queue', 60),
+                new \Symfony\Component\Console\Input\InputArgument('pollperiod', \Symfony\Component\Console\Input\InputArgument::OPTIONAL, 'How often should the service poll the queue', 20),
             ];
         }
 

--- a/Idno/Entities/AsynchronousQueuedEvent.php
+++ b/Idno/Entities/AsynchronousQueuedEvent.php
@@ -17,7 +17,7 @@ namespace Idno\Entities {
         }
             
         public static function getPendingFromQueue($queue = 'default', $limit = 10, $offset = 0) {
-            return self::get(['queue' => $queue, 'complete' => ['$not' => true]], [], $limit, $offset);
+            return self::get(['queue' => $queue, 'complete' => ['$not' => ['$in' => [true]]]], [], $limit, $offset);
         }
         
         public static function getFromQueue($queue = 'default', $limit = 10, $offset = 0) {


### PR DESCRIPTION
## Here's what I fixed or added:

Enabled support for mongo asynchronous queues.. note, this also requires the latest MongoDB driver from PECL

## Here's why I did it:

I wanted to use async queues, and I'm still stuck on mongo