### PR TITLE
Creating a deeper spam trap for public comments

### DIFF
--- a/IdnoPlugins/Comments/Pages/Post.php
+++ b/IdnoPlugins/Comments/Pages/Post.php
@@ -13,13 +13,17 @@ namespace IdnoPlugins\Comments\Pages {
         function postContent()
         {
 
+            $name_field = md5(\Idno\Core\Idno::site()->config()->site_secret . 'name');
+            $url_field = md5(\Idno\Core\Idno::site()->config()->site_secret . 'url');
+
             $body      = strip_tags($this->getInput('body'));
-            $name      = strip_tags($this->getInput('name'));
-            $url       = trim($this->getInput('url'));
-            $url2       = trim($this->getInput('url-2'));
+            $name      = strip_tags($this->getInput($name_field));
+            $url       = trim($this->getInput($url_field));
+            $url2      = $this->getInput('url');
+            $name2     = $this->getInput('name');
             $validator = $this->getInput('validator');
 
-            if (!empty($url2)) {
+            if (!empty($url2) || !empty($name2)) {
                 $this->deniedContent();
             }
 

--- a/IdnoPlugins/Comments/templates/default/comments/public/form.tpl.php
+++ b/IdnoPlugins/Comments/templates/default/comments/public/form.tpl.php
@@ -2,6 +2,9 @@
 
     $object = $vars['object'];
 
+    $name_field = md5(\Idno\Core\Idno::site()->config()->site_secret . 'name');
+    $url_field = md5(\Idno\Core\Idno::site()->config()->site_secret . 'url');
+
 if (!\Idno\Core\Idno::site()->session()->isLoggedOn() && $object instanceof \Idno\Common\Entity) {
     ?>
         <div class="row annotation-add">
@@ -12,20 +15,21 @@ if (!\Idno\Core\Idno::site()->session()->isLoggedOn() && $object instanceof \Idn
             </div>
             <div class="col-md-10 idno-comment-container" id="comment-form">
                 <div class="form-group">
-                    <input type="text" name="name" class="form-control" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_('Your name'); ?>" required>
+                    <input type="text" name="name" class="form-control" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_("You probably shouldn't fill this in"); ?>" style="display: none;" >
+                    <input type="url" name="url" class="form-control" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_("You probably shouldn't fill this in"); ?>" style="display: none;" >
                 </div>
                 <div class="form-group">
-                    <input type="url" name="url" class="form-control" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_('Your website address'); ?>">
+                    <input type="text" name="<?=$name_field?>" class="form-control" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_('Your name'); ?>" required>
                 </div>
                 <div class="form-group">
-                    <input type="text" name="url-2" class="form-control" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_("You probably shouldn't fill this in"); ?>" style="display: none;" >
+                    <input type="url" name="<?=$url_field?>" class="form-control" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_('Your website address'); ?>">
                 </div>
                 <div id="extrafield" style="display:none"></div>
                 <div class="form-group">
                     <textarea name="body" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_('Add a comment ...'); ?>" class="form-control mentionable"></textarea>
                 </div>
                 <p style="text-align: right" id="comment-submit">
-                <?php echo \Idno\Core\Idno::site()->actions()->signForm('annotation/post') ?>
+                    <?php echo \Idno\Core\Idno::site()->actions()->signForm('annotation/post') ?>
                 </p>
             </div>
         </div>
@@ -34,8 +38,6 @@ if (!\Idno\Core\Idno::site()->session()->isLoggedOn() && $object instanceof \Idn
 
                 setTimeout(function() {
                     $('#extrafield').html('<input type="hidden" name="validator" value="<?php echo $object->getUUID()?>">');
-                    //$('#comment-form').prepend('<form action="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>comments/post" method="post">');
-                    //$('#comment-form').append('</form>');
                     $('#comment-form').html('<form action="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>comments/post" method="post">' + $('#comment-form').html() + '</form>');
                     $('#comment-submit').append('<input type="hidden" name="object" value="<?php echo $object->getUUID() ?>"><input type="hidden" name="type" value="reply"><input type="submit" class="btn btn-save" value="<?php echo \Idno\Core\Idno::site()->language()->_('Leave Comment'); ?>">');
                 },4000);


### PR DESCRIPTION
## Here's what I fixed or added:

I changed the comment form to avoid using `name` and `url` fields, and include blank, hidden fields with those names in a hidden form. The idea is that bots will see `name` and `url` first in the form and add content to those. In addition, every site's real `name` and `url` fields will be named something different.

## Here's why I did it:

Public comments on my site were still being heavily abused. Hopefully this stems the tide.