### PR TITLE
Add "name" field to the form documentation

### DIFF
--- a/templates/default/content/syndication/account.tpl.php
+++ b/templates/default/content/syndication/account.tpl.php
@@ -26,7 +26,8 @@ if (!empty($vars['service']) && !empty($vars['username'])) {
         'disabled' => !empty($vars['disabled']),
         'id' => "syndication_{$vars['service']}_{$identifier}_toggle",
         'service' => $vars['service'],
-        'username' => htmlentities($vars['username']),
+        'username' => $vars['username'],
+        'name' => $vars['name'],
         'checked' => $vars['selected'] == true
     ]);
 }


### PR DESCRIPTION
## Here's what I fixed or added:
Add "name" field to the form documentation

Also, since this is for json output, html entities encoding is not required.

## Here's why I did it:

Make parsing easier for API calls