### PR TITLE
Updating Flickr import link

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -64,7 +64,7 @@ listings here do not imply endorsement by the Known project team in any way.
 
 ### Import and Export
 
-* [Flickr Import](https://github.com/mapkyca/KnownFlickrImport) – Import content from your Flickr account, 
+* [Flickr Import](https://github.com/mapkyca/KnownFlickrDumpImport) – Import content from your Flickr account, 
     by [Marcus Povey][]
 * [File Picker](https://github.com/Decentralized–Sharing–Working–Group/idno–file–picker) – pick files from your
     Cozy, ownCloud, or remoteStorage server, by [Decentralized Sharing Community Group][decsharing]


### PR DESCRIPTION
## Here's what I fixed or added:

Updated the Flickr import link
## Here's why I did it:

The project referenced is deprecated, use the new one.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable