### PR TITLE
Attempt to mimic PHP's array name conversion for JSON blobs

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -198,6 +198,7 @@ namespace Idno\Common {
             // First, let's see if we've been sent anything in form input
             if (!empty($_REQUEST['json'])) {
                 $json = trim($_REQUEST['json']);
+                $json = str_replace('[]"', '"', $json); // Fake PHP's array conversion
                 if ($parsed = @json_decode($json, true)) {
                     $this->data = array_merge($parsed, $this->data());
                 }
@@ -206,6 +207,8 @@ namespace Idno\Common {
             if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] != 'GET') {
                 $body = @file_get_contents('php://input');
                 $body = trim($body);
+                $body = str_replace('[]"', '"', $body); // Fake PHP's array conversion
+                
                 if (!empty($body)) {
                     if ($parsed = @json_decode($body, true)) {
                         $this->data = array_merge($parsed, $this->data());


### PR DESCRIPTION

## Here's what I fixed or added:
Attempt to mimic PHP's array name conversion for JSON blobs
## Here's why I did it:

PHP magically converts ```foo[]``` into ```$_REQUEST['foo'] => array(...)```, and these names are expected by the code (e.g. for syndication).

This code attempts to mimic this functionality by automatically removing the "[]" from variable names. Actual [] blocks in payload should be escaped and not modified, but report any problems.
