### PR TITLE
Adding CURLINFO_EFFECTIVE_URL on webservice return

### DIFF
--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -206,12 +206,15 @@ namespace Idno\Core {
             self::$lastRequest  = curl_getinfo($curl_handle, CURLINFO_HEADER_OUT);
             self::$lastResponse = $content;
 
+            $effective_url = curl_getinfo($curl_handle, CURLINFO_EFFECTIVE_URL);
+            
             curl_close($curl_handle);
 
             return [
                 'header' => $header,
                 'content' => $content,
                 'response' => $http_status,
+                'effective_url' => $effective_url,
                 'error' => $error,
             ];
         }


### PR DESCRIPTION



## Here's what I fixed or added:
Adding CURLINFO_EFFECTIVE_URL on webservice return
## Here's why I did it:
A blocker for using newer webmention clients is the lack of the url parameter, this causes the client to not work, or if pedantic mode is enabled, an exception is thrown.
## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the unit tests successfully.