### PR TITLE
Removing :array hint

### DIFF
--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -953,7 +953,7 @@ namespace Idno\Entities {
             return $data;
         }
 
-        public function jsonLDSerialise(array $params = array()): array
+        public function jsonLDSerialise(array $params = array())
         {
             $json = [
                 '@context' => 'http://schema.org',

--- a/IdnoPlugins/Checkin/Checkin.php
+++ b/IdnoPlugins/Checkin/Checkin.php
@@ -97,7 +97,7 @@ namespace IdnoPlugins\Checkin {
             }
         }
 
-        public function jsonLDSerialise(array $params = array()): array
+        public function jsonLDSerialise(array $params = array())
         {
 
             $json = [

--- a/IdnoPlugins/Media/Media.php
+++ b/IdnoPlugins/Media/Media.php
@@ -185,7 +185,7 @@ namespace IdnoPlugins\Media {
 
         }
 
-        public function jsonLDSerialise(array $params = array()): array
+        public function jsonLDSerialise(array $params = array())
         {
 
             $json = [

--- a/IdnoPlugins/Photo/Photo.php
+++ b/IdnoPlugins/Photo/Photo.php
@@ -215,7 +215,7 @@ namespace IdnoPlugins\Photo {
 
         }
 
-        public function jsonLDSerialise(array $params = array()): array
+        public function jsonLDSerialise(array $params = array())
         {
             $json = [
                 "@context" => "http://schema.org",

--- a/IdnoPlugins/Text/Entry.php
+++ b/IdnoPlugins/Text/Entry.php
@@ -127,7 +127,7 @@ namespace IdnoPlugins\Text {
             }
         }
 
-        public function jsonLDSerialise(array $params = array()): array
+        public function jsonLDSerialise(array $params = array())
         {
             $json = [
                 "@context" => "http://schema.org",


### PR DESCRIPTION
the :array syntax hint is not widely supported, it seems. Removing as it's not a massively important thing.