### PR TITLE
In MF2 JSON, visibility is specified as an array

### DIFF
--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -157,7 +157,12 @@ namespace IdnoPlugins\IndiePub\Pages\MicroPub {
                 $video_url   = $this->getJSONInput('video');
                 $audio_url   = $this->getJSONInput('audio');
                 $visibility  = $this->getJSONInput('visibility');
-
+                
+                // Handle visibility
+                if(is_array($visibility) && array_key_exists(0, $visibility)) {
+                    $visibility = $visibility[0];
+                }
+                
                 // Since Known does not support multiple photos or videos, use the first if more than one was given.
                 if(is_array($photo_url) && array_key_exists(0, $photo_url)) {
                     $photo_url = $photo_url[0];


### PR DESCRIPTION
## Here's what I fixed or added:

When submitting the "visibility" property via the Micropub endpoint, the standard is for JSON MF2 is for the property to be specified as an array. This change brings our endpoint into compliance and makes us compatible with more tools.

## Here's why I did it:

I was working on a Micropub action for the iOS app Drafts, and noticed that we were handling this incorrectly.