### PR TITLE
Fix diagnostics

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -1098,6 +1098,15 @@
             }
 
             /**
+             * Set headers to ensure that the current page is not cached.
+             */
+            public function setNoCache() {
+                header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
+                header("Cache-Control: post-check=0, pre-check=0", false);
+                header("Pragma: no-cache");
+            }
+            
+            /**
              * Set the last updated header for this page.
              * Takes a unix timestamp and outputs it as RFC2616 date.
              * @param int $timestamp Unix timestamp.

--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -11,6 +11,7 @@
 
             function getContent()
             {
+                $this->setNoCache();
                 $this->adminGatekeeper(); // Admins only
 
                 // Generate basic diagnostics for report


### PR DESCRIPTION
## Here's what I fixed or added:

* Added a no cache option to page
* Disable caching on diagnostics page

## Here's why I did it:

Changes introduced in ce203f7 had a knock on effect that, since caching actually works, the diagnostics page broke.
