### PR TITLE
Adding a CLI export method

### DIFF
--- a/ConsolePlugins/Export/.gitignore
+++ b/ConsolePlugins/Export/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+!package.json

--- a/ConsolePlugins/Export/Gruntfile.js
+++ b/ConsolePlugins/Export/Gruntfile.js
@@ -1,0 +1,24 @@
+/**
+ * Gruntfile for Export
+ */
+
+module.exports = function (grunt) {
+    // Project configuration.
+    grunt.initConfig({
+	pkg: grunt.file.readJSON('package.json'),
+    });
+
+    
+// Build language pack (todo: find a cleaner way)
+    grunt.registerTask('build-lang', '', function(){
+	
+	const { execSync } = require('child_process');
+	
+	execSync('touch ./languages/export.pot'); // Make sure it exists, if we're going to remove (for broken builds)
+	execSync('rm ./languages/export.pot'); // Remove existing
+	
+	execSync('find . -type f -regex ".*\.php" | php ../../languages/processfile.php >> ./languages/export.pot'); 
+	
+    });
+
+};

--- a/ConsolePlugins/Export/Main.php
+++ b/ConsolePlugins/Export/Main.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace ConsolePlugins\Export {
+
+    use Idno\Core\Migration;
+
+    class Main extends \Idno\Common\ConsolePlugin
+    {
+
+        public static $run = true;
+
+        function registerTranslations()
+        {
+
+            \Idno\Core\Idno::site()->language()->register(
+                new \Idno\Core\GetTextTranslation(
+                    'export', dirname(__FILE__) . '/languages/'
+                )
+            );
+        }
+
+        public function execute(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output)
+        {
+            //$directory = $input->getArgument('directory');
+            $directory = false;
+            
+            \Idno\Core\Idno::site()->config()->export_last_requested = time();
+            \Idno\Core\Idno::site()->config()->export_in_progress    = 1;
+            \Idno\Core\Idno::site()->config()->save();
+            
+            // Remove the previous export file
+            if (!empty(\Idno\Core\Idno::site()->config()->export_file_id)) {
+                if ($file = File::getByID(\Idno\Core\Idno::site()->config()->export_file_id)) {
+                    if ($file instanceof \MongoGridFSFile) {
+                        // TODO: Handle this correctly
+                    } else {
+                        $file->remove();
+                    }
+                    \Idno\Core\Idno::site()->config()->export_file_id  = false;
+                    \Idno\Core\Idno::site()->config()->export_filename = false;
+                    \Idno\Core\Idno::site()->config()->save();
+                }
+            }
+          
+            if ($path = Migration::createCompressedArchive($directory)) {
+
+                \Idno\Core\Idno::site()->config()->export_filename    = $filename;
+                \Idno\Core\Idno::site()->config()->export_file_id     = $file;
+                \Idno\Core\Idno::site()->config()->export_in_progress = 0;
+                \Idno\Core\Idno::site()->config()->save();
+
+                $output->writeln(\Idno\Core\Idno::site()->language()->_("Archive generated at %s", [$path]));
+                
+            } else {
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("Export did not return an archive path."));
+            }
+            
+        }
+
+        public function getCommand()
+        {
+            return 'export';
+        }
+
+        public function getDescription()
+        {
+            return \Idno\Core\Idno::site()->language()->_('Export posts to a number of formats');
+        }
+
+        public function getParameters()
+        {
+            return [
+               // new \Symfony\Component\Console\Input\InputArgument('directory', \Symfony\Component\Console\Input\InputArgument::REQUIRED, \Idno\Core\Idno::site()->language()->_('Location of the directory to export to')),
+            ];
+        }
+
+    }
+
+}

