### PR TITLE
Allow plugins to add data attributes to object types

### DIFF
--- a/Idno/Core/Template.php
+++ b/Idno/Core/Template.php
@@ -26,6 +26,9 @@ namespace Idno\Core {
         // We can also extend templates with HTML or other content
         public $rendered_extensions = array();
 
+        // Keep track of data attributes to add to objects of certain types
+        public $object_data = [];
+
         // Keep track of the HTML purifier
         public $purifier = false;
 
@@ -247,6 +250,48 @@ namespace Idno\Core {
             } else {
                 $this->rendered_extensions[$templateName] .= $content;
             }
+        }
+
+        /**
+         * Stores data attributes to be attached to a particular object type
+         * @param $objectType An activity streams object type ('article', 'note', 'photo', etc)
+         * @param $label
+         * @param $value
+         */
+        function addDataToObjectType($objectType, $label, $value)
+        {
+            if (empty($this->object_data[$objectType])) {
+                $this->object_data[$objectType] = [$label => $value];
+            } else {
+                $this->object_data[$objectType][$label] = $value;
+            }
+        }
+
+        /**
+         * Returns an array of data attributes to be attached to a particular object type
+         * @param $objectType An activity streams object type ('article', 'note', 'photo', etc)
+         * @return array
+         */
+        function getDataForObjectType($objectType)
+        {
+            if (!empty($this->object_data[$objectType])) return $this->object_data[$objectType];
+            return [];
+        }
+
+        /**
+         * Returns a string of data attributes to be attached to the HTML of a particular object type
+         * @param $objectType
+         * @return string
+         */
+        function getDataHTMLAttributesForObjectType($objectType)
+        {
+            $attributes = [];
+            if ($data = $this->getDataForObjectType($objectType)) {
+                foreach($data as $label => $value) {
+                    $attributes[] = 'data-' . $label . '="'.addslashes($value).'"';
+                }
+            }
+            return implode(' ', $attributes);
         }
 
         /**

--- a/Tests/Core/TemplateTest.php
+++ b/Tests/Core/TemplateTest.php
@@ -31,6 +31,18 @@ namespace Tests\Core {
 
         }
 
+        function testDataAttributes()
+        {
+
+            $t = new Template();
+            $t->addDataToObjectType('testobject', 'foo', 'bar');
+            $t->addDataToObjectType('testobject', 'foo2', '"What?!"');
+            $t->addDataToObjectType('testobject2', 'foo3', '!');
+
+            $this->assertEquals('data-foo="bar" data-foo2="\"What?!\""', $t->getDataHTMLAttributesForObjectType('testobject'));
+
+        }
+
     }
 
 }

--- a/templates/default/entity/shell.tpl.php
+++ b/templates/default/entity/shell.tpl.php
@@ -8,7 +8,8 @@ if ($object) {
             <div class="row idno-entry idno-entry-<?php
             if (preg_match('@\\\\([\w]+)$@', get_class($object), $matches)) {
                 echo strtolower($matches[1]);
-            }?> <?php echo $object->getMicroformats2ObjectType() ?> idno-<?php echo $object->getContentTypeCategorySlug() ?> idno-object">
+            }?> <?php echo $object->getMicroformats2ObjectType() ?> idno-<?php echo $object->getContentTypeCategorySlug() ?> idno-object"
+            <?php echo $this->getDataHTMLAttributesForObjectType($object->getActivityStreamsObjectType()); ?>>
 
                 <div class="col-md-1 col-md-offset-1 owner p-author h-card visible-md visible-lg">
                     <p>


### PR DESCRIPTION
## Here's what I fixed or added:

Plugins can now add data attributes to object types

## Here's why I did it:

To allow for smarter front-end capabilities.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [x] I've added tests where applicable
