### PR TITLE
Helper function to retrieve $_FILES details

### DIFF
--- a/Idno/Core/Input.php
+++ b/Idno/Core/Input.php
@@ -44,6 +44,31 @@
 
                 return null;
             }
+            
+            /**
+             * Retrieve files from input.
+             * Retrieve a formatted files array from input, if multiple files are found, this will be turned into
+             * a sensible structure.
+             * @param type $name
+             */
+            public static function getFiles($name) {
+                
+                $files = $_FILES[$name];
+                if (!is_array($files['name']))
+                    return $files; // Short circuit if there's only one entry for a name
+
+                // Normalize file array, 
+                // HT: https://gist.github.com/umidjons/9893735
+                $_files = [];
+                $_files_count = count($files['name']);
+                $_files_keys = array_keys($files);
+                
+                for ($i = 0; $i < $_files_count; $i++)
+                    foreach ($_files_keys as $key)
+                        $_files[$i][$key] = $files[$key][$i];
+                
+                return $_files;
+            }
 
         }
 


### PR DESCRIPTION
## Here's what I fixed or added:

This function normalises the array to a sensible structure, so instead of:

```
$_FILES['file'] = [
	'name' => [
		'foo',
		'bar'
	],
	'size' => [
		123,
		456
	]
]
```

You get

```
$_FILES['file'] = [
	0 => [
		'name' => 'foo',
		'size' => 123
	],
	1 => [
		'name' => 'bar',
		'size' => 456
	]
]
```

## Here's why I did it:

Helper function based on comments from #1991