### PR TITLE
Adding content type filtering support to user profiles

### DIFF
--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -212,6 +212,7 @@ namespace Idno\Core {
             /** Users */
             $this->addPageHandler('/profile/([^\/]+)/?', '\Idno\Pages\User\View');
             $this->addPageHandler('/profile/([^\/]+)/edit/?', '\Idno\Pages\User\Edit');
+            $this->addPageHandler('/profile/([^\/]+)/([A-Za-z\-\/]+)+', '\Idno\Pages\User\View');
 
             /** Search */
             $this->addPageHandler('/search/?', '\Idno\Pages\Search\Forward');

--- a/Idno/Pages/User/View.php
+++ b/Idno/Pages/User/View.php
@@ -33,12 +33,12 @@ namespace Idno\Pages\User {
             $this->setOwner($user);
             $this->setPermalink(); // This is a permalink
 
-             if (!empty($this->arguments[1])) { // If we're on the friendly content-specific URL
+            if (!empty($this->arguments[1])) { // If we're on the friendly content-specific URL
                 if ($friendly_types = explode('/', $this->arguments[1])) {
                     $friendly_types = array_filter($friendly_types);
-                    
+
                     $types = array();
-                    
+
                     // Run through the URL parameters and set content types appropriately
                     foreach ($friendly_types as $friendly_type) {
                         if ($friendly_type == 'all') {

--- a/Idno/Pages/User/View.php
+++ b/Idno/Pages/User/View.php
@@ -33,7 +33,26 @@ namespace Idno\Pages\User {
             $this->setOwner($user);
             $this->setPermalink(); // This is a permalink
 
-            $types  = ['IdnoPlugins\Status\Status', 'IdnoPlugins\Text\Entry'];
+             if (!empty($this->arguments[1])) { // If we're on the friendly content-specific URL
+                if ($friendly_types = explode('/', $this->arguments[1])) {
+                    $friendly_types = array_filter($friendly_types);
+                    
+                    $types = array();
+                    
+                    // Run through the URL parameters and set content types appropriately
+                    foreach ($friendly_types as $friendly_type) {
+                        if ($friendly_type == 'all') {
+                            $types = \Idno\Common\ContentType::getRegisteredClasses();
+                            break;
+                        }
+                        if ($content_type_class = \Idno\Common\ContentType::categoryTitleToClass($friendly_type)) {
+                            $types[] = $content_type_class;
+                        }
+                    }
+                }
+            } else {
+                $types  = ['IdnoPlugins\Status\Status', 'IdnoPlugins\Text\Entry'];
+            }
             $offset = (int)$this->getInput('offset');
             $count  = \Idno\Common\Entity::countFromX($types, array('owner' => $user->getUUID(), 'publish_status' => 'published'));
             $feed   = \Idno\Common\Entity::getFromX($types, array('owner' => $user->getUUID(), 'publish_status' => 'published'), array(), \Idno\Core\Idno::site()->config()->items_per_page, $offset);


### PR DESCRIPTION


## Here's what I fixed or added:
Adding content type filtering support to user profiles
## Here's why I did it:

Previously, user profiles were hard coded to specific content types. 

Solution was to add support to list content types, identical to how it functions on the Homepage.

Refs #178
