### PR TITLE
Handle status messages of '0'

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -97,9 +97,9 @@
                 if (!empty($name)) {
                     $value = null;
                     $request = \Idno\Core\Input::getInput($name, $default, $filter);
-                    if (!empty($request)) {
+                    if ($request !== null) {
                         $value = $request;
-                    } else if (!empty($this->data[$name])) {
+                    } else if (isset($this->data[$name])) {
                         $value = $this->data[$name];
                     }
                     if (($value===null) && ($default!==null))

--- a/Idno/Core/Input.php
+++ b/Idno/Core/Input.php
@@ -26,7 +26,7 @@
             {
                 if (!empty($name)) {
                     $value = null;
-                    if (!empty($_REQUEST[$name])) {
+                    if (isset($_REQUEST[$name])) {
                         $value = $_REQUEST[$name];
                     }
                     if (($value===null) && ($default!==null))

--- a/IdnoPlugins/Status/Status.php
+++ b/IdnoPlugins/Status/Status.php
@@ -88,7 +88,7 @@
                 } else {
                     $new = false;
                 }
-                $body      = \Idno\Core\Idno::site()->currentPage()->getInput('body');
+                $body      = \Idno\Core\Idno::site()->currentPage()->getInput('body'); 
                 $inreplyto = \Idno\Core\Idno::site()->currentPage()->getInput('inreplyto');
                 $tags      = \Idno\Core\Idno::site()->currentPage()->getInput('tags');
                 $access    = \Idno\Core\Idno::site()->currentPage()->getInput('access');
@@ -99,7 +99,7 @@
                     }
                 }
 
-                if (!empty($body)) {
+                if (!empty($body) || ('0' === $body)) {
                     $this->body      = $body;
                     $this->inreplyto = $inreplyto;
                     $this->tags      = $tags;


### PR DESCRIPTION
## Here's what I fixed or added:
* Fixing input functions to better transcribe certain inputs ('0', ' ', etc) as their correct values
* Adding exception for '0' body 

## Here's why I did it:
* Fixing status edge case
* Fixing Input functions to handle values that would erroneously be evaluated as false by empty() 