### PR TITLE
Extend translation mechanism to be more flexible

### DIFF
--- a/Idno/Core/ArrayKeyTranslation.php
+++ b/Idno/Core/ArrayKeyTranslation.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace Idno\Core {
+    
+    /**
+     * Register translation strings for a specific language, based on a massive array of values.
+     * 
+     * This is the simplest way to register translations, using an associative array of "key" => "value"
+     */
+    abstract class ArrayKeyTranslation 
+        extends Translation
+    {
+        
+        public function getString($key) {
+            $keys = $this->getStrings();
+            
+            if (array_key_exists($key, $keys)) {
+                return $keys[$key];
+            }
+                    
+        }
+        
+        /**
+         * Return all of the strings.
+         */
+        abstract public function getStrings();
+        
+    }
+    
+}

--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -6,7 +6,19 @@ namespace Idno\Core {
 
     class Language extends Component {
 
+        /**
+         * Language associated array of translation objects.
+         * @var type 
+         */
+        private $translations = [];
+        
+        // @deprecated
         private $strings = [];
+        
+        /**
+         * Current language
+         * @var type 
+         */
         private $language;
 
         /**
@@ -35,6 +47,7 @@ namespace Idno\Core {
 
         /**
          * Magic method to set language variables
+         * @deprecated Add a Translation object using register
          */
         function __set($string, $translation) {
             if (!empty($string)) {
@@ -52,6 +65,7 @@ namespace Idno\Core {
         /**
          * Chainable function to allow variables to be added as an array.
          * @param $vars array Associated array of "string" => "translation"
+         * @deprecated Add a Translation object using register
          */
         function __($strings) {
             $this->addTranslations($strings);
@@ -71,6 +85,7 @@ namespace Idno\Core {
          * @param $string
          * @param $translation
          * @return bool
+         * @deprecated Add a Translation object using register
          */
         function add($string, $translation) {
             return $this->addTranslation($string, $translation);
@@ -81,6 +96,7 @@ namespace Idno\Core {
          * @param $string
          * @param $translation
          * @return bool
+         * @deprecated Add a Translation object using register
          */
         function addTranslation($string, $translation) {
             if (!empty($string) && is_string($string)) {
@@ -95,6 +111,7 @@ namespace Idno\Core {
         /**
          * Simplify adding translation strings.
          * @param array $strings Associated array of "string" => "translation"
+         * @deprecated Add a Translation object using register
          */
         function addTranslations(array $strings) {
             $this->strings = array_merge($this->strings, $strings);
@@ -108,7 +125,8 @@ namespace Idno\Core {
          */
         public function register(Translation $translation) {
             if ($translation->getLanguage() == $this->getLanguage()) {
-                $this->addTranslations($translation->getStrings());
+                //$this->addTranslations($translation->getStrings());
+                $this->translations[] = $translation;
             }
         }
         
@@ -130,9 +148,19 @@ namespace Idno\Core {
          * @return string|bool
          */
         function getTranslation($string, $failover = true) {
+            
+            // Look through translation objects
+            foreach ($this->translations as $translation) {
+                $value = $translation->getString($string);
+                if (!empty($value))
+                    return $value;
+            }
+            
+            // Look through locally added strings (deprecated).
             if (!empty($this->strings[$string])) {
                 return $this->strings[$string];
             }
+            
             if ($failover) {
                 return $string;
             }

--- a/Idno/Core/Translation.php
+++ b/Idno/Core/Translation.php
@@ -31,9 +31,9 @@ namespace Idno\Core {
         }
         
         /**
-         * @return array An associative array of "string" => "translation"
+         * Return a specific string.
          */
-        abstract public function getStrings();
+        abstract public function getString($key);
         
     }
     

--- a/Tests/Core/LanguageTest.php
+++ b/Tests/Core/LanguageTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Core {
 
-    class EnglishTest extends \Idno\Core\Translation {
+    class EnglishTest extends \Idno\Core\ArrayKeyTranslation {
 
         public function getStrings() {
             return [
@@ -12,7 +12,7 @@ namespace Tests\Core {
 
     }
 
-    class FrenchTest extends \Idno\Core\Translation {
+    class FrenchTest extends \Idno\Core\ArrayKeyTranslation {
 
         public function getStrings() {
             return [

--- a/docs/developers/languages/index.md
+++ b/docs/developers/languages/index.md
@@ -9,7 +9,7 @@ method hook.
 
 ## Adding a translation for a language
 
-It is possible to add single strings, one by one, for the current language, however the easiest way to register multiple strings is to extend ```Idno/Core/Translation``` for each language you want to translate, and then implement its ```getStrings()``` method.
+In order to add a translation, you need to register a ```Translation``` object for a given language short code. To do this you need to extend ```Idno/Core/ArrayKeyTranslation``` for each language you want to translate, and then implement its ```getStrings()``` method.
 
 It is then possible to add them all at once for each language (this way, Known will automatically select the appropriate translation for the loaded language).
 


### PR DESCRIPTION
## Here's what I fixed or added:

Changed the way that the translation code works slightly to no longer pass around strings (although the Massive Array of Strings mechanism is still supported). 

## Here's why I did it:

To make the translation code much more flexible, and allow easier support, of other translation mechanisms (e.g. gettext). It also allows for a heterogeneous environment, with multiple different translation mechanisms being supported.
