### PR TITLE
Correcting translation language call

### DIFF
--- a/IdnoPlugins/Checkin/Checkin.php
+++ b/IdnoPlugins/Checkin/Checkin.php
@@ -7,7 +7,7 @@ namespace IdnoPlugins\Checkin {
 
         function getTitle()
         {
-            return \Idno\Core\Idno::site()->language('Checked into %s', [$this->placename]);
+            return \Idno\Core\Idno::site()->language->_('Checked into %s', [$this->placename]);
         }
 
         function getDescription()


### PR DESCRIPTION
## Here's what I fixed or added:

Correcting translation language call

## Here's why I did it:

Should return a string, not an object