### PR TITLE
Comments plugin: IDs were not unique causing errors

### DIFF
--- a/IdnoPlugins/Comments/templates/default/comments/public/form.tpl.php
+++ b/IdnoPlugins/Comments/templates/default/comments/public/form.tpl.php
@@ -5,6 +5,8 @@
     $name_field = \Idno\Core\Bonita\Forms::obfuscateField('name');
     $url_field = \Idno\Core\Bonita\Forms::obfuscateField('url');
 
+    $uuid = substr($object->getUUID(), -5);
+
 if (!\Idno\Core\Idno::site()->session()->isLoggedOn() && $object instanceof \Idno\Common\Entity) {
     ?>
         <div class="row annotation-add">
@@ -13,7 +15,7 @@ if (!\Idno\Core\Idno::site()->session()->isLoggedOn() && $object instanceof \Idn
                                                        src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>gfx/users/default-00.png"/>
                 </div>
             </div>
-            <div class="col-md-10 idno-comment-container" id="comment-form">
+            <div class="col-md-10 idno-comment-container" id="comment-form-<?= $uuid; ?>">
                 <div class="form-group">
                     <input type="text" name="name" class="form-control" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_("You probably shouldn't fill this in"); ?>" style="display: none;" >
                     <input type="url" name="url" class="form-control" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_("You probably shouldn't fill this in"); ?>" style="display: none;" >
@@ -24,11 +26,11 @@ if (!\Idno\Core\Idno::site()->session()->isLoggedOn() && $object instanceof \Idn
                 <div class="form-group">
                     <input type="url" name="<?=$url_field?>" class="form-control" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_('Your website address'); ?>">
                 </div>
-                <div id="extrafield" style="display:none"></div>
+                <div class="extrafield" style="display:none"></div>
                 <div class="form-group">
                     <textarea name="body" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_('Add a comment ...'); ?>" class="form-control mentionable"></textarea>
                 </div>
-                <p style="text-align: right" id="comment-submit">
+                <p style="text-align: right" class="comment-submit">
                     <?php echo \Idno\Core\Idno::site()->actions()->signForm('annotation/post') ?>
                 </p>
             </div>
@@ -37,9 +39,10 @@ if (!\Idno\Core\Idno::site()->session()->isLoggedOn() && $object instanceof \Idn
             $(document).ready(function () {
 
                 setTimeout(function() {
-                    $('#extrafield').html('<input type="hidden" name="validator" value="<?php echo $object->getUUID()?>">');
-                    $('#comment-form').html('<form action="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>comments/post" method="post">' + $('#comment-form').html() + '</form>');
-                    $('#comment-submit').append('<input type="hidden" name="object" value="<?php echo $object->getUUID() ?>"><input type="hidden" name="type" value="reply"><input type="submit" class="btn btn-save" value="<?php echo \Idno\Core\Idno::site()->language()->_('Leave Comment'); ?>">');
+                    $commentForm = $('#comment-form-<?=$uuid; ?>');
+                    $commentForm.find('.extrafield').html('<input type="hidden" name="validator" value="<?php echo $object->getUUID()?>">');
+                    $commentForm.html('<form action="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>comments/post" method="post">' + $commentForm.html() + '</form>');
+                    $commentForm.find('.comment-submit').append('<input type="hidden" name="object" value="<?php echo $object->getUUID() ?>"><input type="hidden" name="type" value="reply"><input type="submit" class="btn btn-save" value="<?php echo \Idno\Core\Idno::site()->language()->_('Leave Comment'); ?>">');
                 },4000);
 
             })


### PR DESCRIPTION
## Here's what I fixed or added:

Replaced id="comment-form" with id="comment-form-(last 5 digits of uuid)" in `comments/public/form.tpl.php` and fix the related JS.

## Here's why I did it:

Specifically I detected this in the /profile/username page, this was causing bugs because IDs were being repeated from post to post. Maybe somewhere else the same error could occur.

