### PR TITLE
Update Micropub Media Endpoint to return the URL for the uploaded image

### DIFF
--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -128,6 +128,13 @@ namespace IdnoPlugins\IndiePub\Pages\MicroPub {
                 \Idno\Core\Idno::site()->triggerEvent('indiepub/post/success', ['page' => $this, 'object' => $entity]);
                 $this->setResponse(201);
                 header('Location: ' . $local_photo);
+
+                /* return body with the URL to the photo, based upon Accept header */
+                if ($this->isAcceptedContentType('application/json')) {
+                    echo json_encode(['url' => $local_photo], JSON_PRETTY_PRINT);
+                } else {
+                    echo $local_photo;
+                }
             } else {
                 $this->error(400, 'cannot_save_media', 'Problem saving media');
             }


### PR DESCRIPTION
As outlined by this extension:

    https://indieweb.org/micropub_media_endpoint#Response_Body

This enables iOS Shortcuts support for uploading content.