### PR TITLE
Documentation tweaks

### DIFF
--- a/docs/community/contributors.md
+++ b/docs/community/contributors.md
@@ -5,7 +5,7 @@ The following individuals have made major contributions to Known.
 ## Core team
 
 * Ben Werdmuller [http://werd.io](http://werd.io)
-* Erin Jo Richey [http://erinjo.is](http://erinjo.is)
+* Erin Jo Richey [http://erinjorichey.com/](http://erinjorichey.com/)
 
 Homepage: [https://withknown.com/](https://withknown.com/)
 

--- a/docs/developers/standards.md
+++ b/docs/developers/standards.md
@@ -43,7 +43,7 @@ switch ($var) {
 ## Error handling
 
 * Notice errors are errors, please develop your code with ```pedantic_mode = true;``` set in your config.ini
-* Unless there's a VERY good reason you can explain, never use the '@' error suppression operator.
+* Unless there's a VERY good reason you can explain (and should explain) in comments, never use the '@' error suppression operator.
 
 ## Comments
 


### PR DESCRIPTION
## Here's what I fixed or added:

* Reworded a couple of lines for clarity
* Changed Erin's website address

## Here's why I did it:

Clarity, and because erinjo.is is now a casino spam site.
