### PR TITLE
Lets make sure we also initialise the rest of the Component

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -43,6 +43,8 @@ namespace Idno\Common {
                     $this->setOwner(\Idno\Core\Idno::site()->session()->currentUser());
                 }
             }
+            
+            parent::__construct();
         }
 
         /**


### PR DESCRIPTION
## Here's what I fixed or added:

May Entity __construct() override call parent

## Here's why I did it:

So all entities can register hooks/pages/etc as part of component init.
