### PR TITLE
Reverse the colour on enable/disable buttons

### DIFF
--- a/templates/default/admin/plugins/plugin.tpl.php
+++ b/templates/default/admin/plugins/plugin.tpl.php
@@ -119,7 +119,7 @@ foreach (['php', 'known', 'idno', 'build', 'extension', 'plugin'] as $field) {
                             <input type="hidden" name="plugin" value="<?php echo $shortname ?>"/>
                             <input type="hidden" name="container" value="plugin-<?php echo strtolower($shortname) ?>"/>
                             <input type="hidden" name="plugin_action" value="uninstall"/>
-                            <input class="btn btn-default plugin-button" type="submit" value="Disable"/>
+                            <input class="btn btn-primary plugin-button" type="submit" value="Disable"/>
                         </p>
                         <?php echo \Idno\Core\Idno::site()->actions()->signForm(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'admin/plugins/') ?>
                     </form>
@@ -132,7 +132,7 @@ foreach (['php', 'known', 'idno', 'build', 'extension', 'plugin'] as $field) {
                             <input type="hidden" name="plugin" value="<?php echo $shortname ?>"/>
                             <input type="hidden" name="container" value="plugin-<?php echo strtolower($shortname) ?>"/>
                             <input type="hidden" name="plugin_action" value="install"/>
-                            <input class="btn btn-primary plugin-button" type="submit" value="Enable"/>
+                            <input class="btn btn-default plugin-button" type="submit" value="Enable"/>
                         </p>
                         <?php echo \Idno\Core\Idno::site()->actions()->signForm(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'admin/plugins/') ?>
                     </form>


### PR DESCRIPTION

## Here's what I fixed or added:

Reverse the colour on enable/disable buttons

## Here's why I did it:

I found the btn-primary for enable / btn-default for disable confusing since it looks like disabled plugins were enabled.

Reverse these colours.