### PR TITLE
Enabling single-user Known sites to use their base URL as their "me" for IndieAuth

### DIFF
--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -167,6 +167,19 @@
 
                 return \Idno\Core\Idno::site()->config()->getDisplayURL() . 'profile/' . $this->getHandle();
             }
+ 
+            /**
+             * Get the IndieAuth identity URL for this user
+             * @return string
+             */
+            function getIndieAuthURL()
+            {
+                if (\Idno\Core\Idno::site()->config()->single_user) {
+                    return \Idno\Core\Idno::site()->config()->getDisplayURL();
+                }
+
+                return $this->getURL(); 
+            }
 
             /**
              * Wrapper for getURL for consistency

--- a/IdnoPlugins/IndiePub/Pages/IndieAuth/Approve.php
+++ b/IdnoPlugins/IndiePub/Pages/IndieAuth/Approve.php
@@ -19,7 +19,7 @@
                 $state        = $this->getInput('state');
                 $scope        = $this->getInput('scope');
 
-                if (!empty($me) && parse_url($me, PHP_URL_HOST) == parse_url( $user->getURL(), PHP_URL_HOST)) {
+                if (!empty($me) && parse_url($me, PHP_URL_HOST) == parse_url( $user->getIndieAuthURL(), PHP_URL_HOST)) {
                     $indieauth_codes = $user->indieauth_codes;
                     if (empty($indieauth_codes)) {
                         $indieauth_codes = array();

--- a/IdnoPlugins/IndiePub/Pages/IndieAuth/Auth.php
+++ b/IdnoPlugins/IndiePub/Pages/IndieAuth/Auth.php
@@ -3,6 +3,7 @@
     namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
 
         use Idno\Entities\User;
+        use Idno\Core;
 
         class Auth extends \Idno\Common\Page
         {
@@ -34,13 +35,13 @@
                     exit;
                 }
 
-                 if (parse_url($me, PHP_URL_HOST) != parse_url($user->getURL(), PHP_URL_HOST)) {
+                 if (parse_url($me, PHP_URL_HOST) != parse_url($user->getIndieAuthURL(), PHP_URL_HOST)) {
                      $this->setResponse(403);
-                     echo "\"$me\" does not match the logged in user \"{$user->getURL()}\".";
+                     echo "\"$me\" does not match the logged in user \"{$user->getIndieAuthURL()}\".";
                      exit;
                  }
 
-                 $me_prime = $user->getURL();
+                 $me_prime = $user->getIndieAuthURL();
                  $t        = \Idno\Core\site()->template();
                  $t->body  = $t->__(array(
                      'me'           => $me_prime,
@@ -151,6 +152,7 @@
                         'reason' => 'client_id does not match',
                     );
                 }
+
                 return array(
                     'valid'  => true,
                     'user'   => $user,

--- a/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
+++ b/IdnoPlugins/IndiePub/Pages/IndieAuth/Token.php
@@ -32,7 +32,6 @@
             {
                 // Get parameters
                 $code         = $this->getInput('code');
-                $me           = $this->getInput('me');
                 $redirect_uri = $this->getInput('redirect_uri');
                 $state        = $this->getInput('state');
                 $client_id    = $this->getInput('client_id');
@@ -50,7 +49,7 @@
                     // Generate access token and save it to the user
                     $token                    = md5(rand(0, 99999) . time() . $user->getUUID() . $client_id . $state . rand(0, 999999));
                     $indieauth_tokens[$token] = array(
-                        'me'           => $me,
+                        'me'           => $verified['me'],
                         'redirect_uri' => $redirect_uri,
                         'scope'        => $verified['scope'],
                         'client_id'    => $client_id,
@@ -69,7 +68,7 @@
                     echo http_build_query(array(
                         'access_token' => $token,
                         'scope'        => $verified['scope'],
-                        'me'           => $me,
+                        'me'           => $verified['me'],
                     ));
                     exit;
 


### PR DESCRIPTION
## Here's what I fixed or added:

Added a helper method to User called `getIndieAuthURL`, which is used in place of the `getURL` method in the IndieAuth plugin. Then, ensured that the IndieAuth plugin is consistent in how it pulls the `me` from the user.

## Here's why I did it:

Known was playing a bit fast and loose with user URLs. In the case of a single-user instance, in many places the base URL for the site would work just fine, but in others, you'd have to substitute the profile link, which isn't quite right, and threw off other aspects of IndieAuth.

With this change, if the single-user mode is enabled, the base URL of the site can be used consistently throughout, otherwise it falls back to the old behavior.