### PR TITLE
Adding .AppleDouble to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.AppleDouble
 .DS_Store
 .idea/*
 Idno/.idea/.name


### PR DESCRIPTION
## Here's what I fixed or added:

Adding .AppleDouble to the gitignore.

## Here's why I did it:

Because apple products chuck these _everywhere_ and it's really fracking annoying. 