### PR TITLE
Only display notifications for entities that are available.

### DIFF
--- a/Idno/Pages/Service/Notifications/NewNotifications.php
+++ b/Idno/Pages/Service/Notifications/NewNotifications.php
@@ -34,19 +34,26 @@ namespace Idno\Pages\Service\Notifications {
                 $user->last_notification_time = $notifs[0]->created;
                 $user->save();
 
-                $arr = array_map(function ($notif) {
-                    Idno::site()->template()->setTemplateType('email-text');
-                    $body = Idno::site()->template()->__(['notification' => $notif])->draw($notif->getMessageTemplate());
-                    $annotation = $notif->getObject();
+                $arr = array_filter(array_map(function ($notif) {
+                    
+                    $target = $notif->getTarget();
+                    
+                    if (!empty($target)) { // Ensure that notifications on unavailable targets are not rendered
+                        
+                        Idno::site()->template()->setTemplateType('email-text');
+                        $body = Idno::site()->template()->__(['notification' => $notif])->draw($notif->getMessageTemplate());
+                        $annotation = $notif->getObject();
 
-                    return [
-                        'title' => $notif->getMessage(),
-                        'body' => $body,
-                        'icon' => $annotation['owner_image'],
-                        'created' => date('c', $notif->created),
-                        'link' => (empty($notif->url)) ? \Idno\Core\Idno::site()->config()->getDisplayURL() . 'account/notifications' : $notif->link
-                    ];
-                }, $notifs);
+                        return [
+                            'title' => $notif->getMessage(),
+                            'body' => $body,
+                            'icon' => $annotation['owner_image'],
+                            'created' => date('c', $notif->created),
+                            'link' => (empty($notif->url)) ? \Idno\Core\Idno::site()->config()->getDisplayURL() . 'account/notifications' : $notif->link
+                        ];
+                        
+                    }
+                }, $notifs));
             } else {
                 $arr = [];
             }


### PR DESCRIPTION


## Here's what I fixed or added:
Only display notifications for entities that are available.

## Here's why I did it:
It was reported that notifications could throw an exception in some cases. This happened when the notifications endpoint (which uses the email template to render the message) attempted to do so on a target that was no longer available. This meant that notifications sent on posts which were then deleted would cause all notifications to become unavailable.

Solution was to check that the target was available before it was rendered. 

Fixes #2262
