### PR TITLE
Remove HTML Purifier

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -41,8 +41,6 @@ listings here do not imply endorsement by the Known project team in any way.
 
 ### System and Security
 
-* [HTML Output sanitisation](https://github.com/mapkyca/KnownHTMLPurifier) – Provides HTML Purifier user output sanitisation, 
-    by [Marcus Povey][]
 * [Two Factor Authentication](https://github.com/mapkyca/Known2FA) – Two factor authentication for logins, 
     by [Marcus Povey][]
 * [Sitemap.xml](https://github.com/mapkyca/KnownSitemap) – Automatically generate a sitemap.xml for your site, 


### PR DESCRIPTION



## Here's what I fixed or added:
Remove HTML Purifier
## Here's why I did it:

HTML Purifier is now in core (has been for a while), this plugin is no longer needed.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable