### PR TITLE
Modify filesystem to allow storing data from memory

### DIFF
--- a/Idno/Files/FileSystem.php
+++ b/Idno/Files/FileSystem.php
@@ -26,6 +26,15 @@ namespace Idno\Files {
          * @return id of file
          */
         abstract function storeFile($file_path, $metadata, $options);
+        
+        /**
+         * Store file from contents already loaded.
+         * @param $contents
+         * @param $metadata
+         * @param $options
+         * @return id of file
+         */
+        abstract function storeContent($content, $metadata, $options);
 
         /**
          * Get a translated error message for PHP Upload errors.

--- a/Idno/Files/FileSystem.php
+++ b/Idno/Files/FileSystem.php
@@ -25,7 +25,7 @@ namespace Idno\Files {
          * @param $options
          * @return id of file
          */
-        abstract function storeFile($file_path, $metadata, $options);
+        abstract function storeFile($file_path, $metadata, $options = []);
         
         /**
          * Store file from contents already loaded.
@@ -34,7 +34,7 @@ namespace Idno\Files {
          * @param $options
          * @return id of file
          */
-        abstract function storeContent($content, $metadata, $options);
+        abstract function storeContent($content, $metadata, $options = []);
 
         /**
          * Get a translated error message for PHP Upload errors.

--- a/Idno/Files/LocalFileSystem.php
+++ b/Idno/Files/LocalFileSystem.php
@@ -107,6 +107,57 @@ namespace Idno\Files {
             return false;
         }
 
+        public function storeContent($content, $metadata, $options) {
+            
+            if (!empty($content) && $path = \Idno\Core\Idno::site()->config()->uploadpath) {
+
+                // Encode metadata for saving
+                $metadata = json_encode($metadata);
+
+                // Generate a random ID
+                $id = md5(mt_rand() . microtime(true) . $metadata);
+
+                // Generate save path
+                if (substr($path, -1) != '/') {
+                    $path .= '/';
+                }
+                $upload_file = $path . \Idno\Core\Idno::site()->config()->getFileBaseDirName() . '/' . $id[0] . '/' . $id[1] . '/' . $id[2] . '/' . $id[3] . '/' . $id . '.file';
+                $data_file   = $path . \Idno\Core\Idno::site()->config()->getFileBaseDirName() . '/' . $id[0] . '/' . $id[1] . '/' . $id[2] . '/' . $id[3] . '/' . $id . '.data';
+
+                try {
+                    foreach (array($path . \Idno\Core\Idno::site()->config()->getFileBaseDirName(), $path . \Idno\Core\Idno::site()->config()->host . '/' . $id[0], $path . \Idno\Core\Idno::site()->config()->host . '/' . $id[0] . '/' . $id[1], $path . \Idno\Core\Idno::site()->config()->host . '/' . $id[0] . '/' . $id[1] . '/' . $id[2], $path . \Idno\Core\Idno::site()->config()->host . '/' . $id[0] . '/' . $id[1] . '/' . $id[2] . '/' . $id[3]) as $up_path) {
+                        if (!is_dir($up_path)) {
+                            $result = @mkdir($up_path, 0777, true);
+                        }
+                    }
+
+                    if (!@file_put_contents($upload_file, $content)) 
+                    {
+                        throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("There was a problem storing the file data."));
+                    }
+                    if (!@file_put_contents($data_file, $metadata)) 
+                    {
+                        throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_("There was a problem saving the file's metadata"));
+                    }
+
+                    return $id;
+                } catch (\Exception $e) {
+
+                    // Ensure we capture the real error message
+                    \Idno\Core\Idno::site()->logging()->error('Exception while uploading file', ['error' => $e]);
+
+                    \Idno\Core\Idno::site()->session()->addMessage(\Idno\Core\Idno::site()->language()->_("Something went wrong saving your file."));
+                    if (\Idno\Core\Idno::site()->session()->isAdmin()) {
+                        \Idno\Core\Idno::site()->session()->addMessage(\Idno\Core\Idno::site()->language()->_("Check that your upload directory is writeable by the web server and try again."));
+                    }
+
+                }
+
+            }
+
+            return false;
+        }
+
     }
 
 }

--- a/Idno/Files/LocalFileSystem.php
+++ b/Idno/Files/LocalFileSystem.php
@@ -58,7 +58,7 @@ namespace Idno\Files {
          * @param $options
          * @return id of file
          */
-        public function storeFile($file_path, $metadata, $options)
+        public function storeFile($file_path, $metadata, $options = [])
         {
             if (file_exists($file_path) && $path = \Idno\Core\Idno::site()->config()->uploadpath) {
 
@@ -107,7 +107,7 @@ namespace Idno\Files {
             return false;
         }
 
-        public function storeContent($content, $metadata, $options) {
+        public function storeContent($content, $metadata, $options = []) {
             
             if (!empty($content) && $path = \Idno\Core\Idno::site()->config()->uploadpath) {
 

--- a/Idno/Files/MongoDBFileSystem.php
+++ b/Idno/Files/MongoDBFileSystem.php
@@ -96,6 +96,31 @@ namespace Idno\Files {
             return false;
         }
 
+        public function storeContent($content, $metadata, $options): id {
+            $bucket = $this->gridfs_object;
+
+            try {
+
+                if ($source = fopen('php://memory', 'r+')) {
+
+                    fwrite($source, $content);
+                    rewind($source);
+                    
+                    $id = $bucket->uploadFromStream($metadata['filename'], $source, [
+                        'metadata' => $metadata//new \MongoDB\Model\BSONDocument($metadata)
+                    ]);
+
+                    fclose($source);
+
+                    return "$id";
+                }
+            } catch (\Exception $ex) {
+                \Idno\Core\site()->logging()->debug($ex->getMessage());
+            }
+
+            return false;
+        }
+
     }
 
 }

--- a/Idno/Files/MongoDBFileSystem.php
+++ b/Idno/Files/MongoDBFileSystem.php
@@ -96,7 +96,7 @@ namespace Idno\Files {
             return false;
         }
 
-        public function storeContent($content, $metadata, $options): id {
+        public function storeContent($content, $metadata, $options) {
             $bucket = $this->gridfs_object;
 
             try {

--- a/Idno/Files/MongoDBFileSystem.php
+++ b/Idno/Files/MongoDBFileSystem.php
@@ -72,7 +72,7 @@ namespace Idno\Files {
             return false;
         }
 
-        public function storeFile($file_path, $metadata, $options)
+        public function storeFile($file_path, $metadata, $options = [])
         {
 
             $bucket = $this->gridfs_object;
@@ -96,7 +96,7 @@ namespace Idno\Files {
             return false;
         }
 
-        public function storeContent($content, $metadata, $options) {
+        public function storeContent($content, $metadata, $options = []) {
             $bucket = $this->gridfs_object;
 
             try {

--- a/Tests/Core/FilesystemTest.php
+++ b/Tests/Core/FilesystemTest.php
@@ -21,7 +21,7 @@ namespace Tests\Core {
             $loaded = $filesystem->findOne($id);
             
             $this->assertNotEmpty($loaded);
-            $this->assertEquals($content, $loaded);
+            $this->assertEquals($content, $loaded->getBytes());
             
         }
     }

--- a/Tests/Core/FilesystemTest.php
+++ b/Tests/Core/FilesystemTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Core {
+
+    class FilesystemTest extends \Tests\KnownTestCase {
+        
+        
+        function testStoreContent() {
+            
+            $content = "this is a test content";
+            $filename = get_class($this) . '_' . time();
+            
+            $filesystem = \Idno\Core\Idno::site()->filesystem();
+            
+            $id = $filesystem->storeContent($content, [
+                'filename' => $filename,
+                'meta_type' => 'text/plain'
+            ]);
+            
+            
+            $loaded = $filesystem->findOne($id);
+            
+            $this->assertNotEmpty($loaded);
+            $this->assertEquals($content, $loaded);
+            
+        }
+    }
+
+}


### PR DESCRIPTION
## Here's what I fixed or added:

Introducing storeContent

## Here's why I did it:

Filesystem interface only allowed storing directly from a file, but sometimes you already have the data you want to store

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [x] I've added tests where applicable
