### PR TITLE
getAdmins has a default offset value

### DIFF
--- a/Idno/Core/Admin.php
+++ b/Idno/Core/Admin.php
@@ -42,7 +42,7 @@ namespace Idno\Core {
          * @param type $offset
          * @return type
          */
-        static function getAdmins($limit = 10, $offset)
+        static function getAdmins($limit = 10, $offset = 0)
         {
             return \Idno\Entities\User::get(['admin' => true], [], $limit, $offset);
         }


### PR DESCRIPTION
## Here's what I fixed or added:

The moved `getAdmins()` method didn't have a default value for `offset`, so needed exactly two parameters, breaking some plugins that depended on it. Additionally, methods should always supply  a default value for `offset`.
