### PR TITLE
i18n: Apply translation hooks to thrown Exceptions

### DIFF
--- a/Idno/Caching/FilesystemCache.php
+++ b/Idno/Caching/FilesystemCache.php
@@ -15,7 +15,7 @@ namespace Idno\Caching {
             
             $domain = md5(\Idno\Core\Idno::site()->config()->host);
             if (empty($domain))
-                throw new \RuntimeException("No domain specified for cache");
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("No domain specified for cache"));
             
             $pathbase = \Idno\Core\Idno::site()->config()->cachepath;
             if (empty($pathbase))

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -350,7 +350,7 @@
                 
                     $this->debugLogToken();
                     
-                    throw new \RuntimeException('Invalid token.');
+                    throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_('Invalid token.'));
                 }
 
                 if (\Idno\Core\Idno::site()->session()->isAPIRequest()) {
@@ -424,7 +424,7 @@
                      * redirection to other sites (eg a Known hub).
 
                     if (!Entity::isLocalUUID($location)) {
-                        throw new \RuntimeException('Attempted to redirect page to a non local URL.');
+                        throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_('Attempted to redirect page to a non local URL.'));
                     }
                     */
                     
@@ -514,7 +514,7 @@
                 } else {
                     $this->debugLogToken();
                     
-                    throw new \Idno\Exceptions\SecurityException('The page you were on timed out.');
+                    throw new \Idno\Exceptions\SecurityException(\Idno\Core\Idno::site()->language()->_('The page you were on timed out.'));
                 }
 
                 if (\Idno\Core\Idno::site()->session()->isAPIRequest()) {
@@ -600,7 +600,7 @@
                 } else {
                     $this->debugLogToken();
                     
-                    throw new \Idno\Exceptions\SecurityException('The page you were on timed out.');
+                    throw new \Idno\Exceptions\SecurityException(\Idno\Core\Idno::site()->language()->_('The page you were on timed out.'));
                 }
 
                 if (\Idno\Core\Idno::site()->session()->isAPIRequest()) {

--- a/Idno/Common/Plugin.php
+++ b/Idno/Common/Plugin.php
@@ -73,7 +73,7 @@
                 $manifest = $this->getManifest();
                 
                 if (empty($manifest['version']))
-                    throw new \Idno\Exceptions\ConfigurationException('Plugin ' . get_class($this) . ' doesn\'t have a version');
+                    throw new \Idno\Exceptions\ConfigurationException(\Idno\Core\Idno::site()->language()->_('Plugin %s doesn\'t have a version', [get_class($this)]));
                 
                 return $manifest['version'];
             }

