### PR TITLE
Remove 'camera' attribute from file upload

### DIFF
--- a/templates/default/entity/User/edit.tpl.php
+++ b/templates/default/entity/User/edit.tpl.php
@@ -24,7 +24,6 @@
                             <input type="file" name="avatar" id="photo"
                                    class="form-control"
                                    accept="image/*"
-                                   capture="camera"
                                    onchange="photoPreview(this)"/>
 
                         </span>


### PR DESCRIPTION



## Here's what I fixed or added:
Remove 'camera' attribute from file upload
## Here's why I did it:
Bringing this in line with that of the photos plugin, and hopefully avoid issues on mobile where camera capture is forced.

Closes #2311
## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable
