### PR TITLE
i18n: Call registration hook for translations in console plugins

### DIFF
--- a/Idno/Common/ConsolePlugin.php
+++ b/Idno/Common/ConsolePlugin.php
@@ -19,6 +19,8 @@ namespace Idno\Common {
 
             $this->init();
             $this->registerEventHooks();
+            
+            $this->registerTranslations();
         }
         
         function init() {}


### PR DESCRIPTION
## Here's what I fixed or added:

Adding a registerTranslations() hook to console plugins

## Here's why I did it:

Looking to the future, because console commands should probably be translatable too.