--- a/ConsolePlugins/Export/Main.php
+++ b/ConsolePlugins/Export/Main.php
@@ -3,6 +3,7 @@
 namespace ConsolePlugins\Export {
 
     use Idno\Core\Migration;
+    use Idno\Entities\File;
 
     class Main extends \Idno\Common\ConsolePlugin
     {
@@ -45,7 +46,7 @@ namespace ConsolePlugins\Export {
             if ($path = Migration::createCompressedArchive($directory)) {
 
                 \Idno\Core\Idno::site()->config()->export_filename    = $path;
-                \Idno\Core\Idno::site()->config()->export_file_id     = 1;
+                \Idno\Core\Idno::site()->config()->export_file_id     = false;
                 \Idno\Core\Idno::site()->config()->export_in_progress = 0;
                 \Idno\Core\Idno::site()->config()->save();
 

--- a/ConsolePlugins/Export/Main.php
+++ b/ConsolePlugins/Export/Main.php
@@ -44,8 +44,8 @@ namespace ConsolePlugins\Export {
           
             if ($path = Migration::createCompressedArchive($directory)) {
 
-                \Idno\Core\Idno::site()->config()->export_filename    = $filename;
-                \Idno\Core\Idno::site()->config()->export_file_id     = $file;
+                \Idno\Core\Idno::site()->config()->export_filename    = $path;
+                \Idno\Core\Idno::site()->config()->export_file_id     = 1;
                 \Idno\Core\Idno::site()->config()->export_in_progress = 0;
                 \Idno\Core\Idno::site()->config()->save();
 

--- a/ConsolePlugins/Export/languages/export.pot
+++ b/ConsolePlugins/Export/languages/export.pot
@@ -1,0 +1,16 @@
+#: ./Main.php:52
+msgid "Archive generated at %s"
+msgstr ""
+
+#: ./Main.php:55
+msgid "Export did not return an archive path."
+msgstr ""
+
+#: ./Main.php:67
+msgid "Export posts to a number of formats"
+msgstr ""
+
+#: ./Main.php:73
+msgid "Location of the directory to export to"
+msgstr ""
+

--- a/ConsolePlugins/Export/package.json
+++ b/ConsolePlugins/Export/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "Emport",
+  "version": "0.9.9-a",
+  "devDependencies": {
+    "grunt": "^0.4.5"
+  }
+}

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -142,7 +142,7 @@ namespace Idno\Core {
 
                         if (is_callable(array($object, 'draw'))) {
                             try {
-                                $html = $object->draw();
+                                $html = trim($object->draw());
                                 if (!empty($html)) {
                                     file_put_contents($html_path . $object_name . '.html', $html);
                                 }

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -63,18 +63,19 @@ namespace Idno\Core {
             }
 
             // If we've made it here, we've created a temporary directory with the hash name
-
-            $config = array(
+            
+            // Write some details about the export
+            file_put_contents($dir . $name . DIRECTORY_SEPARATOR . 'known.json', json_encode([
                 'url' => Idno::site()->config()->getURL(),
                 'title' => Idno::site()->config()->getTitle(),
                 // Include some version info in case we change the export format
                 'version' => \Idno\Core\Version::version(),
                 'build' => \Idno\Core\Version::build(),
-            );
-
-            file_put_contents($dir . $name . DIRECTORY_SEPARATOR . 'known.json', json_encode($config, JSON_PRETTY_PRINT));
-            $all_in_one_json = '';
-
+            ], JSON_PRETTY_PRINT));
+            
+            // We now also want to output the current loaded config
+            file_put_contents($dir . $name . DIRECTORY_SEPARATOR . 'config.json', json_encode(\Idno\Core\Idno::site()->config(), JSON_PRETTY_PRINT));
+            
             // Let's export everything.
             $fields = array();
             $query_parameters = array();
@@ -137,7 +138,7 @@ namespace Idno\Core {
                         }
                         $json_object = json_encode($object, JSON_PRETTY_PRINT);
                         file_put_contents($json_path . $object_name . '.json', $json_object);
-                        //$all_in_one_json[] = json_decode($json_object);
+                        
                         fwrite($f, $json_object . ',');
 
                         if (is_callable(array($object, 'draw'))) {
@@ -192,7 +193,6 @@ namespace Idno\Core {
                 fwrite($f, '{}]'); // Fudge to allow json decode
             fclose($f);
 
-            //file_put_contents($dir . $name . DIRECTORY_SEPARATOR . 'entities.json', json_encode($all_in_one_json));
             // As we're successful, return the unique name of the archive
             \Idno\Core\Idno::site()->logging()->debug("Archive constructed at {$dir}{$name}");
             return $dir . $name;

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -171,7 +171,11 @@ namespace Idno\Core {
             $limit = 10;
             $offset = 0;
             $f = fopen($dir . $name . DIRECTORY_SEPARATOR . 'exported_data.' . $export_ext, 'wb');
-            fwrite($f, '[');
+            
+            if ($export_ext == 'json')
+                fwrite($f, '[');
+            
+            
             while ($exported_records = \Idno\Core\Idno::site()->db()->exportRecords('entities', $limit, $offset)) {
 
                 if ($export_ext == 'json')

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -142,7 +142,10 @@ namespace Idno\Core {
 
                         if (is_callable(array($object, 'draw'))) {
                             try {
-                                file_put_contents($html_path . $object_name . '.html', $object->draw());
+                                $html = $object->draw();
+                                if (!empty($html)) {
+                                    file_put_contents($html_path . $object_name . '.html', $html);
+                                }
                             } catch (\Error $e) { // Sometimes calling draw will break since some of the expected context is unavailable at this point. Don't let this kill the whole export.
                                 \Idno\Core\Idno::site()->logging()->debug($e->getMessage());
                             }

--- a/Idno/Data/Mongo.php
+++ b/Idno/Data/Mongo.php
@@ -481,7 +481,7 @@ namespace Idno\Data {
             try {
                 if ($result = $this->getRecords([], [], $limit, $offset, $collection))
                 {
-                    return json_encode($result);
+                    return json_encode($result, JSON_PRETTY_PRINT);
                 }
             } catch (\Exception $e) {
                 return false;

--- a/IdnoPlugins/Event/templates/default/entity/RSVP.tpl.php
+++ b/IdnoPlugins/Event/templates/default/entity/RSVP.tpl.php
@@ -1,5 +1,6 @@
 <?php
-if (\Idno\Core\Idno::site()->currentPage()->isPermalink()) {
+$currentPage = \Idno\Core\Idno::site()->currentPage();
+if (!empty($currentPage) && \Idno\Core\Idno::site()->currentPage()->isPermalink()) {
     $rel = 'rel="in-reply-to" class="u-in-reply-to"';
 } else {
     $rel = '';

--- a/IdnoPlugins/Media/templates/default/entity/Media.tpl.php
+++ b/IdnoPlugins/Media/templates/default/entity/Media.tpl.php
@@ -2,7 +2,8 @@
 
     $player_id = rand(0, 9999);
 
-if (\Idno\Core\Idno::site()->currentPage()->isPermalink()) {
+$currentPage = \Idno\Core\Idno::site()->currentPage();
+if (!empty($currentPage) && \Idno\Core\Idno::site()->currentPage()->isPermalink()) {
     $rel = 'rel="in-reply-to"';
 } else {
     $rel = '';

--- a/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
+++ b/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
@@ -7,7 +7,8 @@
         $multiple = true;
     $cnt = 0;
 
-if (\Idno\Core\Idno::site()->currentPage()->isPermalink()) {
+    $currentPage = \Idno\Core\Idno::site()->currentPage();
+if (!empty($currentPage) && \Idno\Core\Idno::site()->currentPage()->isPermalink()) {
     $rel = 'rel="in-reply-to"';
 } else {
     $rel = '';

--- a/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
+++ b/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
@@ -32,7 +32,7 @@ if (empty($vars['feed_view']) && $vars['object']->getTitle() && $vars['object']-
     if (!empty($attachments)) {
         foreach ($attachments as $attachment) {
 
-            if (!\Idno\Core\Idno::site()->currentPage()->isPermalink()) {
+            if (!empty($currentPage) && !\Idno\Core\Idno::site()->currentPage()->isPermalink()) {
                 if ($cnt == 5 && $num_pics>$cnt) {
                     ?>
     <div class="photo-view photo-view-more">
@@ -71,7 +71,7 @@ if (empty($vars['feed_view']) && $vars['object']->getTitle() && $vars['object']-
 
             ?>
             <div class="photo-view">
-                <a href="<?php echo \Idno\Core\Idno::site()->currentPage()->isPermalink() ? $this->makeDisplayURL($mainsrc) : $vars['object']->getDisplayURL(); ?>" 
+                <a href="<?php echo (!empty($currentPage) && \Idno\Core\Idno::site()->currentPage()->isPermalink()) ? $this->makeDisplayURL($mainsrc) : $vars['object']->getDisplayURL(); ?>" 
                    data-gallery="<?php echo htmlentities(strip_tags($vars['object']->getTitle()), ENT_QUOTES, 'UTF-8'); ?>"
                    data-original-img="<?php echo $this->makeDisplayURL($mainsrc) ?>"
                    data-title="<?php echo htmlentities(strip_tags($vars['object']->getTitle()), ENT_QUOTES, 'UTF-8'); ?>" 

--- a/IdnoPlugins/Text/templates/default/entity/Entry.tpl.php
+++ b/IdnoPlugins/Text/templates/default/entity/Entry.tpl.php
@@ -1,5 +1,6 @@
 <?php
-if (\Idno\Core\Idno::site()->currentPage()->isPermalink()) {
+$currentPage = \Idno\Core\Idno::site()->currentPage();
+if (!empty($currentPage) && \Idno\Core\Idno::site()->currentPage()->isPermalink()) {
     $rel = 'rel="in-reply-to" class="u-in-reply-to"';
 } else {
     $rel = '';


### PR DESCRIPTION
Adds a CLI export function to match the import function, for similar reasons, that CLI has fewer restriction in terms of runtime and memory.

Improved the export function somewhat in order to make it export more safely, and handle errors better.

Still no import for this, PRs welcome.

Discussion: My thinking is that we should actually remove the web interface import and export code, since this is a pretty technical thing to do. Raising the bar slightly to using the CLI (which works better anyway as you're not going to hit so many memory issues) might reduce some of the help questions. Anyway.