### PR TITLE
Adding a console plugin wrapper for import

### DIFF
--- a/ConsolePlugins/Import/.gitignore
+++ b/ConsolePlugins/Import/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+!package.json

--- a/ConsolePlugins/Import/Gruntfile.js
+++ b/ConsolePlugins/Import/Gruntfile.js
@@ -1,0 +1,24 @@
+/**
+ * Gruntfile for Import
+ */
+
+module.exports = function (grunt) {
+    // Project configuration.
+    grunt.initConfig({
+	pkg: grunt.file.readJSON('package.json'),
+    });
+
+    
+// Build language pack (todo: find a cleaner way)
+    grunt.registerTask('build-lang', '', function(){
+	
+	const { execSync } = require('child_process');
+	
+	execSync('touch ./languages/import.pot'); // Make sure it exists, if we're going to remove (for broken builds)
+	execSync('rm ./languages/import.pot'); // Remove existing
+	
+	execSync('find . -type f -regex ".*\.php" | php ../../languages/processfile.php >> ./languages/import.pot'); 
+	
+    });
+
+};

--- a/ConsolePlugins/Import/Main.php
+++ b/ConsolePlugins/Import/Main.php
@@ -3,10 +3,10 @@
 namespace ConsolePlugins\Import {
 
     use Idno\Core\Migration;
-    
+
     class Main extends \Idno\Common\ConsolePlugin
     {
-        
+
         public static $run = true;
 
         function registerTranslations()
@@ -23,12 +23,12 @@ namespace ConsolePlugins\Import {
         {
             $filename = $input->getArgument('file');
             $import_type = $input->getArgument('format');
-            
+
             if (!file_exists($filename))
                 throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_('Import file %s could not be found.', [$filename]));
-            
+
             $xml = file_get_contents($filename);
-            
+
             $imported = false;
             switch (strtolower($import_type)) {
 
@@ -42,15 +42,15 @@ namespace ConsolePlugins\Import {
                     throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_('%s is an unrecognised import type', [$import_type]));
 
             }
-            
+
             if ($imported) {
-                
+
                 $output->writeln(\Idno\Core\Idno::site()->language()->_('Completed import successfully'));
-                
+
             } else {
-                
+
                 $output->writeln(\Idno\Core\Idno::site()->language()->_('Import completed, but may not have been successful'));
-                
+
             }
         }
 

--- a/ConsolePlugins/Import/Main.php
+++ b/ConsolePlugins/Import/Main.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace ConsolePlugins\Import {
+
+    use Idno\Core\Migration;
+    
+    class Main extends \Idno\Common\ConsolePlugin
+    {
+        
+        public static $run = true;
+
+        function registerTranslations()
+        {
+
+            \Idno\Core\Idno::site()->language()->register(
+                new \Idno\Core\GetTextTranslation(
+                    'import', dirname(__FILE__) . '/languages/'
+                )
+            );
+        }
+
+        public function execute(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output)
+        {
+            $filename = $input->getArgument('file');
+            $import_type = $input->getArgument('format');
+            
+            if (!file_exists($filename))
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_('Import file %s could not be found.', [$filename]));
+            
+            $xml = file_get_contents($filename);
+            
+            $imported = false;
+            switch (strtolower($import_type)) {
+
+                case 'blogger':
+                    $imported = Migration::importBloggerXML($xml);
+                    break;
+                case 'wordpress':
+                    $imported = Migration::importWordPressXML($xml);
+                    break;
+                default:
+                    throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_('%s is an unrecognised import type', [$import_type]));
+
+            }
+            
+            if ($imported) {
+                
+                $output->writeln(\Idno\Core\Idno::site()->language()->_('Completed import successfully'));
+                
+            } else {
+                
+                $output->writeln(\Idno\Core\Idno::site()->language()->_('Import completed, but may not have been successful'));
+                
+            }
+        }
+
+        public function getCommand()
+        {
+            return 'import';
+        }
+
+        public function getDescription()
+        {
+            return \Idno\Core\Idno::site()->language()->_('Import posts from WordPress, Blogger etc');
+        }
+
+        public function getParameters()
+        {
+            return [
+                new \Symfony\Component\Console\Input\InputArgument('format', \Symfony\Component\Console\Input\InputArgument::REQUIRED, \Idno\Core\Idno::site()->language()->_('Import type: wordpress, blogger')),
+                new \Symfony\Component\Console\Input\InputArgument('file', \Symfony\Component\Console\Input\InputArgument::REQUIRED, \Idno\Core\Idno::site()->language()->_('Location of the export file/directory')),
+            ];
+        }
+
+    }
+
+}

--- a/ConsolePlugins/Import/languages/import.pot
+++ b/ConsolePlugins/Import/languages/import.pot
@@ -1,0 +1,28 @@
+#: ./Main.php:28
+msgid "Import file %s could not be found."
+msgstr ""
+
+#: ./Main.php:42
+msgid "%s is an unrecognised import type"
+msgstr ""
+
+#: ./Main.php:48
+msgid "Completed import successfully"
+msgstr ""
+
+#: ./Main.php:52
+msgid "Import completed, but may not have been successful"
+msgstr ""
+
+#: ./Main.php:64
+msgid "Import posts from WordPress, Blogger etc"
+msgstr ""
+
+#: ./Main.php:70
+msgid "Import type: wordpress, blogger"
+msgstr ""
+
+#: ./Main.php:71
+msgid "Location of the export file/directory"
+msgstr ""
+

--- a/ConsolePlugins/Import/package.json
+++ b/ConsolePlugins/Import/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "Import",
+  "version": "0.9.9-a",
+  "devDependencies": {
+    "grunt": "^0.4.5"
+  }
+}


### PR DESCRIPTION
## Here's what I fixed or added:

Adding a console plugin wrapper for import

## Here's why I did it:

A number of people have reported issues using the web import code. Often this occurs on large imports where resources (memory, run time, etc) start becoming an issue. This is less of a problem on CLI, and so I'm adding a CLI wrapper for the same import.

