### PR TITLE
Using componentFactory for file systems.

### DIFF
--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -89,13 +89,16 @@ namespace Idno\Core {
                     break;
                 default:
                     
-                    $this->filesystem = $this->componentFactory($this->config->filesystem, "Idno\\Files\\FileSystem", "Idno\\Files\\", "Idno\\Files\\LocalFileSystem");
-                    
                     if (empty($this->filesystem)) {
                         if ($fs = $this->db()->getFilesystem()) {
                             $this->filesystem = $fs;
                         }
                     }
+                    
+                    if (!empty($this->config->filesystem)) {
+                        $this->filesystem = $this->componentFactory($this->config->filesystem, "Idno\\Files\\FileSystem", "Idno\\Files\\", "Idno\\Files\\LocalFileSystem");
+                    }
+                    
                     break;
             }
 

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -88,10 +88,9 @@ namespace Idno\Core {
                     $this->filesystem = new \Idno\Files\LocalFileSystem();
                     break;
                 default:
-                    if (class_exists("Idno\\Files\\{$this->config->filesystem}")) {
-                        $filesystem       = "Idno\\Files\\{$this->config->filesystem}";
-                        $this->filesystem = new $filesystem();
-                    }
+                    
+                    $this->filesystem = $this->componentFactory($this->config->filesystem, "Idno\\Files\\FileSystem", "Idno\\Files\\", "Idno\\Files\\LocalFileSystem");
+                    
                     if (empty($this->filesystem)) {
                         if ($fs = $this->db()->getFilesystem()) {
                             $this->filesystem = $fs;


### PR DESCRIPTION



## Here's what I fixed or added:
Using componentFactory for file systems.
## Here's why I did it:
Previously, there was not a unified way to specify alternative filesystems, and plugins (including the S3 plugin) had to resort to the dark arts to install themselves. 

Solution was to use the component factory to unify this mechanism.
## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable
