### PR TITLE
Fixing mongo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 # Configure different DB environments
 env:
   - DB=mysql
-#  - DB=mongo
+  - DB=mongo
   - DB=sqlite3
   - DB=pgsql
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
 matrix:
     allow_failures:
         - php: 5.6
-        - php: 7.2
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,13 @@ before_script:
 
 services:
   - mongodb
+  
+addons:
+  apt:
+    sources:
+      - mongodb-3.4-precise
+    packages:
+      - mongodb-org-server
 
 after_failure:
   - sudo cat $TRAVIS_BUILD_DIR/apache-error.log

--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -100,7 +100,7 @@
              */
             function load()
             {
-                /*$config = Idno::site()->db()->getRecord('config', 'config');*/ // MP: Removed as not compatible with Mongo. If hard coded IDs are absolutely necessary, find another way.
+                /*$config = Idno::site()->db()->getRecord('config', 'config');*/ // MP: Removed as not compatible with Mongo. If hard coded IDs are absolutely necessary, another way needs to be found.
                 if (empty($config)) $config = \Idno\Core\Idno::site()->db()->getAnyRecord('config');
                 if ($config) {
                     $this->default_config = false;
@@ -241,7 +241,7 @@
                 unset($array['bypass_fulltext_search']);
                 unset($array['filter_shell']);
 
-                /* $array['_id'] = 'config'; // Hardcode configuration ID */ // MP: Removed as not compatible with Mongo. If hard coded IDs are absolutely necessary, find another way.
+                /* $array['_id'] = 'config'; // Hardcode configuration ID */ // MP: Removed as not compatible with Mongo. If hard coded IDs are absolutely necessary, another way needs to be found.
 
                 if (\Idno\Core\Idno::site()->db()->saveRecord('config', $array)) {
                     $this->init();

--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -100,7 +100,7 @@
              */
             function load()
             {
-                /*$config = Idno::site()->db()->getRecord('config', 'config');*/
+                /*$config = Idno::site()->db()->getRecord('config', 'config');*/ // MP: Removed as not compatible with Mongo. If hard coded IDs are absolutely necessary, find another way.
                 if (empty($config)) $config = \Idno\Core\Idno::site()->db()->getAnyRecord('config');
                 if ($config) {
                     $this->default_config = false;
@@ -241,7 +241,7 @@
                 unset($array['bypass_fulltext_search']);
                 unset($array['filter_shell']);
 
-                /* $array['_id'] = 'config'; // Hardcode configuration ID */
+                /* $array['_id'] = 'config'; // Hardcode configuration ID */ // MP: Removed as not compatible with Mongo. If hard coded IDs are absolutely necessary, find another way.
 
                 if (\Idno\Core\Idno::site()->db()->saveRecord('config', $array)) {
                     $this->init();

--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -241,7 +241,7 @@
                 unset($array['bypass_fulltext_search']);
                 unset($array['filter_shell']);
 
-                $array['_id'] = 'config'; // Hardcode configuration ID
+                /* $array['_id'] = 'config'; // Hardcode configuration ID */
 
                 if (\Idno\Core\Idno::site()->db()->saveRecord('config', $array)) {
                     $this->init();

--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -100,8 +100,8 @@
              */
             function load()
             {
-                $config = Idno::site()->db()->getRecord('config', 'config');
-                if (!$config) $config = \Idno\Core\Idno::site()->db()->getAnyRecord('config');
+                /*$config = Idno::site()->db()->getRecord('config', 'config');*/
+                if (empty($config)) $config = \Idno\Core\Idno::site()->db()->getAnyRecord('config');
                 if ($config) {
                     $this->default_config = false;
                     unset($config['dbname']); // Ensure we don't accidentally load protected data from db

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -64,8 +64,8 @@
                     'title' => Idno::site()->config()->getTitle(),
                     
                     // Include some version info in case we change the export format
-                    'version' => Idno::site()->getVersion(),
-                    'build' => Idno::site()->getMachineVersion(),
+                    'version' => \Idno\Core\Version::version(),
+                    'build' => \Idno\Core\Version::build(),
                 );
 
                 file_put_contents($dir . $name . DIRECTORY_SEPARATOR . 'known.json', json_encode($config));

--- a/Idno/Entities/RemoteUser.php
+++ b/Idno/Entities/RemoteUser.php
@@ -9,7 +9,7 @@
 
     namespace Idno\Entities {
 
-        class RemoteUser extends \Idno\Entities\User implements \JsonSerializable
+        class RemoteUser extends \Idno\Entities\User 
         {
 
             public function save($add_to_feed = false, $feed_verb = 'post')

--- a/Idno/Pages/Account/Settings/Feedback.php
+++ b/Idno/Pages/Account/Settings/Feedback.php
@@ -32,7 +32,7 @@
                     $results    = Webservice::post('https://withknown.com/vendor-services/feedback/', array(
                         'url'     => \Idno\Core\Idno::site()->config()->getURL(),
                         'title'   => \Idno\Core\Idno::site()->config()->getTitle(),
-                        'version' => \Idno\Core\Idno::site()->getVersion(),
+                        'version' => \Idno\Core\Version::version(),
                         'public'  => \Idno\Core\Idno::site()->config()->isPublicSite(),
                         'hub'     => \Idno\Core\Idno::site()->config()->known_hub,
                         'email'   => $email,

--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -126,7 +126,7 @@
                 $basics['report']['php-extensions']['message'] = trim($basics['report']['php-extensions']['message'], ' ,') . ' missing.';
                 
                 // Check for configuration bug
-                $configs = \Idno\Core\Idno::site()->db()->getRecords([], [], 10, 0, 'config');
+                $configs = \Idno\Core\Idno::site()->db()->getRecords([], [], PHP_INT_MAX, 0, 'config');
                 if (count($configs) != 1) {
                     $basics['report']['configuration']['message'] = count($configs) . ' Config entries found in database, there should be only one!';
                     $basics['report']['configuration']['status'] = 'Warning';

--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -128,7 +128,7 @@
                 // Check for configuration bug
                 $configs = \Idno\Core\Idno::site()->db()->getRecords([], [], PHP_INT_MAX, 0, 'config');
                 if (count($configs) != 1) {
-                    $basics['report']['configuration']['message'] = count($configs) . ' Config entries found in database, there should be only one!';
+                    $basics['report']['configuration']['message'] = count($configs) . ' Config entries found in database, there should be only one. This is almost certainly not a cause for concern.';
                     $basics['report']['configuration']['status'] = 'Warning';
                     $basics['status'] = 'Failure';
                 }


### PR DESCRIPTION
## Here's what I fixed or added:

* Reverting the breaking change introduced in an earlier commit
* Allow Mongo build tests
* Tidied up some other cruft

## Here's why I did it:

While I understand the reason for hard coding an ID for the config object (which I understand was a workaround for the previously introduced multiple config bug - now fixed) using such IDs is not compatible in Mongo or other nosql dbs which all tend to prefer their own IDs so they can manage efficient indexing.

Only one Config can ever be returned in later Known builds, so the hard coded ID shouldn't be necessary. Cleanup of the sawdust should be accomplished by a separate tool.
