### PR TITLE
Pass annotation permalink as parameter.

### DIFF
--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -190,6 +190,7 @@ namespace Idno\Core {
             $this->addPageHandler('/view/([A-Za-z0-9]+)/annotations/([A-Za-z0-9]+)?', '\Idno\Pages\Annotation\View');
             $this->addPageHandler($permalink_route . '/annotations/([A-Za-z0-9]+)?', '\Idno\Pages\Annotation\View');
             $this->addPageHandler($permalink_route . '/annotations/([A-Za-z0-9]+)/delete/?', '\Idno\Pages\Annotation\Delete'); // Delete annotation
+            $this->addPageHandler($permalink_route .'/annotation/delete/?', '\Idno\Pages\Annotation\Delete'); // Delete annotation alternate
             $this->addPageHandler('/annotation/post/?', '\Idno\Pages\Annotation\Post');
 
             /** Bookmarklets and sharing */

--- a/Idno/Pages/Annotation/Delete.php
+++ b/Idno/Pages/Annotation/Delete.php
@@ -30,8 +30,13 @@ namespace Idno\Pages\Annotation {
             if (empty($object)) {
                 $this->goneContent();
             }
+            
+            $permalink = \Idno\Core\Webservice::base64UrlDecode($this->getInput('permalink'));
 
-            $permalink = $object->getURL() . '/annotations/' . $this->arguments[1];
+            // Default to constructed permalink if one is not provided.
+            if (empty($permalink))
+                $permalink = $object->getURL() . '/annotations/' . $this->arguments[1];
+            
             if ($object->canEditAnnotation($permalink)) {
                 if (($object->removeAnnotation($permalink)) && ($object->save())) {
                     //\Idno\Core\Idno::site()->session()->addMessage(\Idno\Core\Idno::site()->language()->_('The annotation was deleted.'));

--- a/templates/default/content/annotation/edit.tpl.php
+++ b/templates/default/content/annotation/edit.tpl.php
@@ -1,7 +1,7 @@
 <div class="edit edit-annotation">
     <p>
         <?php echo  \Idno\Core\Idno::site()->actions()->createLink(
-            $vars['object']->getUrl() . '/annotation/delete?permalink=' . \Idno\Core\Webservice::base64UrlEncode($vars['annotation_permalink']), //$vars['annotation_permalink'] . '/delete/',
+            $vars['object']->getDisplayUrl() . '/annotation/delete?permalink=' . \Idno\Core\Webservice::base64UrlEncode($vars['annotation_permalink']), //$vars['annotation_permalink'] . '/delete/',
             \Idno\Core\Idno::site()->language()->_('Delete'),
             [],
             ['method' => 'POST']);

--- a/templates/default/content/annotation/edit.tpl.php
+++ b/templates/default/content/annotation/edit.tpl.php
@@ -1,8 +1,10 @@
 <div class="edit edit-annotation">
     <p>
         <?php echo  \Idno\Core\Idno::site()->actions()->createLink(
-                $vars['object']->getUrl() . '/annotation/delete?permalink=' . \Idno\Core\Webservice::base64UrlEncode($vars['annotation_permalink']), //$vars['annotation_permalink'] . '/delete/', 
-                \Idno\Core\Idno::site()->language()->_('Delete'), 
-                [], ['method' => 'POST']);?>
+            $vars['object']->getUrl() . '/annotation/delete?permalink=' . \Idno\Core\Webservice::base64UrlEncode($vars['annotation_permalink']), //$vars['annotation_permalink'] . '/delete/',
+            \Idno\Core\Idno::site()->language()->_('Delete'),
+            [],
+            ['method' => 'POST']);
+        ?>
     </p>
 </div>

--- a/templates/default/content/annotation/edit.tpl.php
+++ b/templates/default/content/annotation/edit.tpl.php
@@ -1,5 +1,8 @@
 <div class="edit edit-annotation">
     <p>
-        <?php echo  \Idno\Core\Idno::site()->actions()->createLink($vars['annotation_permalink'] . '/delete/', \Idno\Core\Idno::site()->language()->_('Delete'), array(), array('method' => 'POST'));?>
+        <?php echo  \Idno\Core\Idno::site()->actions()->createLink(
+                $vars['object']->getUrl() . '/annotation/delete?permalink=' . \Idno\Core\Webservice::base64UrlEncode($vars['annotation_permalink']), //$vars['annotation_permalink'] . '/delete/', 
+                \Idno\Core\Idno::site()->language()->_('Delete'), 
+                [], ['method' => 'POST']);?>
     </p>
 </div>


### PR DESCRIPTION


## Here's what I fixed or added:
Pass annotation permalink as parameter.

## Here's why I did it:

Generating an annotation slug from the current URL causes problems in some cases (e.g. if you're behind a reverse proxy, or have changed your site url).

Solution was to explicitly pass the full slug/annotation permalink rather than construct it on deletion.

Fixes #2260