### PR TITLE
Changing syndication targets to arrays

### DIFF
--- a/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
+++ b/IdnoPlugins/IndiePub/Pages/MicroPub/Endpoint.php
@@ -66,7 +66,7 @@ namespace IdnoPlugins\IndiePub\Pages\MicroPub {
                         header('Content-Type: application/json');
                         echo json_encode([
                             'media-endpoint' => \Idno\Core\Idno::site()->config()->url . 'micropub/endpoint',
-                            'syndicate-to' => $account_strings,
+                            'syndicate-to' => $account_data,
                         ], JSON_PRETTY_PRINT);
                         break;
                     case 'syndicate-to':


### PR DESCRIPTION
In reference to https://github.com/swentel/indigenous-android/issues/152

Indigenous was throwing errors when using known as it expects syndication targets to be an array, and not string.

I changed this on my own instance of known 0.9.9-a (build = 2018101001) and Indigenous can now read the syndication targets correctly.

I also checked using Quill, and Aperture, where the syndication targets also work.