### PR TITLE
Add getIcon method to Photo.php

### DIFF
--- a/IdnoPlugins/Photo/Photo.php
+++ b/IdnoPlugins/Photo/Photo.php
@@ -35,6 +35,24 @@ namespace IdnoPlugins\Photo {
         {
             return array('type' => 'photo');
         }
+        
+        /**
+         * Retrieve icon
+         * @return mixed|string
+         */
+        function getIcon()
+        {
+            $urls = [];
+            if (!empty($this->thumbs_large)) {
+                foreach ($this->thumbs_large as $filename => $data) {
+                    $urls[] = preg_replace('/^(https?:\/\/\/)/', \Idno\Core\Idno::site()->config()->url, $data['url']);
+                }
+            }
+            if (!empty($urls)) {
+                return $urls[0];
+            }
+            return parent::getIcon();
+        }
 
         /**
          * Extend json serialisable to include some extra data


### PR DESCRIPTION
Allows the image to show up in the opengraph metadata.

## Here's what I fixed or added:

Imitating the getIcon{} override in IdnoPlugins/Text/Entry.php, added an override.  Based the code for finding an image on the code in jsonSerialize().  Chose the large image.

## Here's why I did it:

So photo posts could use their photos as thumbnails for Facebook

## Checklist:

- [x ] This pull request addresses a single issue
- [ x] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x ] I've adhered to Known's style guide (I think so?)
- [x ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x ] I've tested my code in-browser
- [x ] My code contains descriptive comments
- [ ] I've added tests where applicable

