### PR TITLE
Add edit URL to content type

### DIFF
--- a/Idno/Pages/Homepage.php
+++ b/Idno/Pages/Homepage.php
@@ -91,6 +91,9 @@ namespace Idno\Pages {
 
                 // If we can't create an object of this type, hide from the button bar
                 foreach ($create as $key => $obj) {
+                    
+                    $obj->editUrl = $obj->getEditURL(); // Helper for API clients: handle flexible site configuration
+                    
                     if (!$obj->createable) {
                         unset($create[$key]);
                     }


### PR DESCRIPTION

## Here's what I fixed or added:

Add edit URL to content type

## Here's why I did it:

In order to help API clients, lets list the edit endpoints so the clients can know which endpoints can be called.