--- a/Idno/Core/AsynchronousQueue.php
+++ b/Idno/Core/AsynchronousQueue.php
@@ -51,7 +51,7 @@ class AsynchronousQueue extends EventQueue
     function dispatch(\Idno\Entities\AsynchronousQueuedEvent &$event) {
         
         if (!defined("KNOWN_EVENT_QUEUE_SERVICE"))
-            throw new \RuntimeException("You can not dispatch asynchronous events from within the web app, please run the service");
+            throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("You can not dispatch asynchronous events from within the web app, please run the service"));
         
         try {
         
@@ -60,7 +60,7 @@ class AsynchronousQueue extends EventQueue
             if (!empty($event->runAsContext)) {
                 $user = \Idno\Entities\User::getByUUID($event->runAsContext);
                 if (empty($user))
-                    throw new \RuntimeException("Invalid user ($event->runAsContext) given for runAsContext, aborting");
+                    throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Invalid user (%s) given for runAsContext, aborting", [$event->runAsContext]));
 
                 \Idno\Core\Idno::site()->session()->logUserOn($user);
                 

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -133,7 +133,7 @@
                 // Check for secure sessions being delivered insecurely, and vis versa
                 /*if (isset($_SESSION['secure']) && $_SESSION['secure'] != Idno::site()->isSecure()) {
                     $message = Idno::site()->isSecure() ? 'Insecure session accessed securely' : 'Secure session accessed insecurely';
-                    throw new \Idno\Exceptions\SecurityException('Session funnybusiness: ' . $message);
+                    throw new \Idno\Exceptions\SecurityException(\Idno\Core\Idno::site()->language()->_('Session funnybusiness: ', [$message));
                 }*/
             }
 

--- a/Idno/Core/TokenProvider.php
+++ b/Idno/Core/TokenProvider.php
@@ -29,7 +29,7 @@
                 $bytes    = openssl_random_pseudo_bytes($length, $strength);
 
                 if (!$strength) {
-                    throw new \Idno\Exceptions\ConfigurationException("Token was generated using an a cryptographically weak algorithm, this probably means your version of OpenSSL is broken or very old.");
+                    throw new \Idno\Exceptions\ConfigurationException(\Idno\Core\Idno::site()->language()->_("Token was generated using an a cryptographically weak algorithm, this probably means your version of OpenSSL is broken or very old."));
                 }
 
                 return $bytes;

--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -446,7 +446,7 @@
                             if (class_exists('CURLFile')) {
                                 return new \CURLFile($file, $mime, $name);
                             } else {
-                                throw new \Idno\Exceptions\ConfigurationException("Your version of PHP doesn't support CURLFile.");
+                                throw new \Idno\Exceptions\ConfigurationException(\Idno\Core\Idno::site()->language()->_("Your version of PHP doesn't support CURLFile."));
                             }
                         }
 

--- a/Idno/Data/Mongo.php
+++ b/Idno/Data/Mongo.php
@@ -34,12 +34,8 @@
             function __construct($dbstring = null, $dbuser = null, $dbpass = null, $dbname = null, $dbauthsrc = null)
             {
                 // Check for library, and show a more friendly error message
-                if (!extension_loaded('mongodb')) {
-                    
-                    $message = "It looks like you don't have the new mongodb driver installed (<a href=\"https://secure.php.net/manual/en/set.mongodb.php\">https://secure.php.net/manual/en/set.mongodb.php</a>)\n\n";
-                    $message .= "Make sure you have it installed and configured, e.g. by running \"pecl install mongodb;\"";
-                    
-                    throw new \Idno\Exceptions\ConfigurationException($message);
+                if (!extension_loaded('mongodb')) {                    
+                    throw new \Idno\Exceptions\ConfigurationException(\Idno\Core\Idno::site()->language()->_("It looks like you don't have the new mongodb driver installed (<a href=\"https://secure.php.net/manual/en/set.mongodb.php\">https://secure.php.net/manual/en/set.mongodb.php</a>)\n\nMake sure you have it installed and configured, e.g. by running \"pecl install mongodb;\""));
                 }
                 
                 // Add library namespace

--- a/Idno/Entities/GenericDataItem.php
+++ b/Idno/Entities/GenericDataItem.php
@@ -40,7 +40,7 @@
             public function save($add_to_feed = false, $feed_verb = 'post')
             {
                 if (empty($this->datatype)) {
-                    throw new \RuntimeException("GenericDataItem classes must have a datatype label set.");
+                    throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("GenericDataItem classes must have a datatype label set."));
                 }
 
                 return parent::save($add_to_feed, $feed_verb);

--- a/Idno/Files/LocalFileSystem.php
+++ b/Idno/Files/LocalFileSystem.php
@@ -84,10 +84,10 @@
                         }
 
                         if (!@copy($file_path, $upload_file)) {
-                            throw new \RuntimeException("There was a problem storing the file data.");
+                            throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("There was a problem storing the file data."));
                         }
                         if (!@file_put_contents($data_file, $metadata)) {
-                                throw new \RuntimeException("There was a problem saving the file's metadata");
+                                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("There was a problem saving the file's metadata"));
                         }
 
                         return $id;

