### PR TITLE
Rebranding the legacy "audio" plugin as a "media" plugin. 

### DIFF
--- a/IdnoPlugins/Media/ContentType.php
+++ b/IdnoPlugins/Media/ContentType.php
@@ -5,8 +5,8 @@ namespace IdnoPlugins\Media {
     class ContentType extends \Idno\Common\ContentType
     {
 
-        public $title = 'Audio';
-        public $category_title = 'Audio';
+        public $title = 'Media';
+        public $category_title = 'Media';
         public $entity_class = 'IdnoPlugins\\Media\\Media';
         public $indieWebContentType = array('media','audio','video');
 

--- a/IdnoPlugins/Media/Pages/Edit.php
+++ b/IdnoPlugins/Media/Pages/Edit.php
@@ -31,9 +31,9 @@ namespace IdnoPlugins\Media\Pages {
             $body = $t->__(['body' => $edit_body])->draw('entity/editwrapper');
 
             if (empty($object)) {
-                $title = \Idno\Core\Idno::site()->language()->_('Upload audio');
+                $title = \Idno\Core\Idno::site()->language()->_('Upload media');
             } else {
-                $title = \Idno\Core\Idno::site()->language()->_('Edit audio details');
+                $title = \Idno\Core\Idno::site()->language()->_('Edit media details');
             }
 
             if (!empty($this->xhr)) {

--- a/IdnoPlugins/Media/languages/media.pot
+++ b/IdnoPlugins/Media/languages/media.pot
@@ -15,23 +15,23 @@ msgid "We couldn't delete your media."
 msgstr ""
 
 #: ./Pages/Edit.php:34
-msgid "Upload audio"
+msgid "Upload media"
 msgstr ""
 
 #: ./Pages/Edit.php:36
-msgid "Edit audio details"
+msgid "Edit media details"
 msgstr ""
 
 #: ./templates/default/entity/Media/edit.tpl.php:13
-msgid "New Audio"
+msgid "New Media"
 msgstr ""
 
 #: ./templates/default/entity/Media/edit.tpl.php:15
-msgid "Edit Audio"
+msgid "Edit Media"
 msgstr ""
 
 #: ./templates/default/entity/Media/edit.tpl.php:25
-msgid "Choose different audio"
+msgid "Choose different media"
 msgstr ""
 
 #: ./templates/default/entity/Media/edit.tpl.php:38
@@ -43,7 +43,7 @@ msgid "Give it a title"
 msgstr ""
 
 #: ./templates/default/entity/Media/edit.tpl.php:54
-msgid "Describe your audio"
+msgid "Describe your media"
 msgstr ""
 
 #: ./templates/default/entity/Media/edit.tpl.php:55

--- a/IdnoPlugins/Media/plugin.ini
+++ b/IdnoPlugins/Media/plugin.ini
@@ -1,7 +1,7 @@
 [Plugin description]
-name =              "Audio"
+name =              "Media"
 version =           0.9.9-a
 author =            "Known"
 author_email =      "feedback@withknown.com"
 author_url =        "https://withknown.com"
-description =       "Upload audio or music and turn your site into a podcast."
+description =       "Upload audio or video."

--- a/IdnoPlugins/Media/templates/default/entity/Media/edit.tpl.php
+++ b/IdnoPlugins/Media/templates/default/entity/Media/edit.tpl.php
@@ -10,9 +10,9 @@
                 <?php
 
                 if (empty($vars['object']->_id)) {
-                    ?><?php echo \Idno\Core\Idno::site()->language()->_('New Audio'); ?><?php
+                    ?><?php echo \Idno\Core\Idno::site()->language()->_('New Media'); ?><?php
                 } else {
-                    ?><?php echo \Idno\Core\Idno::site()->language()->_('Edit Audio'); ?><?php
+                    ?><?php echo \Idno\Core\Idno::site()->language()->_('Edit Media'); ?><?php
                 }
 
                 ?>
@@ -22,7 +22,7 @@
                 
                 <label>
                     <span class="btn btn-primary btn-file">
-                        <i class="fa fa-play-circle"></i> <span id="media-filename"><?php if (empty($vars['object']->_id)) { ?><?php echo \Idno\Core\Idno::site()->language()->_('Upload audio'); ?><?php } else { ?><?php echo \Idno\Core\Idno::site()->language()->_('Choose different audio'); ?><?php } ?></span> 
+                        <i class="fa fa-play-circle"></i> <span id="media-filename"><?php if (empty($vars['object']->_id)) { ?><?php echo \Idno\Core\Idno::site()->language()->_('Upload media'); ?><?php } else { ?><?php echo \Idno\Core\Idno::site()->language()->_('Choose different media'); ?><?php } ?></span> 
                         <?php echo $this->__([
                         'name' => 'media',
                         'id' => 'media',
@@ -51,7 +51,7 @@
                 'wordcount' => false,
                 'height' => 250,
                 'class' => 'wysiwyg-short',
-                'placeholder' => \Idno\Core\Idno::site()->language()->_('Describe your audio'),
+                'placeholder' => \Idno\Core\Idno::site()->language()->_('Describe your media'),
                 'label' => \Idno\Core\Idno::site()->language()->_('Description'),
             ])->draw('forms/input/richtext')?>
             <?php echo $this->draw('entity/tags/input');?>

--- a/IdnoPlugins/Media/templates/default/entity/Media/icon.tpl.php
+++ b/IdnoPlugins/Media/templates/default/entity/Media/icon.tpl.php
@@ -1,1 +1,1 @@
-<i class="fa fa-microphone"></i>
+<i class="fa fa-podcast"></i>


### PR DESCRIPTION
This effort was halfway done, and this change should bring it all the way there.

## Here's what I fixed or added:

Renamed "audio" in relevant places to "video" and picked a more appropriate icon.

## Here's why I did it:

Inconsistency makes me sad.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [ ] I've added tests where applicable