### PR TITLE
DRY: Attempt to load some settings from package.json

### DIFF
--- a/Idno/Core/Plugins.php
+++ b/Idno/Core/Plugins.php
@@ -150,9 +150,19 @@ namespace Idno\Core {
                 foreach ($folders as $folder) {
                     if ($folder != '.' && $folder != '..') {
                         if (is_dir(\Idno\Core\Idno::site()->config()->path . '/IdnoPlugins/' . $folder)) {
-                            if (file_exists(\Idno\Core\Idno::site()->config()->path . '/IdnoPlugins/' . $folder . '/plugin.ini')) {
-                                if ($this->isAllowed($folder)) {
-                                    $plugins[$folder] = parse_ini_file(\Idno\Core\Idno::site()->config()->path . '/IdnoPlugins/' . $folder . '/plugin.ini', true);
+                            if ($this->isAllowed($folder)) {
+                                
+                                if (!is_array($plugins[$folder]))
+                                    $plugins[$folder]= [];
+                                
+                                // See if we can load some values from a package.json
+                                if (file_exists(\Idno\Core\Idno::site()->config()->path . '/IdnoPlugins/' . $folder . '/package.json')) {
+                                    $plugins[$folder]['Plugin description'] = array_replace_recursive($plugins[$folder], json_decode(file_get_contents(\Idno\Core\Idno::site()->config()->path . '/IdnoPlugins/' . $folder . '/package.json'), true));
+                                }
+                                
+                                // Get stuff from plugin.ini
+                                if (file_exists(\Idno\Core\Idno::site()->config()->path . '/IdnoPlugins/' . $folder . '/plugin.ini')) {
+                                    $plugins[$folder] = array_replace_recursive($plugins[$folder], parse_ini_file(\Idno\Core\Idno::site()->config()->path . '/IdnoPlugins/' . $folder . '/plugin.ini', true));
                                 }
                             }
                         }
@@ -165,9 +175,19 @@ namespace Idno\Core {
                     if ($folders = scandir(\Idno\Core\Idno::site()->config()->path . '/hosts/' . $host . '/IdnoPlugins')) {
                         foreach ($folders as $folder) {
                             if ($folder != '.' && $folder != '..') {
-                                if (file_exists(\Idno\Core\Idno::site()->config()->path . '/hosts/' . $host . '/IdnoPlugins/' . $folder . '/plugin.ini')) {
-                                    if ($this->isAllowed($folder)) {
-                                        $plugins[$folder] = parse_ini_file(\Idno\Core\Idno::site()->config()->path . '/hosts/' . $host . '/IdnoPlugins/' . $folder . '/plugin.ini', true);
+                                if ($this->isAllowed($folder)) {
+                                    
+                                    if (!is_array($plugins[$folder]))
+                                        $plugins[$folder]= [];
+                                    
+                                    // See if we can load some values from a package.json
+                                    if (file_exists(\Idno\Core\Idno::site()->config()->path . '/hosts/' . $host . '/IdnoPlugins/' . $folder . '/package.json')) {
+                                        $plugins[$folder]['Plugin description'] = array_replace_recursive($plugins[$folder], json_decode(file_get_contents(\Idno\Core\Idno::site()->config()->path . '/hosts/' . $host . '/IdnoPlugins/' . $folder . '/package.json'), true));
+                                    }
+                                    
+                                    // Get stuff from plugin.ini
+                                    if (file_exists(\Idno\Core\Idno::site()->config()->path . '/hosts/' . $host . '/IdnoPlugins/' . $folder . '/plugin.ini')) {
+                                        $plugins[$folder] = array_replace_recursive($plugins[$folder], $plugins[$folder] = parse_ini_file(\Idno\Core\Idno::site()->config()->path . '/hosts/' . $host . '/IdnoPlugins/' . $folder . '/plugin.ini', true));
                                     }
                                 }
                             }


### PR DESCRIPTION

## Here's what I fixed or added:

Attempt to load some settings from package.json

## Here's why I did it:

Since some packages are starting to use package.json in order to set various grunt tasks, and since there are a number of common attributes, lets give the ability to use package.json to set some plugin settings.

Requires #2213