### PR TITLE
Adding missing translation

### DIFF
--- a/IdnoPlugins/Text/languages/text.pot
+++ b/IdnoPlugins/Text/languages/text.pot
@@ -1,25 +1,5 @@
-#: ./Pages/Delete.php:27
-msgid "Delete %s"
-msgstr ""
-
-#: ./Pages/Delete.php:41
-msgid "You don't have permission to perform this task."
-msgstr ""
-
-#: ./Pages/Delete.php:46
-msgid "%s was deleted."
-msgstr ""
-
-#: ./Pages/Delete.php:48
-msgid "We couldn't delete %s."
-msgstr ""
-
-#: ./Pages/Edit.php:42
-msgid "Write an entry"
-msgstr ""
-
-#: ./Pages/Edit.php:44
-msgid "Edit entry"
+#: ./Entry.php:116
+msgid "You can\'t save an empty entry."
 msgstr ""
 
 #: ./templates/default/entity/Entry/edit.tpl.php:36
@@ -46,7 +26,31 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: ./Entry.php:116
-msgid "You can\'t save an empty entry."
+#: ./templates/default/entity/Entry.tpl.php:33
+msgid "%d min read"
+msgstr ""
+
+#: ./Pages/Delete.php:27
+msgid "Delete %s"
+msgstr ""
+
+#: ./Pages/Delete.php:41
+msgid "You don't have permission to perform this task."
+msgstr ""
+
+#: ./Pages/Delete.php:46
+msgid "%s was deleted."
+msgstr ""
+
+#: ./Pages/Delete.php:48
+msgid "We couldn't delete %s."
+msgstr ""
+
+#: ./Pages/Edit.php:42
+msgid "Write an entry"
+msgstr ""
+
+#: ./Pages/Edit.php:44
+msgid "Edit entry"
 msgstr ""
 

--- a/IdnoPlugins/Text/templates/default/entity/Entry.tpl.php
+++ b/IdnoPlugins/Text/templates/default/entity/Entry.tpl.php
@@ -30,9 +30,9 @@ if (empty($vars['feed_view']) && empty($vars['object']->notime)) {
             <span class="vague"><?php
 
                 $minutes = $vars['object']->getReadingTimeInMinutes();
-                echo $minutes . ' min';
+                echo \Idno\Core\Idno::site()->language()->_('%d min read', [$minutes]);
 
-            ?> read </span>
+            ?></span>
         </p>
     <?php
 


### PR DESCRIPTION
## Here's what I fixed or added:

Adding a missing translation hook for the Text plugin

## Here's why I did it:

It was missing, it shouldn't have been

## Checklist:

- [x] This pull request addresses a single issue
- [x] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [x] I've added tests where applicable
