### PR TITLE
Expanding standards document around comments

### DIFF
--- a/docs/developers/standards.md
+++ b/docs/developers/standards.md
@@ -44,12 +44,20 @@ switch ($var) {
 * Notice errors are errors, please develop your code with ```pedantic_mode = true;``` set in your config.ini
 * Unless there's a VERY good reason you can explain, never use the '@' error suppression operator.
 
-## PHP doc blocks:
+## Comments
+
+We like comments, and when in doubt, you probably should write a comment! That doesn't mean writing a comment for every line, but 
+we'd like to know your thought process behind what you wrote, and why you did something a certain way. 
+
+This will help future developers, maybe even you, so be kind to your future self!
+
+### PHP doc blocks:
 
 Use PHP doc blocks for every method, *except* inherited methods, where they are optional. Use your best judgment here.
 
 * Explain the purpose of the method or class as clearly as you can. For example, "loads ClassName by property_name" is bad; 
   "loads objects that have a property called property_name" is much better.
+* Explain what object properties are, and what they're for.
 * "Just read the code" isn't a good idea, and we don't like it.
 * That said, clear, simple code is good :)
 


### PR DESCRIPTION
## Here's what I fixed or added:

Expanding the documentation a little around comments.

## Here's why I did it:

I think it was needed, because I want to encourage commenting!