### PR TITLE
Documentation: Reordering the language page.

### DIFF
--- a/docs/developers/languages/index.md
+++ b/docs/developers/languages/index.md
@@ -9,36 +9,15 @@ method hook.
 
 ## Adding a translation for a language
 
-In order to add a translation, you need to register a ```Translation``` object for a given language short code. To do this you need to extend ```Idno/Core/ArrayKeyTranslation``` for each language you want to translate, and then implement its ```getStrings()``` method.
-
-It is then possible to add them all at once for each language (this way, Known will automatically select the appropriate translation for the loaded language).
-
-E.g.
-
-```
-\Idno\Core\Idno::site()->language()->register(new \IdnoPlugins\Example\Languages\English('en_GB'));
-\Idno\Core\Idno::site()->language()->register(new \IdnoPlugins\Example\Languages\French('fr_FR'));
-```
-
-## Using a translation
-
-Once a string has been registered, it is possible to echo the string, and have it translated:
-
-E.g.
-
-```
-echo \Idno\Core\Idno::site()->language()->_('This is the string to translate');
-```
-
-## Gettext support
-
-Known also now supports [gettext](https://en.wikipedia.org/wiki/Gettext), which is a widely supported localisation platform.
+Known supports [gettext](https://en.wikipedia.org/wiki/Gettext), which is a widely supported localisation platform. This is the recommended method for adding 
+translations to your code.
 
 ### Creating .POT file
 
-The first step, after you've used ```\Idno\Core\Idno::site()->language()->_()``` to write your strings, is to generate a POT template translation file. To do this, in ```/languages/``` there's a helpful script, go into this directory and run the script
+The first step, after you've used ```\Idno\Core\Idno::site()->language()->_()``` to write your strings, is to generate a POT template 
+translation file. To do this, in ```/languages/``` there's a helpful script, go into this directory and run the script
 
-```
+```bash
 ./makepot.sh /path/to/your/plugin > /path/to/your/plugin/languages/language.pot
 ```
 
@@ -50,7 +29,8 @@ This will parse all your plugin's PHP files and extract translatable strings.
 
 ### Creating your translation
 
-Open up your .POT file with a suitable tool, e.g. [poedit](https://poedit.net/), and save your .mo and .po files as ```/path/to/your/plugin/languages/*LOCALE*/LC_MESSAGES/*DOMAIN*.mo|po```, where:
+Open up your .POT file with a suitable tool, e.g. [poedit](https://poedit.net/), and save your .mo and .po files as 
+```/path/to/your/plugin/languages/*LOCALE*/LC_MESSAGES/*DOMAIN*.mo|po```, where:
 
 * LOCALE is the locale you're writing for, e.g. pt_BR
 * DOMAIN is the domain, e.g. your plugin name 'myplugin'
@@ -71,4 +51,31 @@ function registerTranslations()
         )
     );   
 }
+```
+
+
+## Using a translation
+
+Once a string has been registered, it is possible to echo the string, and have it translated:
+
+E.g.
+
+```
+echo \Idno\Core\Idno::site()->language()->_('This is the string to translate');
+```
+
+
+## Adding a translation for a language (alternative)
+
+If you don't want to go the Gettext route for whatever reason, you can quickly add a translation for a language in code.
+
+In order to add a translation, you need to register a ```Translation``` object for a given language short code. To do this you need to extend ```Idno/Core/ArrayKeyTranslation``` for each language you want to translate, and then implement its ```getStrings()``` method.
+
+It is then possible to add them all at once for each language (this way, Known will automatically select the appropriate translation for the loaded language).
+
+E.g.
+
+```
+\Idno\Core\Idno::site()->language()->register(new \IdnoPlugins\Example\Languages\English('en_GB'));
+\Idno\Core\Idno::site()->language()->register(new \IdnoPlugins\Example\Languages\French('fr_FR'));
 ```


### PR DESCRIPTION
## Here's what I fixed or added:

Documentation: Reordering the language page.

## Here's why I did it:

Gettext is the "blessed" method for adding translations, so this should be made clearer.

Reordered documentation to place gettext section first.

