### PR TITLE
Providing a mechanism to specify alternative shells

### DIFF
--- a/Idno/Core/Bonita/Templates.php
+++ b/Idno/Core/Bonita/Templates.php
@@ -168,11 +168,12 @@ namespace Idno\Core\Bonita {
         /**
          * Draws the shell template
          * @param $echo If set to true (by default), echoes the page; otherwise returns it
+         * @param $shell Optional override of the page shell template to be used
          */
-        function drawPage($echo = true) {
+        function drawPage($echo = true, $shell = 'shell') {
             if ($echo) {
 
-                $content = $this->draw('shell');
+                $content = $this->draw($shell);
                 header('Content-Length: ' . strlen($content));
 
                 // Break long output to avoid an Apache performance bug
@@ -183,7 +184,7 @@ namespace Idno\Core\Bonita {
 
                 exit;
             } else
-                return $this->draw('shell');
+                return $this->draw($shell);
         }
 
         /**

--- a/Idno/Core/Template.php
+++ b/Idno/Core/Template.php
@@ -97,9 +97,10 @@
             /**
              * Draws the page shell.
              * @param bool $echo
+             * @param $shell Optional override of the page shell template to be used
              * @return false|string
              */
-            function drawPage($echo = true)
+            function drawPage($echo = true, $shell = 'shell')
             {
 
                 // Get messages and flush session
@@ -108,7 +109,7 @@
                 // End session BEFORE we output any data
                 session_write_close();
 
-                return parent::drawPage($echo);
+                return parent::drawPage($echo, $shell);
 
             }
 


### PR DESCRIPTION
## Here's what I fixed or added:

Adding a mechanism to use alternative page shells.

## Here's why I did it:

Allow pages to render alternative page shells without switching out to alternative template hierarchies 

Ref #1846 