### PR TITLE
Fix indieauth scopes

### DIFF
--- a/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
+++ b/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
@@ -36,7 +36,6 @@
                 $redirect_uri = $this->getInput('redirect_uri');
                 $state        = $this->getInput('state');
                 $client_id    = $this->getInput('client_id');
-                $scope        = $this->getInput('scope');
 
                 $verified = Auth::verifyCode($code, $client_id, $redirect_uri, $state);
                 if ($verified['valid']===true) {
@@ -53,7 +52,7 @@
                     $indieauth_tokens[$token] = array(
                         'me'           => $me,
                         'redirect_uri' => $redirect_uri,
-                        'scope'        => $scope,
+                        'scope'        => $verified['scope'],
                         'client_id'    => $client_id,
                         'issued_at'    => time(),
                         'nonce'        => mt_rand(1000000, pow(2, 30))
@@ -63,13 +62,13 @@
                     if (\Idno\Core\Idno::site()->session()->isLoggedOn() && $user->getUUID() == \Idno\Core\Idno::site()->session()->currentUser()->getUUID()) {
                         \Idno\Core\Idno::site()->session()->refreshSessionUser($user);
                     }
-
+                    
                     // Output to the browser
                     $this->setResponse(200);
                     header('Content-Type: application/x-www-form-urlencoded');
                     echo http_build_query(array(
                         'access_token' => $token,
-                        'scope'        => $scope,
+                        'scope'        => $verified['scope'],
                         'me'           => $me,
                     ));
                     exit;

--- a/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
+++ b/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
@@ -36,6 +36,7 @@
                 $redirect_uri = $this->getInput('redirect_uri');
                 $state        = $this->getInput('state');
                 $client_id    = $this->getInput('client_id');
+                $scope        = $this->getInput('scope');
 
                 $verified = Auth::verifyCode($code, $client_id, $redirect_uri, $state);
                 if ($verified['valid']===true) {
@@ -52,7 +53,7 @@
                     $indieauth_tokens[$token] = array(
                         'me'           => $me,
                         'redirect_uri' => $redirect_uri,
-                        'scope'        => 'post',
+                        'scope'        => $scope,
                         'client_id'    => $client_id,
                         'issued_at'    => time(),
                         'nonce'        => mt_rand(1000000, pow(2, 30))
@@ -68,7 +69,7 @@
                     header('Content-Type: application/x-www-form-urlencoded');
                     echo http_build_query(array(
                         'access_token' => $token,
-                        'scope'        => 'post',
+                        'scope'        => $scope,
                         'me'           => $me,
                     ));
                     exit;


### PR DESCRIPTION
## Here's what I fixed or added:

IndieAuth scopes were hardcoded to "post," rather than using the requested scopes. I fixed the code to read the scopes off of the original request, and passing those through.

## Here's why I did it:

This created several issues for third-party clients connecting to Known via IndieAuth, including Together, Quill, and OwnYourGram.
