### PR TITLE
More entropy apikey

### DIFF
--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -334,7 +334,7 @@
             {
                 $token = new \Idno\Core\TokenProvider();
 
-                $apikey       = strtolower(substr(base64_encode($token->generateToken(32)), 12, 16));
+                $apikey       = strtolower(base64_encode($token->generateToken(16)));
                 $this->apikey = $apikey;
                 $this->save();
 

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -334,7 +334,7 @@
             {
                 $token = new \Idno\Core\TokenProvider();
 
-                $apikey       = strtolower(base64_encode($token->generateToken(16)));
+                $apikey       = strtolower(base64_encode($token->generateToken(24)));
                 $this->apikey = $apikey;
                 $this->save();
 

--- a/templates/default/account/settings/tools.tpl.php
+++ b/templates/default/account/settings/tools.tpl.php
@@ -57,16 +57,29 @@
 
 <div class="row" style="margin-top: 2em">
 
-    <div class="col-md-4 col-md-offset-1">
+    <div class="col-md-10 col-md-offset-1">
 
         <h2>API</h2>
-        <p>
-            <form id="apikey_form"><?= $t->__(['action' => '/account/settings/tools/'])->draw('forms/token')?>
-            Your API key: <input type="text" id="apikey" class="span4" name="apikey"
-                                 value="Click to show" readonly></form> <?php
+        
+        <div class="form-group">
+            <div class="col-md-2">
+                <label class="control-label">Your API key: </label>
+            </div>
+            <div class="col-md-8">
+                
+                <form id="apikey_form"><?= $t->__(['action' => '/account/settings/tools/'])->draw('forms/token')?>
+                    <input type="text" id="apikey" class=" form-control" name="apikey" value="Click to show" readonly></form>
+            </div>
+
+            <div class="col-md-1">
+                 <?php
                                  if (!empty($user->apikey)) {
                                      echo \Idno\Core\Idno::site()->actions()->createLink(\Idno\Core\Idno::site()->currentPage()->currentUrl(), 'Revoke', array('_method' => 'revoke'), array('method' => 'POST', 'class' => 'btn btn-danger', 'confirm' => true, 'confirm-text' => 'Revoking this key will mean you must update any applications that use this key!'));
                                  } ?>
+            </div>
+        </div>
+        <p>
+            
         </p>
 
     </div>


### PR DESCRIPTION
## Here's what I fixed or added:

* Added more entropy to api key generation
* Changed tool control to be consistent with skinned controls elsewhere.

## Here's why I did it:

Did some more thinking and research on standard practices, and #831 isn't such a problem since it's never user generated and won't expose other accounts. Admin limit prevents system wide damage so an attacker can only do what they can do anyway, and although attack via database dump is still an issue, since this is a generated value we won't be exposing other user accounts elsewhere.

So, added some more entropy to the key.
