### PR TITLE
Normalise action generation

### DIFF
--- a/Idno/Core/Bonita/Forms.php
+++ b/Idno/Core/Bonita/Forms.php
@@ -64,6 +64,9 @@ namespace Idno\Core\Bonita {
             }
 
             if (abs(time() - $time) < \Idno\Core\Idno::site()->config()->form_token_expiry) {
+                
+                \Idno\Core\Idno::site()->logging()->debug("Token for $action has a valid time " . date('r', $time));
+                
                 if (self::token($action, $time) == $token) {
                     return true;
                 }
@@ -100,6 +103,9 @@ namespace Idno\Core\Bonita {
          * @return true|false
          */
         public static function token($action, $time) {
+            
+            // Normalise action by stripping get line
+            $action = explode('?', $action)[0];
             
             $hmac = hash_hmac('sha256', $action, \Idno\Core\Bonita\Main::getSiteSecret(), true);
             $hmac = hash_hmac('sha256', $time, $hmac, true);

--- a/Idno/Core/Bonita/Forms.php
+++ b/Idno/Core/Bonita/Forms.php
@@ -101,16 +101,17 @@ namespace Idno\Core\Bonita {
          */
         public static function token($action, $time) {
             
+            $hmac = hash_hmac('sha256', $action, \Idno\Core\Bonita\Main::getSiteSecret(), true);
+            $hmac = hash_hmac('sha256', $time, $hmac, true);
+            $hmac = hash_hmac('sha256', session_id(), $hmac);
+            
             \Idno\Core\Idno::site()->logging()->debug("Generating CSRF token for {$action} over: ". print_r([
                 'action' => $action,
                 'time' => $time,
                 'site_secret' => \Idno\Core\TokenProvider::truncateToken(\Idno\Core\Idno::site()->config()->site_secret),
                 'session_id' => \Idno\Core\TokenProvider::truncateToken(session_id()),
+                'token' => \Idno\Core\TokenProvider::truncateToken($hmac),
             ], true));
-            
-            $hmac = hash_hmac('sha256', $action, \Idno\Core\Bonita\Main::getSiteSecret(), true);
-            $hmac = hash_hmac('sha256', $time, $hmac, true);
-            $hmac = hash_hmac('sha256', session_id(), $hmac);
 
             return $hmac;
         }


### PR DESCRIPTION
## Here's what I fixed or added:

* Improved token generation debug
* Stripped GET line from action when generating a CSRF token

## Here's why I did it:

I started running into invalid tokens being generated (which may or may not be the same as the issue @benwerd has been hitting), but in this case it was being caused by the GET line being included in the token generation. Since the GET line could vary between generation and post, this caused problems.