### PR TITLE
CSRF Token debug

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -317,6 +317,7 @@
                         'time' => $_REQUEST['__bTs'],
                         'token' => \Idno\Core\TokenProvider::truncateToken($_REQUEST['__bTk']),
                         'action' => $_REQUEST['__bTa'],
+                        'site_secret' => \Idno\Core\TokenProvider::truncateToken(\Idno\Core\Idno::site()->config()->site_secret),
                         'session_id' => \Idno\Core\TokenProvider::truncateToken(session_id()),
                         'expected-token' => \Idno\Core\TokenProvider::truncateToken(
                                 \Idno\Core\Bonita\Forms::token($_REQUEST['__bTa'], $_REQUEST['__bTs'])

--- a/Idno/Core/Bonita/Forms.php
+++ b/Idno/Core/Bonita/Forms.php
@@ -100,6 +100,14 @@ namespace Idno\Core\Bonita {
          * @return true|false
          */
         public static function token($action, $time) {
+            
+            \Idno\Core\Idno::site()->logging()->debug("Generating CSRF token for {$action} over: ". print_r([
+                'action' => $action,
+                'time' => $time,
+                'site_secret' => \Idno\Core\TokenProvider::truncateToken(\Idno\Core\Idno::site()->config()->site_secret),
+                'session_id' => \Idno\Core\TokenProvider::truncateToken(session_id()),
+            ], true));
+            
             $hmac = hash_hmac('sha256', $action, \Idno\Core\Bonita\Main::getSiteSecret(), true);
             $hmac = hash_hmac('sha256', $time, $hmac, true);
             $hmac = hash_hmac('sha256', session_id(), $hmac);


### PR DESCRIPTION
## Here's what I fixed or added:

Logging somewhat redacted details for both sides of the CSRF exchange - token generation and token validation.

## Here's why I did it:

Some sites are getting "Invalid token" errors, so this information is being corrupted somewhere along the line. I'd like to know what, and when.