### PR TITLE
i18n: Correcting line numbers on .pot file language generator

### DIFF
--- a/languages/processfile.php
+++ b/languages/processfile.php
@@ -20,7 +20,7 @@ foreach ($filenames as $filename) {
 
                 $string = $translation[0];
                 $offset = $translation[1];
-                $linenumber = getLineNumber($in, $offset);
+                $linenumber = getLineNumber($file, $offset);
 
                 $normalised_string = str_replace('"', '\"', $string);
 


### PR DESCRIPTION
## Here's what I fixed or added:

Use correct input variable for line number generation

## Here's why I did it:

Previously the language file generator was using the wrong input data in order to calculate the line number of the specific translation string.

