### PR TITLE
Remove reference to Fontello

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Third party libraries are licensed separately.
   * Console. Source: https://github.com/symfony/Console
 * ToroPHP, which is distributed under the MIT License. Source: https://github.com/anandkunal/ToroPHP/
 * Font Awesome, which is distributed under the Open Font License, version 1.1: http://fortawesome.github.io/Font-Awesome/
-* Fontello, which is distributed under the MIT License, for generating open source webfont. Source: https://github.com/fontello/fontello
 * Steve Clay's AutoP, which is distributed under the MIT License. Source: https://code.google.com/p/mrclay/
 * Aaron Parecki's Webmention Client, which is distributed under the Apache 2.0 license. Source: https://github.com/aaronpk/mention-client
 * Barnaby Walters's Microformats 2 Parser, which is distributed under the MIT License. Source: https://github.com/indieweb/php-mf2


### PR DESCRIPTION
## Here's what I fixed or added:

Remove reference to fontello

## Here's why I did it:

Pretty sure we no longer use Fontello, so probably should remove reference to it.