### PR TITLE
Changing install defaults: Default events to enabled.

### DIFF
--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -19,7 +19,7 @@
                 'sessionname'            => 'known', // Default session name
                 'boolean_search'         => true, // Should search be boolean?
                 'open_registration'      => true, // Can anyone register for this system?
-                'initial_plugins'        => array('Status', 'Text', 'Photo', 'Firefox', 'FooterJS', 'IndiePub', 'Styles'),
+                'initial_plugins'        => array('Status', 'Text', 'Photo', 'Event', 'Firefox', 'FooterJS', 'IndiePub', 'Styles'),
                 'plugins'                => array(), // Default plugins
                 'assets'                 => [      // Assets to be included
                                                    'mediaelementplayer' => true,


### PR DESCRIPTION
## Here's what I fixed or added:

Added the Event plugin to the initial plugins

## Here's why I did it:

It was reported that folk were finding this functionality hard to find when defaulted off, and people were getting questions