### PR TITLE
Make getAnyRecord consistent with mongo

### DIFF
--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -342,7 +342,7 @@
                 try {
                     $collection = $this->sanitiseCollection($collection);
 
-                    $statement = $this->client->prepare("select {$collection}.* from " . $collection . " limit 1");
+                    $statement = $this->client->prepare("select {$collection}.* from " . $collection . " order by created desc limit 1");
                     if ($statement->execute()) {
                         if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
                             return json_decode($row['contents'], true);

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -285,7 +285,7 @@
                 try {
                     $collection = $this->sanitiseCollection($collection);
 
-                    $statement = $this->client->prepare("select {$collection}.* from " . $collection . " limit 1");
+                    $statement = $this->client->prepare("select {$collection}.* from " . $collection . " order by {$collection}.created desc limit 1");
                     if ($statement->execute()) {
                         if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
                             return json_decode($row['contents'], true);

--- a/Idno/Data/Sqlite3.php
+++ b/Idno/Data/Sqlite3.php
@@ -311,7 +311,7 @@
                 try {
                     $collection = $this->sanitiseCollection($collection);
 
-                    $statement = $this->client->prepare("select {$collection}.* from " . $collection . " limit 1");
+                    $statement = $this->client->prepare("select {$collection}.* from " . $collection . " {$collection}.`created` desc limit 1");
                     if ($statement->execute()) {
                         if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
                             return json_decode($row['contents'], true);

--- a/Tests/Data/ConfigTest.php
+++ b/Tests/Data/ConfigTest.php
@@ -7,6 +7,13 @@ namespace Tests\Data {
      */
     class ConfigTest extends \Tests\KnownTestCase  {
         
+        /**
+         * Like the Highlander, there can be only one.
+         */
+        public function testMultipleConfig() {
+            $configs = \Idno\Core\Idno::site()->db()->getRecords([], [], 10, 0, 'config');
+            $this->assertCount(1, $configs);
+        }
         
         /**
          * Ensure that config collection has been correctly configured.


### PR DESCRIPTION
## Here's what I fixed or added:

Added ordering to the sql query in getAnyRecord to return the latest matching

## Here's why I did it:

In cases of multiple entries this caused inconsistent results