### PR TITLE
Resolving a warning in PHP 7.2 with sessions.

### DIFF
--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -69,9 +69,9 @@
                     session_save_path(Idno::site()->config()->session_path);
                 }
 
+                session_cache_limiter('public');
                 session_name(Idno::site()->config->sessionname);
                 session_start();
-                session_cache_limiter('public');
 
                 // Flag insecure sessions (so we can check state changes etc)
                 if (!isset($_SESSION['secure'])) {


### PR DESCRIPTION
## Here's what I fixed or added:

Rearranged the sequence of session setup.

## Here's why I did it:

The cache limiter isn't supposed to be modified once a session is started.
