### PR TITLE
Use vsprintf instead of sprintf

### DIFF
--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -182,7 +182,7 @@ namespace Idno\Core {
          * @return string
          */
         public function write($string, array $subs = []) {
-            return sprintf($this->get($string), $subs);
+            return vsprintf($this->get($string), $subs);
         }
 
         /**


### PR DESCRIPTION
## Here's what I fixed or added:

Use vsprintf instead of sprintf

## Here's why I did it:

This is the correct use when passing parameters