### PR TITLE
Document a few useful config items, including smtp

### DIFF
--- a/docs/install/config.md
+++ b/docs/install/config.md
@@ -52,6 +52,18 @@ If you are using MongoDB, you can leave this option blank to use GridFS storage.
 **uploadpath**<br>
 The full path used by Known to upload files. This path must be writeable by the web server.
 
+**smtp_host, smtp_port, smtp_username, smtp_secure, from_email**<br>
+Configuration for SMTP server.  Without these set (here or in the UI)
+it will be impossible to do password recovery emails.
+'smtp_secure' should be 'tls' or 'ssl'.
+
+**loglevel**<br>
+Log levels to show 0 - off, 1 - errors, 2 - errors & warnings,
+3 - errors, warnings and info, 4 - 3 + debug
+
+**debug**<br>
+Enable debugging of various sorts.
+
 ## Other config.ini directives
 
 **alwaysplugins[]**<br>

--- a/docs/install/config.md
+++ b/docs/install/config.md
@@ -64,7 +64,6 @@ Log levels to show:
 * 2 - errors & warnings
 * 3 - errors, warnings, & useful information
 * 4 - errors, warnings, useful information, & debugging output
-3 - errors, warnings and info, 4 - 3 + debug
 
 **debug**<br>
 Enable debugging output.

--- a/docs/install/config.md
+++ b/docs/install/config.md
@@ -54,7 +54,7 @@ The full path used by Known to upload files. This path must be writeable by the 
 
 **smtp_host, smtp_port, smtp_username, smtp_secure, from_email**<br>
 Configuration for SMTP server.  Without these set (here or in the UI)
-it will be impossible to do password recovery emails.
+it will be impossible to send password recovery emails.
 'smtp_secure' should be 'tls' or 'ssl'.
 
 **loglevel**<br>

--- a/docs/install/config.md
+++ b/docs/install/config.md
@@ -58,7 +58,12 @@ it will be impossible to send password recovery emails.
 'smtp_secure' should be 'tls' or 'ssl'.
 
 **loglevel**<br>
-Log levels to show 0 - off, 1 - errors, 2 - errors & warnings,
+Log levels to show:
+* 0 - off
+* 1 - errors
+* 2 - errors & warnings
+* 3 - errors, warnings, & useful information
+* 4 - errors, warnings, useful information, & debugging output
 3 - errors, warnings and info, 4 - 3 + debug
 
 **debug**<br>

--- a/docs/install/config.md
+++ b/docs/install/config.md
@@ -67,7 +67,7 @@ Log levels to show:
 3 - errors, warnings and info, 4 - 3 + debug
 
 **debug**<br>
-Enable debugging of various sorts.
+Enable debugging output.
 
 ## Other config.ini directives
 


### PR DESCRIPTION
If you accidentally lock yourself out of your install and you haven’t configured smtp, it’s nice to be able to do so, so you can get your password back.
