### PR TITLE
Truncate the fingerprint

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -56,7 +56,7 @@
                 if (!defined('KNOWN_UNIT_TEST')) { // Don't do header stuff in unit tests
                     header('X-Powered-By: https://withknown.com');
                     header('X-Clacks-Overhead: GNU Terry Pratchett');
-                    header('X-Known-Build-Fingerprint: ' . \Idno\Core\Version::fingerprint());
+                    header('X-Known-Build-Fingerprint: ' . \Idno\Core\TokenProvider::truncateToken(\Idno\Core\Version::fingerprint()));
                 }
                 if ($template = $this->getInput('_t')) {
                     if (\Idno\Core\Idno::site()->template()->templateTypeExists($template)) {


### PR DESCRIPTION
## Here's what I fixed or added:

Truncate the fingerprint

## Here's why I did it:

To avoid any possibility of some future tech will work out the build version from the fingerprint, lets truncate it. This will give us the same result (ability to tell whether core has been updated) without leaking any info.
