### PR TITLE
Adds mechanism to escape translated strings.

### DIFF
--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -68,6 +68,17 @@ namespace Idno\Core {
         {
             return vsprintf($this->get($string), $subs);
         }
+        
+        /**
+         * Return an ESCAPED translated string, substituting variables in subs in the format of sprintf.
+         * @param type $string String to translate
+         * @param array $subs List of substitution variables to be used in the translated string
+         * @return string
+         */
+        public function esc_($string, array $subs = []) 
+        {
+            return htmlentities($this->_($string, $subs), ENT_QUOTES, 'UTF-8');
+        }
 
         /**
          * Register a translation.


### PR DESCRIPTION
Sometimes strings need to be escaped in order for them to be safe to be echoed, this adds a helper method to do so.

Closes #2174