### PR TITLE
Only store created time if notification has actually been retrieved.

### DIFF
--- a/Idno/Pages/Service/Notifications/NewNotifications.php
+++ b/Idno/Pages/Service/Notifications/NewNotifications.php
@@ -31,7 +31,8 @@ namespace Idno\Pages\Service\Notifications {
                     return $notif->created > $last_time;
                 });
 
-                $user->last_notification_time = $notifs[0]->created;
+                if (!empty($notifs[0]->created))
+                    $user->last_notification_time = $notifs[0]->created;
                 $user->save();
 
                 $arr = array_map(function ($notif) {


### PR DESCRIPTION


## Here's what I fixed or added:

Only store created time if notification has actually been retrieved.
## Here's why I did it:

This is to avoid a notification loop.