### PR TITLE
HTTP Strict Transport Security support

### DIFF
--- a/Tests/API/HSTSTest.php
+++ b/Tests/API/HSTSTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\API {
+
+    /**
+     * Test HSTS handling on webservice calls
+     */
+    class HSTSTest extends \Tests\KnownTestCase {
+
+        function testHSTS() { 
+
+            // Tidy up
+            if ($cache = \Idno\Core\Idno::site()->cache())
+            {
+                 $cache->delete(parse_url('localhost', PHP_URL_HOST));
+                 $cache->delete(parse_url('mapkyca.com', PHP_URL_HOST));
+            }
+            
+            
+            $result = \Idno\Core\Webservice::get('http://localhost');
+            
+            
+            
+            $this->assertFalse(\Idno\Core\Webservice::isHSTS('http://localhost'));
+            
+            // Call HTTPS endpoint
+            $result = \Idno\Core\Webservice::get('http://mapkyca.com');
+            $result = \Idno\Core\Webservice::get('http://mapkyca.com');
+            
+            // Check storage
+            $this->assertTrue(\Idno\Core\Webservice::isHSTS('http://mapkyca.com'));
+            
+            // Tidy up so we can re-run test
+            if ($cache = \Idno\Core\Idno::site()->cache())
+            {
+                 $cache->delete(parse_url('localhost', PHP_URL_HOST));
+                 $cache->delete(parse_url('mapkyca.com', PHP_URL_HOST));
+            }
+            
+        }
+
+    }
+
+}

--- a/Tests/EnvironmentTest.php
+++ b/Tests/EnvironmentTest.php
@@ -24,12 +24,12 @@ namespace Tests {
                      //'curl','date','dom','gd','json','libxml','mbstring','pdo','pdo_mysql','reflection','session','simplexml', 'openssl'
                      \Idno\Core\Installer::requiredModules()
                       as $extension) {
-                echo "$extension\n";
+                echo "$extension " .var_export(extension_loaded($extension), true). "\n";
                 $this->assertTrue(extension_loaded($extension));
             }
 
             echo "Checking available DB (mysql, mongodb, sqlite, pgsql)\n";
-            $this->assertTrue(extension_loaded('mysql') || extension_loaded('mongodb') || extension_loaded('sqlite') || extension_loaded('pgsql'));
+            $this->assertTrue(extension_loaded('pdo_mysql') || extension_loaded('mongodb') || extension_loaded('pdo_sqlite') || extension_loaded('pdo_pgsql'));
         }
 
         /**


### PR DESCRIPTION
## Here's what I fixed or added:

Added HSTS support to Webservice::send()

## Here's why I did it:

HTTP Strict Security Policy is a method by which a web server can instruct a client to address any future requests to a secure endpoint to always use the secure endpoint.

Previously, if a Known webservice call was addressed at http://example.com but was forwarded to https://example.com, future requests would also follow the Location headers. 

Now, if HSTS headers are set on https://example.com, and are found to be valid, any future request to http://example.com will automatically be rewritten to call the secure endpoint.

Refs #2181