### PR TITLE
Allow stub console plugins

### DIFF
--- a/known.php
+++ b/known.php
@@ -72,6 +72,18 @@
                                 ->setCode([$c, 'execute']);
                     } 
                 }
+            } else {
+                $stubclass = "ConsolePlugins\\$file";
+                $stubclass = str_replace('.php', '', $stubclass);
+                if (class_exists($stubclass)) {
+                    $c = new $stubclass(); 
+                    if ($c instanceof \Idno\Common\ConsolePlugin) {
+                        $console->register($c->getCommand())
+                                ->setDescription($c->getDescription())
+                                ->setDefinition($c->getParameters())
+                                ->setCode([$c, 'execute']);
+                    } 
+                }
             }
         }
     }


### PR DESCRIPTION
## Here's what I fixed or added:

Allow php files in ConsolePlugins/ to be scanned for console plugins

## Here's why I did it:

It was time consuming to create full directory hierarchies when you just needed a quick console file. 