### PR TITLE
Resolving an issue with the UrlUnfurler in PHP 7.2

### DIFF
--- a/Idno/Common/ContentType.php
+++ b/Idno/Common/ContentType.php
@@ -11,7 +11,7 @@
 
             // Property containing the entity class associated with this content type (default is generic object type)
             static public $registered = array();
-            public $entity_class = 'Idno\\Entities\\Object';
+            public $entity_class = 'Idno\\Entities\\BaseObject';
             public $handler_class = 'Idno\\Common\\ContentType';
             public $title = 'Content type';
             public $indieWebContentType = array();

--- a/Idno/Entities/AsynchronousQueuedEvent.php
+++ b/Idno/Entities/AsynchronousQueuedEvent.php
@@ -5,7 +5,7 @@ namespace Idno\Entities {
     /**
      * Represents a queued event stored in the AsynchronousQueue.
      */
-    class AsynchronousQueuedEvent extends \Idno\Entities\Object {
+    class AsynchronousQueuedEvent extends \Idno\Entities\BaseObject {
          
         public function save($add_to_feed = false, $feed_verb = 'post')
         {

--- a/Idno/Entities/BaseObject.php
+++ b/Idno/Entities/BaseObject.php
@@ -9,7 +9,7 @@
 
     namespace Idno\Entities {
 
-        class Object extends \Idno\Common\Entity
+        class BaseObject extends \Idno\Common\Entity
         {
 
 

--- a/Idno/Entities/GenericDataItem.php
+++ b/Idno/Entities/GenericDataItem.php
@@ -10,7 +10,7 @@
 
     namespace Idno\Entities {
 
-        class GenericDataItem extends \Idno\Entities\Object
+        class GenericDataItem extends \Idno\Entities\BaseObject
         {
             /**
              * Retrieve a bit of generic data by it's data type

--- a/Idno/Entities/UnfurledUrl.php
+++ b/Idno/Entities/UnfurledUrl.php
@@ -4,7 +4,7 @@ namespace Idno\Entities {
 
     use Idno\Common\Component;
 
-    class UnfurledUrl extends Object {
+    class UnfurledUrl extends BaseObject {
 
         /**
          * Copied and modified from https://github.com/mapkyca/php-ogp, extract information from graph headers


### PR DESCRIPTION
PHP 7.2 now reserves the word "Object." Rename to "BaseObject" to fix.

## Here's what I fixed or added:

Renamed "Object" to "BaseObject."

## Here's why I did it:

URL Unfurling was failing on PHP 7.2 with an error:

```PHP Fatal error:  Cannot use 'Object' as class name as it is reserved in /var/www/cleverdevil.io/Idno/Entities/Object.php on line 12```