### PR TITLE
Open unfurled urls in a new window

### DIFF
--- a/templates/default/entity/UnfurledUrl.tpl.php
+++ b/templates/default/entity/UnfurledUrl.tpl.php
@@ -27,9 +27,9 @@ if (!empty($object->data['og']['og:image']))
 <div class="row unfurled-url" id="<?= $vars['id']; ?>" data-url="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>">
     <div class="basics">
         <?php if (!empty($image)) { ?>
-            <div class="image"><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><img src="<?= $this->getProxiedImageUrl($image); ?>"/></a></div>
+            <div class="image"><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>" target="_blank"><img src="<?= $this->getProxiedImageUrl($image); ?>"/></a></div>
         <?php } ?>
-        <h3><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlentities($title, ENT_QUOTES, 'UTF-8'); ?></a></h3>
+        <h3><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>" target="_blank"><?= htmlentities($title, ENT_QUOTES, 'UTF-8'); ?></a></h3>
         <?php if (!empty($description)) { ?><blockquote class="description"><?= htmlentities($description, ENT_QUOTES, 'UTF-8'); ?></blockquote><?php } ?>
 
         <!--<div class="byline"><a href="<?= htmlentities($object->source_url, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlentities(parse_url($object->source_url, PHP_URL_HOST), ENT_QUOTES, 'UTF-8'); ?></a></div>-->


### PR DESCRIPTION
## Here's what I fixed or added:

Adding target="_blank" to unfurl urls

## Here's why I did it:

It happened a couple of times that I accidently clicked on an unfurled URL while editing a post, causing me to navigate away and losing the post.

Simplest solution is to open unfurled links in a blank tab/new window.

