### PR TITLE
Config diagnostics and entity instantiation error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-
+dist: precise
 php:
  - 5.6
  - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: precise
+
 php:
  - 5.6
  - 7.0

--- a/Idno/Core/DataConcierge.php
+++ b/Idno/Core/DataConcierge.php
@@ -145,13 +145,17 @@
              */
             function rowToEntity($row)
             {
-                if (!empty($row['entity_subtype'])) { 
-                    if (class_exists($row['entity_subtype'])) {
-                        $object = new $row['entity_subtype']();
-                        $object->loadFromArray($row);
+                try {
+                    if (!empty($row['entity_subtype'])) { 
+                        if (class_exists($row['entity_subtype'])) {
+                            $object = new $row['entity_subtype']();
+                            $object->loadFromArray($row);
 
-                        return $object;
-                    } 
+                            return $object;
+                        } 
+                    }
+                } catch (\Error $e) {
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                 }
 
                 return false;

--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -106,6 +106,14 @@
                     }
                 }
                 $basics['report']['php-extensions']['message'] = trim($basics['report']['php-extensions']['message'], ' ,') . ' missing.';
+                
+                // Check for configuration bug
+                $configs = \Idno\Core\Idno::site()->db()->getRecords([], [], 10, 0, 'config');
+                if (count($configs) != 1) {
+                    $basics['report']['configuration']['message'] = count($configs) . ' Config entries found in database, there should be only one!';
+                    $basics['report']['configuration']['status'] = 'Warning';
+                    $basics['status'] = 'Failure';
+                }
 
                 // Check upload directory (if set)
                 $basics['report']['upload-path'] = ['status' => 'Ok', 'message' => ''];


### PR DESCRIPTION
## Here's what I fixed or added:

* Diagnostics entry to show the multiple config bug
* PHP7 support to catch fatal errors during object instantiation

## Here's why I did it:

* Wanted to try and get down to the why of why some domains had multiple configs
* Handle left over Entity in old unit tests