--- a/Idno/Pages/Account/Settings/Following/Bookmarklet.php
+++ b/Idno/Pages/Account/Settings/Following/Bookmarklet.php
@@ -34,7 +34,7 @@
                             $hcard = $this->removeDuplicateProfiles($hcard);
 
                             if (!count($hcard)) {
-                                //throw new \RuntimeException("Sorry, could not find any users on that page, perhaps they need to mark up their profile in <a href=\"http://microformats.org/wiki/microformats-2\">Microformats</a>?"); // TODO: Add a manual way to add the user
+                                //throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Sorry, could not find any users on that page, perhaps they need to mark up their profile in <a href=\"http://microformats.org/wiki/microformats-2\">Microformats</a>?")); // TODO: Add a manual way to add the user
 
                                 // No entry could be found, so lets fake one and allow manual entry
                                 $hcard[] = [
@@ -61,9 +61,9 @@
                             $t->drawPage();
                         }
                     } else
-                        throw new \RuntimeException("Sorry, there was a problem parsing the page!");
+                        throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Sorry, there was a problem parsing the page!"));
                 } else
-                    throw new \RuntimeException("Sorry, $u could not be retrieved!");
+                    throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Sorry, %s could not be retrieved!", [$u]));
 
                 // forward back
                 $this->forward($_SERVER['HTTP_REFERER']);
@@ -146,7 +146,7 @@
                             // TODO: Get a profile URL - get it from passed photo variable, upload to local and treat as avatar.
 
                             if (!$new_user->save())
-                                throw new \Exception ("There was a problem saving the new remote user.");
+                                throw new \Exception (\Idno\Core\Idno::site()->language()->_("There was a problem saving the new remote user."));
 
                         }
                     } else
@@ -180,9 +180,9 @@
                             \Idno\Core\Idno::site()->session()->addErrorMessage('You\'re already following ' . $this->getInput('name'));
                         }
                     } else
-                        throw new \RuntimeException('Sorry, that user doesn\'t exist!');
+                        throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_('Sorry, that user doesn\'t exist!'));
                 } else
-                    throw new \RuntimeException("No UUID, please try that again!");
+                    throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("No UUID, please try that again!"));
             }
 
         }

