### PR TITLE
Moving configuration to its own directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Idno/.idea/.name
 /.htaccess
 /doc/output/
 /Uploads/*
+/configuration/
 
 /.DS_Store
 /*/.DS_Store

--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -159,8 +159,8 @@
                     $this->ini_config = array();
                     
                     foreach ([
-                        $this->path,
-                        $this->path . '/configuration'
+                        $this->path,                    // Check old location (Warning: @deprecated and will be removed in future installs)
+                        $this->path . '/configuration'  // Check for configuration in the new location
                     ] as $path) {
                         
                         if ($config = @parse_ini_file($path . '/config.ini', true)) {

--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -155,30 +155,38 @@
             function loadIniFiles()
             {
                 if (empty($this->ini_config)) {
+                    
                     $this->ini_config = array();
-                    if ($config = @parse_ini_file($this->path . '/config.ini', true)) {
-                        if (!empty($config)) {
-                            $this->default_config = false;
-                            $this->ini_config     = array_replace_recursive($config, $this->ini_config);
+                    
+                    foreach ([
+                        $this->path,
+                        $this->path . '/configuration'
+                    ] as $path) {
+                        
+                        if ($config = @parse_ini_file($path . '/config.ini', true)) {
+                            if (!empty($config)) {
+                                $this->default_config = false;
+                                $this->ini_config     = array_replace_recursive($config, $this->ini_config);
+                            }
                         }
-                    }
-                    if (file_exists($this->path . '/config.json')) {
-                        if ($json = file_get_contents($this->path . '/config.json')) {
-                            if ($json = json_decode($json, true)) {
-                                if (!empty($json)) {
-                                    $this->default_config = false;
-                                    $this->ini_config     = array_replace_recursive($this->ini_config, $json);
+                        if (file_exists($path . '/config.json')) {
+                            if ($json = file_get_contents($path . '/config.json')) {
+                                if ($json = json_decode($json, true)) {
+                                    if (!empty($json)) {
+                                        $this->default_config = false;
+                                        $this->ini_config     = array_replace_recursive($this->ini_config, $json);
+                                    }
                                 }
                             }
                         }
-                    }
 
-                    // Per domain configuration
-                    if ($config = @parse_ini_file($this->path . '/' . $this->host . '.ini', true)) {
-                        unset($this->ini_config['initial_plugins']);  // Don't let plugin settings be merged
-                        unset($this->ini_config['alwaysplugins']);
-                        unset($this->ini_config['antiplugins']);
-                        $this->ini_config = array_replace_recursive($this->ini_config, $config);
+                        // Per domain configuration
+                        if ($config = @parse_ini_file($path . '/' . $this->host . '.ini', true)) {
+                            unset($this->ini_config['initial_plugins']);  // Don't let plugin settings be merged
+                            unset($this->ini_config['alwaysplugins']);
+                            unset($this->ini_config['antiplugins']);
+                            $this->ini_config = array_replace_recursive($this->ini_config, $config);
+                        }
                     }
 
                     // Check environment variables and set as appropriate

--- a/configuration/.htaccess
+++ b/configuration/.htaccess
@@ -1,0 +1,1 @@
+deny from all

--- a/nginx.conf
+++ b/nginx.conf
@@ -84,5 +84,9 @@ http {
     location ~* \.(xml|ini)$ {
       deny all;
     }
+
+    location /configuration/ {
+      deny all;
+    }
   }
 }

--- a/warmup/settings.php
+++ b/warmup/settings.php
@@ -160,7 +160,7 @@ END;
             } else {
                 @rename(dirname(dirname(__FILE__)) . '/htaccess.dist', dirname(dirname(__FILE__)) . '/.htaccess');
             }
-            if ($fp = @fopen('../config.ini', 'w')) {
+            if ($fp = @fopen(dirname(dirname(__FILE__)). '/configuration/config.ini', 'w')) {
                 fwrite($fp, $ini_file);
                 fclose($fp);
                 header('Location: ../begin/register?set_name='.urlencode($site_title));

--- a/warmup/settings.php
+++ b/warmup/settings.php
@@ -100,10 +100,15 @@
     }
 
     if ($ok) {
-        if (file_exists('../config.ini')) {
-            if ($config = @parse_ini_file('../config.ini')) {
-                header('Location: ../begin/register?set_name=' . urlencode($site_title));
-                exit;
+        foreach ([
+            dirname(dirname(__FILE__)) . '/config.ini',
+            dirname(dirname(__FILE__)) . '/configuration/config.ini'
+        ] as $location) {
+            if (file_exists($location)) {
+                if ($config = @parse_ini_file($location)) {
+                    header('Location: ../begin/register?set_name=' . urlencode($site_title));
+                    exit;
+                }
             }
         }
     }

--- a/warmup/top.php
+++ b/warmup/top.php
@@ -1,9 +1,14 @@
 <?php
 
-    if (file_exists('../config.ini')) {
-        if ($config = @parse_ini_file('../config.ini')) {
-            if (!empty($config)) {
-                header('Location: ../'); exit;
+    foreach ([
+        dirname(dirname(__FILE__)) . '/config.ini',
+        dirname(dirname(__FILE__)) . '/configuration/config.ini'
+    ] as $location) {
+        if (file_exists($location)) {
+            if ($config = @parse_ini_file($location)) {
+                if (!empty($config)) {
+                    header('Location: ../'); exit;
+                }
             }
         }
     }


### PR DESCRIPTION
## Here's what I fixed or added:

Originally config files were scattered around the root. This patch attempts to also load configurations from a configuration directory.

## Here's why I did it:

As well as tidying things up it also means that the *whole* root doesn't need to be web server writable for automatic configuration (which will help us with things like #2060 ). It also helps with future modularisation. 
