### PR TITLE
Unify tagging display

### DIFF
--- a/IdnoPlugins/Checkin/templates/default/entity/Checkin.tpl.php
+++ b/IdnoPlugins/Checkin/templates/default/entity/Checkin.tpl.php
@@ -31,9 +31,9 @@
             echo $this->autop($this->parseURLs($this->parseHashtags($object->body)));
         }
 
-        if (!empty($object->tags)) {?>
-            <p class="tag-row"><i class="icon-tag"></i> <?= $this->parseHashtags($object->tags) ?></p>
-        <?php } ?>
+        if (!empty($object->tags)) {
+            echo $this->__(['tags' => $object->tags])->draw('forms/output/tags');
+        } ?>
     </div>
 
 </div>

--- a/IdnoPlugins/Like/templates/default/entity/Like.tpl.php
+++ b/IdnoPlugins/Like/templates/default/entity/Like.tpl.php
@@ -42,10 +42,11 @@
         
         }
         
+        
+        
         if (!empty($vars['object']->tags)) {
-        ?>
-            <p class="tag-row"><i class="icon-tag"></i><?=$this->parseURLs($this->parseHashtags(htmlentities(strip_tags($vars['object']->tags))))?></p>
-        <?php
+        
+            echo $this->__(['tags' => $vars['object']->tags])->draw('forms/output/tags');
         }
 
     ?>

--- a/IdnoPlugins/Media/templates/default/entity/Media.tpl.php
+++ b/IdnoPlugins/Media/templates/default/entity/Media.tpl.php
@@ -7,6 +7,10 @@
     } else {
         $rel = '';
     }
+    $tags = "";
+    if (!empty($vars['object']->tags)) {
+        $tags = $this->__(['tags' => $vars['object']->tags])->draw('forms/output/tags');
+    }
     if (empty($vars['feed_view'])) {
         ?>
         <div class="audio-play-wrapper"><a href="#" id="player<?=$player_id?>" class="audio-play-button"><i class="fa fa-play"></i></a></div>
@@ -78,12 +82,6 @@
     }
 ?>
 <div class="e-content">
-<?= $this->autop($this->parseHashtags($this->parseURLs($vars['object']->body, $rel))) ?>
+<?= $this->autop($this->parseHashtags($this->parseURLs($vars['object']->body, $rel))) . $tags; ?>
 </div>
-<?php
-    if (!empty($vars['object']->tags)) {
-?>
 
-<p class="tag-row"><i class="icon-tag"></i> <?=$this->parseHashtags($vars['object']->tags)?></p>
-
-<?php }

--- a/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
+++ b/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
@@ -12,8 +12,11 @@
     } else {
         $rel = '';
     }
+    
+    $tags = "";
     if (!empty($vars['object']->tags)) {
-        $vars['object']->body .= '<p class="tag-row"><i class="icon-tag"></i>' . $vars['object']->tags . '</p>';
+        $tags = $this->__(['tags' => $vars['object']->tags])->draw('forms/output/tags');
+        
     }
     if (empty($vars['feed_view']) && $vars['object']->getTitle() && $vars['object']->getTitle() != 'Untitled') {
         ?>
@@ -77,6 +80,6 @@
             $cnt ++;
         }
     } ?>
-    <?= $this->autop($this->parseHashtags($this->parseURLs($vars['object']->body, $rel))) ?>
+    <?= $this->autop($this->parseHashtags($this->parseURLs($vars['object']->body, $rel))) . $tags ?>
 
 </div>

--- a/IdnoPlugins/Status/templates/default/entity/Status.tpl.php
+++ b/IdnoPlugins/Status/templates/default/entity/Status.tpl.php
@@ -7,10 +7,7 @@
         $rel = '';
     }*/
     if (!empty($vars['object']->tags)) {
-        if (is_array($vars['object']->tags))
-            $tags = '<p class="tag-row"><i class="icon-tag"></i>' . implode(' ', $vars['object']->tags) . '</p>';
-        else
-        /*$vars['object']->body .= */ $tags = '<p class="tag-row"><i class="icon-tag"></i>' . $vars['object']->tags . '</p>';
+        $tags = $this->__(['tags' => $vars['object']->tags])->draw('forms/output/tags');
     }
 
 ?>

--- a/IdnoPlugins/Text/templates/default/entity/Entry.tpl.php
+++ b/IdnoPlugins/Text/templates/default/entity/Entry.tpl.php
@@ -4,9 +4,11 @@
     } else {
         $rel = '';
     }
+    $tags = "";
     if (!empty($vars['object']->tags)) {
-        $tags = is_array($vars['object']->tags) ? implode(', ' , $vars['object']->tags) : $vars['object']->tags;
-        $vars['object']->body .= '<p class="tag-row"><i class="icon-tag"></i>' . $tags . '</p>';
+//        $tags = is_array($vars['object']->tags) ? implode(', ' , $vars['object']->tags) : $vars['object']->tags;
+//        $vars['object']->body .= '<p class="tag-row"><i class="icon-tag"></i>' . $tags . '</p>';
+        $tags = $this->__(['tags' => $vars['object']->tags])->draw('forms/output/tags');
     }
 ?>
 
@@ -39,7 +41,7 @@
 <div class="e-content entry-content">
 <?php
 
-    echo $this->__(['value' => $vars['object']->body, 'object' => $vars['object'], 'rel' => $rel])->draw('forms/output/richtext');
+    echo $this->__(['value' => $vars['object']->body, 'object' => $vars['object'], 'rel' => $rel])->draw('forms/output/richtext') . $tags;
 
 ?>
 </div>

--- a/templates/default/forms/output/tags.tpl.php
+++ b/templates/default/forms/output/tags.tpl.php
@@ -1,0 +1,19 @@
+<?php
+if (!empty($vars['tags'])) {
+    if (is_array($vars['tags'])) {
+        ?>
+        <p class="tag-row">
+            <i class="fa fa-tag"></i>
+            <?php foreach ($vars['tags'] as $tag) { ?>
+            <a href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL(); ?>tag/<?= urlencode($tag); ?>" class="p-category" rel="tag"><?= $tag ?></a>
+            <?php } ?>
+        </p> 
+        <?php
+    } else {
+        ?>
+        <i class="fa fa-tag"></i><a href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL(); ?>tag/<?= urlencode($vars['tags']); ?>" class="p-category" rel="tag"><?= $vars['tags'] ?></a>
+        <?php
+    }
+}
+
+unset($this->vars['tags']);


### PR DESCRIPTION
## Here's what I fixed or added:

* Added a common output view for (deprecated) tags
* Handle both string and array tags
* Updated core plugins

## Here's why I did it:

While Known's interface uses #hashtags rather than explicit tags, some clients use them, and they weren't being drawn very well at all