--- a/Idno/Pages/Admin/Statistics.php
+++ b/Idno/Pages/Admin/Statistics.php
@@ -11,7 +11,7 @@ namespace Idno\Pages\Admin {
             $stats = \Idno\Core\Statistics::gather($report);
             
             if (empty($stats) || !is_array($stats))
-                throw new \RuntimeException("Something went wrong, either no statistics were returned or it wasn't in the correct format.");
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Something went wrong, either no statistics were returned or it wasn't in the correct format."));
 
             if ($this->xhr) {
 

--- a/Idno/Pages/Search/User.php
+++ b/Idno/Pages/Search/User.php
@@ -18,11 +18,11 @@ namespace Idno\Pages\Search {
             
             // Sanitise
             if ($sort != 'created' && $sort != 'name') {
-                throw new \RuntimeException("Invalid sort type $sort");
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Invalid sort type %s", [$sort]));
             }
             
             if ($order != 'asc' && $order != 'desc') {
-                throw new \RuntimeException("Invalid sort order $order");
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Invalid sort order %s", [$order]));
             }
             
  	    

--- a/Idno/Pages/Service/Security/CSRFToken.php
+++ b/Idno/Pages/Service/Security/CSRFToken.php
@@ -11,7 +11,7 @@ namespace Idno\Pages\Service\Security {
             
             $action = $this->getInput('url');
             if (empty($action))
-                throw new \RuntimeException("URL missing");
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("URL missing"));
             
             \Idno\Core\Idno::site()->logging()->debug("Updating token for $action");
             

--- a/Idno/Pages/Service/Web/ImageProxy.php
+++ b/Idno/Pages/Service/Web/ImageProxy.php
@@ -70,11 +70,11 @@ namespace Idno\Pages\Service\Web {
                         exit;
 
                     } else {
-                        throw new \RuntimeException("There was a problem decoding the url");
+                        throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("There was a problem decoding the url"));
                     }
                     
                 } else {
-                    throw new \RuntimeException("No url specified");
+                    throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("No url specified"));
                 }
                 
             } catch (\Exception $e) {
@@ -215,7 +215,7 @@ namespace Idno\Pages\Service\Web {
                                     \Idno\Core\Idno::site()->logging()->debug("Transforming image: Maxsize=$maxsize, Square=" . var_export($square, true));
                                     
                                     $tmp = \Idno\Entities\File::writeTmpFile($result['content']);
-                                    if (!$tmp) throw new \RuntimeException("Could not save temporary file");
+                                    if (!$tmp) throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Could not save temporary file"));
                                     
                                     if (!\Idno\Entities\File::isSVG($tmp, $tmp)) {
                                     
@@ -246,7 +246,7 @@ namespace Idno\Pages\Service\Web {
                         }
                             
                         $size = strlen($content);
-                        if ($size == 0) throw new \RuntimeException("Looks like something went wrong, image was zero bytes big!");
+                        if ($size == 0) throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Looks like something went wrong, image was zero bytes big!"));
                         \Idno\Core\Idno::site()->logging()->debug("Storing " . $size . ' bytes of content.');
                         \Idno\Core\Idno::site()->logging()->debug('Meta: ' . print_r($meta, true));
                         
@@ -261,11 +261,11 @@ namespace Idno\Pages\Service\Web {
                         exit;
                         
                     } else {
-                        throw new \RuntimeException("There was a problem decoding the url");
+                        throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("There was a problem decoding the url"));
                     }
                     
                 } else {
-                    throw new \RuntimeException("No url specified");
+                    throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("No url specified"));
                 }
             
             } catch (\Exception $e) {

--- a/Idno/Pages/Service/Web/UrlUnfurl.php
+++ b/Idno/Pages/Service/Web/UrlUnfurl.php
@@ -15,7 +15,7 @@ namespace Idno\Pages\Service\Web {
             $url = trim($this->getInput('url'));
 
             if (empty($url))
-                throw new \RuntimeException("You need to specify a working URL");
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("You need to specify a working URL"));
 
             // Try and get UnfurledURL entity
             if ($object = \Idno\Entities\UnfurledUrl::getBySourceURL($url)) {
@@ -41,7 +41,7 @@ namespace Idno\Pages\Service\Web {
             $forcenew = $this->getInput('forcenew', false);
 
             if (empty($url))
-                throw new \RuntimeException("You need to specify a working URL");
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("You need to specify a working URL"));
 
             // Try and get UnfurledURL entity
             $object = \Idno\Entities\UnfurledUrl::getBySourceURL($url);
@@ -63,7 +63,7 @@ namespace Idno\Pages\Service\Web {
             $result = $object->unfurl($url);
             
             if (!$result)
-                throw new \RuntimeException("Url $url could not be unfurled");
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Url %s could not be unfurled", [$url]));
 
             $object->save();
             

--- a/Idno/Stats/Timer.php
+++ b/Idno/Stats/Timer.php
@@ -33,7 +33,7 @@ namespace Idno\Stats {
                 return $now - self::$timers[$timer];
             }
             
-            throw new \RuntimeException("Timer $timer has not been started.");
+            throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Timer %s has not been started.", [$timer]));
         }
         
         /**

--- a/Idno/Stats/TotalTimer.php
+++ b/Idno/Stats/TotalTimer.php
@@ -38,7 +38,7 @@ namespace Idno\Stats {
                 return static::$timerTotals[$timer];
             }
             
-            throw new \RuntimeException("Timer $timer has not been started.");
+            throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Timer %s has not been started.", [$timer]));
         }
 
     }


### PR DESCRIPTION
## Here's what I fixed or added:

Added translation hook around (most) thrown exceptions

## Here's why I did it:

Errors should be available in all languages