### PR TITLE
Removing plugin directory autoloader.

### DIFF
--- a/Idno/Core/Plugins.php
+++ b/Idno/Core/Plugins.php
@@ -23,18 +23,7 @@ namespace Idno\Core {
          */
         public function init()
         {
-
-            // Add a classloader to look for a package autoloader
-            // TODO: make sure this works with multitenant sites and plugins on an external path
-            spl_autoload_register(function ($class) {
-                if (!empty(\Idno\Core\Idno::site()->config->config['plugins']))
-                foreach (\Idno\Core\Idno::site()->config->config['plugins'] as $plugin) {
-                    if (file_exists(\Idno\Core\Idno::site()->config()->path . '/IdnoPlugins/' . $plugin . '/autoloader.php')) {
-                        include_once(\Idno\Core\Idno::site()->config()->path . '/IdnoPlugins/' . $plugin . '/autoloader.php');
-                    }
-                }
-            });
-
+            
             if (!empty(\Idno\Core\Idno::site()->config()->directloadplugins)) {
                 foreach (\Idno\Core\Idno::site()->config()->directloadplugins as $plugin => $folder) {
                     @include $folder . '/Main.php';


### PR DESCRIPTION


## Here's what I fixed or added:
Removing plugin directory autoloader.
## Here's why I did it:
The autoloader used to handle situations where an actual Known plugin exists inside a subfolder in a github checkout.

Unfortunately, this was clunky and didn't really work very well, and there's got to be a better way of doing. Probably with *gulp* composer.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable
