### PR TITLE
Shrinking controls for unfurl to icons only

### DIFF
--- a/templates/default/content/unfurl.tpl.php
+++ b/templates/default/content/unfurl.tpl.php
@@ -8,8 +8,8 @@ if (empty($vars['object']->hide_preview)) { ?>
     <div class="unfurl col-md-12" style="display:none;" data-url="<?= $dataurl; ?>"></div>
     <?php if ($vars['object']->canEdit() && (!empty($vars['object']->_id))) { ?>
     <div class="unfurl-edit pull-right small">
-        <a href="#" class="refresh"><i class="fa fa-sync"></i> <?= \Idno\Core\Idno::site()->language()->_('Refresh preview'); ?></a> &nbsp;
-        <a href="#" class="delete"><i class="fa fa-trash"></i> <?= \Idno\Core\Idno::site()->language()->_('Remove preview'); ?></a>
+        <a href="#" class="refresh"><i class="fa fa-sync"></i></a>
+        <a href="#" class="delete"><i class="fa fa-trash"></i></a>
     </div>
     <?php } ?>
 </div>


### PR DESCRIPTION
The text labels were huge, and unfortunately inconsistently sized across templates. Here's how the revised version looks:

<img width="739" alt="screen shot 2018-09-19 at 10 17 01 pm" src="https://user-images.githubusercontent.com/624104/45797305-c64f5800-bc59-11e8-9ee1-f465cc1583f9.png">
