### PR TITLE
Added Dreamhost link

### DIFF
--- a/docs/install/sharedhost.md
+++ b/docs/install/sharedhost.md
@@ -2,3 +2,4 @@
 
 * [Arvixe](https://withknown.com/guides/arvixe/)
 * [Reclaim Hosting](https://withknown.com/guides/reclaim/)
+* [Dreamhost] (https://www.kiaikim.com/2017/how-to-install-the-known-platform-on-a-dreamhost-shared)


### PR DESCRIPTION
Added link to Dreamhost installation instructions on kiaikim.com

## Here's what I fixed or added:
Add a link to my kiaikim.com post for installing Known on Dreamhost

## Here's why I did it:
Would have added the text to the site, but not sure if that's the way it should be done. Plus this github interface is new to me and I'd probably mess it up somehow. Feel free to copy the text and add/edit it directly onto the site.
