### PR TITLE
Require Gettext extension during installation

### DIFF
--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -196,7 +196,8 @@ namespace Idno\Core {
                 'reflection',
                 'session',
                 'simplexml',
-                'openssl'
+                'openssl',
+                'gettext',
             ];
         }
 


### PR DESCRIPTION
## Here's what I fixed or added:

Warn about missing gettext extension

## Here's why I did it:

While we don't want Known to crash when missing, we want to say gettext is a requirement