### PR TITLE
Installer: Specify different database engines

### DIFF
--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -161,6 +161,10 @@ namespace Idno\Core {
                 $pass,
                 $schema = 'mysql'
         ) {
+            // Skip schema install for mongo, not necessary
+            if ($schema == 'mongo' || $schema == 'mongodb')
+                return true;
+            
             $dbname = preg_replace("/[^a-zA-Z0-9\_\.]/", "", $dbname); // Sanitise $dbname
             
             $database_string = $schema . ':';

--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -174,6 +174,7 @@ namespace Idno\Core {
             $dbscheme = "";
             switch ($schema) {
                 
+                case 'sqlite3' : $dbscheme = 'sqlite'; break;
                 case 'postgres': $dbscheme = 'pgsql'; break;
                 default:
                     $dbscheme = $schema;

--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -174,19 +174,24 @@ namespace Idno\Core {
             $database_string .= 'dbname=' . $dbname;
 
             $dbh = new \PDO($database_string, $user, $pass);
-            if ($schema = @file_get_contents("{$this->root_path}/warmup/schemas/$schema/$schema.sql")) {
-                $dbh->exec('use `' . $dbname . '`');
-                if (!$dbh->exec($schema)) {
-                    $err = $dbh->errorInfo();
-                    if ($err[0] === '00000') {
-                        // exec() might return false (no rows affected) and still have been successful
-                        // http://php.net/manual/en/pdo.exec.php#118156
-                    } else if ($err[0] === '01000') {
-                        error_log('INSTALLATION WARNING: Installed database schema with warnings: '.$err[2]);
-                    } else {
-                        throw new \RuntimeException('We couldn\'t automatically install the database schema: '.$err[2]);
+            $dbh->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+            
+            if ($sql = @file_get_contents("{$this->root_path}/warmup/schemas/$schema/$schema.sql")) {
+                
+                $statements = explode(";\n", $sql); // Explode statements; only mysql can support multiple statements per line, and then not safely.
+                foreach ($statements as $sql) {
+                    $sql = trim($sql);
+                    if (!empty($sql)) {
+                        try {
+                            $statement = $client->prepare($sql);
+                            $statement->execute();
+                        } catch (\Exception $e) {
+                            $err = $dbh->errorInfo();
+                            throw new \RuntimeException('We couldn\'t automatically install the database schema: '.$err[2]);
+                        }
                     }
                 }
+                
             } else {
                 throw new \RuntimeException("We couldn't find the schema doc.");
             }

--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -121,6 +121,7 @@ namespace Idno\Core {
                 'version' => Version::version(),
                 'datetime' => date('r'),
                 
+                'database' => 'MySQL',
                 'dbname' => 'known',
                 'dbhost' => 'localhost',
                 

--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -170,7 +170,16 @@ namespace Idno\Core {
             if ($schema == 'mongo' || $schema == 'mongodb')
                 return true;
             
-            $database_string = $schema . ':';
+            // Crufty hack to alias schemas if they're different from class. TODO: do this nicer
+            $dbscheme = "";
+            switch ($schema) {
+                
+                case 'postgres': $dbscheme = 'pgsql'; break;
+                default:
+                    $dbscheme = $schema;
+            }
+            
+            $database_string = $dbscheme . ':';
             $database_string .= 'host=' . $host . ';';
             $database_string .= 'dbname=' . $dbname;
 

--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -183,7 +183,7 @@ namespace Idno\Core {
                     $sql = trim($sql);
                     if (!empty($sql)) {
                         try {
-                            $statement = $client->prepare($sql);
+                            $statement = $dbh->prepare($sql);
                             $statement->execute();
                         } catch (\Exception $e) {
                             $err = $dbh->errorInfo();

--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -161,18 +161,20 @@ namespace Idno\Core {
                 $pass,
                 $schema = 'mysql'
         ) {
+            
+            $dbname = preg_replace("/[^a-zA-Z0-9\_\.]/", "", $dbname); // Sanitise $dbname
+            $schema = preg_replace("/[^a-zA-Z0-9\_\.]/", "", strtolower($schema)); // Sanitise $schema
+            
             // Skip schema install for mongo, not necessary
             if ($schema == 'mongo' || $schema == 'mongodb')
                 return true;
-            
-            $dbname = preg_replace("/[^a-zA-Z0-9\_\.]/", "", $dbname); // Sanitise $dbname
             
             $database_string = $schema . ':';
             $database_string .= 'host=' . $host . ';';
             $database_string .= 'dbname=' . $dbname;
 
             $dbh = new \PDO($database_string, $user, $pass);
-            if ($schema = @file_get_contents($this->root_path . '/warmup/schemas/mysql/mysql.sql')) {
+            if ($schema = @file_get_contents("{$this->root_path}/warmup/schemas/$schema/$schema.sql")) {
                 $dbh->exec('use `' . $dbname . '`');
                 if (!$dbh->exec($schema)) {
                     $err = $dbh->errorInfo();

--- a/warmup/CLI/CLIInstaller.php
+++ b/warmup/CLI/CLIInstaller.php
@@ -31,6 +31,7 @@ class CLIInstaller extends \Idno\Core\Installer {
     private $config = [];
     private $expected_manifest = [
         'site_title' => '"Site title"',
+        'database' => '"Database type, usually \'MySQL\'"',
         'mysql_name' => '"Database name"',
         'mysql_user' => '"Database username"',
         'mysql_pass' => '"Database password"',
@@ -115,6 +116,7 @@ class CLIInstaller extends \Idno\Core\Installer {
                     'dbuser' => $this->config['mysql_user'],
                     'dbhost' => $this->config['mysql_host'],
                     'uploadpath' => $this->config['upload_path'],
+                    'database' => $this->config['database'],
                 ]);
                 
             });
@@ -179,6 +181,11 @@ class CLIInstaller extends \Idno\Core\Installer {
                     $this->config['site_title'] = $helper->ask($input, $output, $question);
                 }
                 
+                if (empty($this->config['database'])) {
+                    $question = new Symfony\Component\Console\Question\Question('Please enter the database type: ', 'MySQL');
+
+                    $this->config['database'] = $helper->ask($input, $output, $question);
+                }
                 
                 if (empty($this->config['mysql_name'])) {
                     $question = new Symfony\Component\Console\Question\Question('Please enter the name of the database: ', 'known');
@@ -219,7 +226,9 @@ class CLIInstaller extends \Idno\Core\Installer {
                     $this->config['mysql_host'], 
                     $this->config['mysql_name'], 
                     $this->config['mysql_user'], 
-                    $this->config['mysql_pass']
+                    $this->config['mysql_pass'],
+                        
+                    $this->config['database']
                 );
                 
                 $this->writeApacheConfig();
@@ -230,6 +239,7 @@ class CLIInstaller extends \Idno\Core\Installer {
                     'dbuser' => $this->config['mysql_user'],
                     'dbhost' => $this->config['mysql_host'],
                     'uploadpath' => $this->config['upload_path'],
+                    'database' => $this->config['database'],
                 ]);
             
                 $this->writeConfig($ini_file, $config_name);

--- a/warmup/webserver-configs/config.ini.template
+++ b/warmup/webserver-configs/config.ini.template
@@ -4,7 +4,7 @@
 # Built: %datetime%
 #
 
-database = 'MySQL'
+database = '%database%'
 dbname = '%dbname%'
 dbpass = '%dbpass%'
 dbuser = '%dbuser%'


### PR DESCRIPTION
## Here's what I fixed or added:

Added the ability for the installer to handle different database engines (e.g. postgres).

Web installer is still hard coded to MySQL, however CLI is more flexible.

## Here's why I did it:

Because they exist, and should be easier to use.

Refs: idno/Known-Docker#9