### PR TITLE
Whitelist certain iframe sources

### DIFF
--- a/Idno/Core/Purifier.php
+++ b/Idno/Core/Purifier.php
@@ -22,6 +22,10 @@ namespace Idno\Core {
                 'maps.google.com/'
             ];
 
+            if (!empty(Idno::site()->config()->allowedIframes) && is_array(Idno::site()->config()->allowedIframes)) {
+                $allowedIframes = array_merge($allowedIframes, Idno::site()->config()->allowedIframes);
+            }
+
             $config = \HTMLPurifier_Config::createDefault();
             $config->set('Cache.SerializerPath', $upload_dir);
             $config->set('HTML.SafeIframe', true);

--- a/Idno/Core/Purifier.php
+++ b/Idno/Core/Purifier.php
@@ -14,8 +14,18 @@ namespace Idno\Core {
                 $upload_dir = \Idno\Core\Idno::site()->config()->getTempDir();
             }
 
+            $allowedIframes = [
+                'www.youtube.com/embed/',
+                'player.vimeo.com/video/',
+                'embed.radiopublic.com/e',
+                'w.soundcloud.com/player/',
+                'maps.google.com/'
+            ];
+
             $config = \HTMLPurifier_Config::createDefault();
             $config->set('Cache.SerializerPath', $upload_dir);
+            $config->set('HTML.SafeIframe', true);
+            $config->set('URI.SafeIframeRegexp', '%^https?://('.implode($allowedIframes,'|').')%');
             $this->purifier = new \HTMLPurifier($config);
         }
 


### PR DESCRIPTION
## Here's what I fixed or added:

HTMLPurifier now allows iframes for YouTube, Vimeo, SoundCloud, RadioPublic, and Google Maps by default.

Users can also whitelist other iframe sources using the new `allowedIframes` config setting.

Fixes #2314

## Here's why I did it:

Users should absolutely be allowed to post safe iframes of their choice.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable
