### PR TITLE
Rename Object to BaseObject

### DIFF
--- a/Idno/Common/ContentType.php
+++ b/Idno/Common/ContentType.php
@@ -11,7 +11,7 @@
 
             // Property containing the entity class associated with this content type (default is generic object type)
             static public $registered = array();
-            public $entity_class = 'Idno\\Entities\\Object';
+            public $entity_class = 'Idno\\Entities\\BaseObject';
             public $handler_class = 'Idno\\Common\\ContentType';
             public $title = 'Content type';
             public $indieWebContentType = array();

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -16,7 +16,7 @@ namespace Idno\Common {
     use Idno\Core\Webmention;
     use Idno\Entities\User;
 
-    class Entity extends Component implements EntityInterface
+    abstract class Entity extends Component implements EntityInterface
     {
 
         // Which collection should this be stored in?

--- a/Idno/Entities/AsynchronousQueuedEvent.php
+++ b/Idno/Entities/AsynchronousQueuedEvent.php
@@ -5,7 +5,7 @@ namespace Idno\Entities {
     /**
      * Represents a queued event stored in the AsynchronousQueue.
      */
-    class AsynchronousQueuedEvent extends \Idno\Entities\Object {
+    class AsynchronousQueuedEvent extends \Idno\Entities\BaseObject {
          
         public function save($add_to_feed = false, $feed_verb = 'post')
         {

--- a/Idno/Entities/BaseObject.php
+++ b/Idno/Entities/BaseObject.php
@@ -1,0 +1,16 @@
+<?php
+
+    /**
+     * User-created object representation
+     *
+     * @package idno
+     * @subpackage core
+     */
+
+    namespace Idno\Entities {
+
+        abstract class BaseObject extends \Idno\Common\Entity
+        {
+        }
+
+    }

--- a/Idno/Entities/GenericDataItem.php
+++ b/Idno/Entities/GenericDataItem.php
@@ -10,7 +10,7 @@
 
     namespace Idno\Entities {
 
-        class GenericDataItem extends \Idno\Entities\Object
+        class GenericDataItem extends \Idno\Entities\BaseObject
         {
             /**
              * Retrieve a bit of generic data by it's data type

--- a/Idno/Entities/Object.php
+++ b/Idno/Entities/Object.php
@@ -9,10 +9,18 @@
 
     namespace Idno\Entities {
 
-        class Object extends \Idno\Common\Entity
+        /**
+         * @deprecated Object is a reserved word in PHP 7.2+ and will be removed in the next version, use BaseObject instead.
+         */
+        abstract class Object extends \Idno\Common\Entity
         {
 
-
+            function __construct() {
+                
+                \Idno\Core\Idno::site()->logging()->warning("DEPRECATION WARNING: Object is a reserved word in PHP 7.2+ and will be removed in the next version, use BaseObject instead.");
+                
+                parent::__construct();
+            }
         }
 
     }

--- a/Idno/Entities/RemoteObject.php
+++ b/Idno/Entities/RemoteObject.php
@@ -9,7 +9,7 @@
 
     namespace Idno\Entities {
 
-        class RemoteObject extends \Idno\Entities\Object implements \JsonSerializable
+        class RemoteObject extends \Idno\Entities\BaseObject implements \JsonSerializable
         {
 
             public function save($add_to_feed = false, $feed_verb = 'post')

--- a/Idno/Entities/UnfurledUrl.php
+++ b/Idno/Entities/UnfurledUrl.php
@@ -4,7 +4,7 @@ namespace Idno\Entities {
 
     use Idno\Common\Component;
 
-    class UnfurledUrl extends Object {
+    class UnfurledUrl extends BaseObject {
 
         /**
          * Copied and modified from https://github.com/mapkyca/php-ogp, extract information from graph headers

--- a/Tests/Common/EntityTest.php
+++ b/Tests/Common/EntityTest.php
@@ -25,7 +25,7 @@ class EntityTest extends \Tests\KnownTestCase {
 
     public function testPrepareSlug()
     {
-        $entity = new GenericDataItem();
+        $entity = new GenericDataItem(); $entity->setDatatype('data-slug-test');
         $this->assertEquals(
             'test-a-simple-title',
             $entity->prepareSlug('Test a Simple Title'));
@@ -67,13 +67,13 @@ class EntityTest extends \Tests\KnownTestCase {
         $title  = "IndieWebCamp Nürnberg $unique is live!";
         $slug   = "indiewebcamp-n%C3%BCrnberg-$unique-is-live";
 
-        $entity = new GenericDataItem();
+        $entity = new GenericDataItem();  $entity->setDatatype('data-slug-test');
         $entity->setSlugResilient($title);
         $this->assertEquals($slug, $entity->getSlug());
         $entity->save();
         $this->toDelete[] = $entity;
 
-        $entity = new GenericDataItem();
+        $entity = new GenericDataItem();  $entity->setDatatype('data-slug-test');
         $entity->setSlugResilient($title);
         $this->assertEquals($slug . '-1', $entity->getSlug());
         $entity->save();
@@ -85,7 +85,7 @@ class EntityTest extends \Tests\KnownTestCase {
      */
     function testAddWebmentions_SimpleReply()
     {
-        $entity = new GenericDataItem();
+        $entity = new GenericDataItem();  $entity->setDatatype('data-slug-test');
         $entity->setOwner($this->user());
         $entity->title = "This will be the target of our webmention";
         $entity->publish();
@@ -124,7 +124,7 @@ EOD;
      */
     function testAddWebmentions_OtherTypes()
     {
-        $entity = new GenericDataItem();
+        $entity = new GenericDataItem(); $entity->setDatatype('data-slug-test');
         $entity->setOwner($this->user());
         $entity->title = "This will be the target of our webmention";
         $entity->publish();
@@ -215,7 +215,7 @@ EOD
      */
     function testAddWebmentions_RemoteFeed()
     {
-        $entity = new GenericDataItem();
+        $entity = new GenericDataItem(); $entity->setDatatype('data-slug-test');
         $entity->setOwner($this->user());
         $entity->title = "This post will be the webmention target";
         $entity->publish();
@@ -262,7 +262,7 @@ EOD;
     function testAddWebmentions_LocalFeed()
     {
         for ($i = 0 ; $i < 5 ; $i++) {
-            $entity = new GenericDataItem();
+            $entity = new GenericDataItem(); $entity->setDatatype('data-slug-test');
             $entity->setOwner($this->user());
             $entity->title = "This post will be the webmention target";
             $entity->publish();

--- a/Tests/Common/EntityTest.php
+++ b/Tests/Common/EntityTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Common;
 
-use Idno\Common\Entity;
+use Idno\Entities\GenericDataItem;
 use Idno\Core\Idno;
 use Idno\Core\Webservice;
 
@@ -25,7 +25,7 @@ class EntityTest extends \Tests\KnownTestCase {
 
     public function testPrepareSlug()
     {
-        $entity = new Entity();
+        $entity = new GenericDataItem();
         $this->assertEquals(
             'test-a-simple-title',
             $entity->prepareSlug('Test a Simple Title'));
@@ -67,13 +67,13 @@ class EntityTest extends \Tests\KnownTestCase {
         $title  = "IndieWebCamp Nürnberg $unique is live!";
         $slug   = "indiewebcamp-n%C3%BCrnberg-$unique-is-live";
 
-        $entity = new Entity();
+        $entity = new GenericDataItem();
         $entity->setSlugResilient($title);
         $this->assertEquals($slug, $entity->getSlug());
         $entity->save();
         $this->toDelete[] = $entity;
 
-        $entity = new Entity();
+        $entity = new GenericDataItem();
         $entity->setSlugResilient($title);
         $this->assertEquals($slug . '-1', $entity->getSlug());
         $entity->save();
@@ -85,7 +85,7 @@ class EntityTest extends \Tests\KnownTestCase {
      */
     function testAddWebmentions_SimpleReply()
     {
-        $entity = new Entity();
+        $entity = new GenericDataItem();
         $entity->setOwner($this->user());
         $entity->title = "This will be the target of our webmention";
         $entity->publish();
@@ -124,7 +124,7 @@ EOD;
      */
     function testAddWebmentions_OtherTypes()
     {
-        $entity = new Entity();
+        $entity = new GenericDataItem();
         $entity->setOwner($this->user());
         $entity->title = "This will be the target of our webmention";
         $entity->publish();
@@ -215,7 +215,7 @@ EOD
      */
     function testAddWebmentions_RemoteFeed()
     {
-        $entity = new Entity();
+        $entity = new GenericDataItem();
         $entity->setOwner($this->user());
         $entity->title = "This post will be the webmention target";
         $entity->publish();
@@ -262,7 +262,7 @@ EOD;
     function testAddWebmentions_LocalFeed()
     {
         for ($i = 0 ; $i < 5 ; $i++) {
-            $entity = new Entity();
+            $entity = new GenericDataItem();
             $entity->setOwner($this->user());
             $entity->title = "This post will be the webmention target";
             $entity->publish();


### PR DESCRIPTION
## Here's what I fixed or added:

Introduces BaseObject, deprecated Object and migrates classes across.

This is soft deprecated so as to mitigate hardship for plugin authors.

## Here's why I did it:

Object is a reserved word in PHP 7.2+, so we need to migrate away.

Closes #1977 - includes all this stuff (thanks for the PR) but does a couple of other bits.
Closes #1980 