### PR TITLE
Move the backing and sponsors buttons next to build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
+[![Build Status](https://travis-ci.org/idno/Known.svg?branch=master)](https://travis-ci.org/idno/Known) 
+[![Backers on Open Collective](https://opencollective.com/known/backers/badge.svg)](#backers) 
+[![Sponsors on Open Collective](https://opencollective.com/known/sponsors/badge.svg)](#sponsors) 
+
 # Known: a social group platform
 
 ![Known - A social group platform](https://withknown.com/img/home/screens.png)
 
 ## Installation 
-[![Build Status](https://travis-ci.org/idno/Known.svg?branch=master)](https://travis-ci.org/idno/Known) 
-[![Backers on Open Collective](https://opencollective.com/known/backers/badge.svg)](#backers) 
-[![Sponsors on Open Collective](https://opencollective.com/known/sponsors/badge.svg)](#sponsors) 
 
 ### One-click Known sites
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ![Known - A social group platform](https://withknown.com/img/home/screens.png)
 
-## Installation [![Build Status](https://travis-ci.org/idno/Known.svg?branch=master)](https://travis-ci.org/idno/Known)[![Backers on Open Collective](https://opencollective.com/known/backers/badge.svg)](#backers)
- [![Sponsors on Open Collective](https://opencollective.com/known/sponsors/badge.svg)](#sponsors) 
+## Installation [![Build Status](https://travis-ci.org/idno/Known.svg?branch=master)](https://travis-ci.org/idno/Known)[![Backers on Open Collective](https://opencollective.com/known/backers/badge.svg)](#backers)[![Sponsors on Open Collective](https://opencollective.com/known/sponsors/badge.svg)](#sponsors) 
 
 ### One-click Known sites
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 ![Known - A social group platform](https://withknown.com/img/home/screens.png)
 
-## Installation [![Build Status](https://travis-ci.org/idno/Known.svg?branch=master)](https://travis-ci.org/idno/Known)[![Backers on Open Collective](https://opencollective.com/known/backers/badge.svg)](#backers)[![Sponsors on Open Collective](https://opencollective.com/known/sponsors/badge.svg)](#sponsors) 
+## Installation 
+[![Build Status](https://travis-ci.org/idno/Known.svg?branch=master)](https://travis-ci.org/idno/Known) 
+[![Backers on Open Collective](https://opencollective.com/known/backers/badge.svg)](#backers) 
+[![Sponsors on Open Collective](https://opencollective.com/known/sponsors/badge.svg)](#sponsors) 
 
 ### One-click Known sites
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Known: a social group platform
-[![Backers on Open Collective](https://opencollective.com/known/backers/badge.svg)](#backers)
- [![Sponsors on Open Collective](https://opencollective.com/known/sponsors/badge.svg)](#sponsors) 
+
 ![Known - A social group platform](https://withknown.com/img/home/screens.png)
 
-## Installation [![Build Status](https://travis-ci.org/idno/Known.svg?branch=master)](https://travis-ci.org/idno/Known)
+## Installation [![Build Status](https://travis-ci.org/idno/Known.svg?branch=master)](https://travis-ci.org/idno/Known)[![Backers on Open Collective](https://opencollective.com/known/backers/badge.svg)](#backers)
+ [![Sponsors on Open Collective](https://opencollective.com/known/sponsors/badge.svg)](#sponsors) 
 
 ### One-click Known sites
 


### PR DESCRIPTION
## Here's what I fixed or added:

Move the backing and sponsors buttons next to build status

## Here's why I did it:

Just tidying up

## Checklist:

- [x] This pull request addresses a single issue
- [x] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [x] I've added tests where applicable