### PR TITLE
Check that queue isn't empty before iterating it.

### DIFF
--- a/Idno/Pages/Service/Queues/Queue.php
+++ b/Idno/Pages/Service/Queues/Queue.php
@@ -19,9 +19,10 @@ namespace Idno\Pages\Service\Queues {
             \Idno\Core\Idno::site()->logging()->debug("Displaying event queue from $queue");
             
             $array = [];
-            $queue_list = \Idno\Entities\AsynchronousQueuedEvent::getPendingFromQueue($queue, $limit, $offset);
-            foreach ($queue_list as $event) {
-                $array[] = (string)$event->getID();
+            if ($queue_list = \Idno\Entities\AsynchronousQueuedEvent::getPendingFromQueue($queue, $limit, $offset)) {
+                foreach ($queue_list as $event) {
+                    $array[] = (string)$event->getID();
+                }
             }
             
             Idno::site()->template()->__([


### PR DESCRIPTION
## Here's what I fixed or added:

Check that queue isn't empty before iterating it.

## Here's why I did it:

Empty queues produce warning if empty in the foreach.