### PR TITLE
Improved error message templates

### DIFF
--- a/Idno/start.php
+++ b/Idno/start.php
@@ -145,4 +145,4 @@
     $webfinger    = new Idno\Core\Webfinger();
     $webmention   = new Idno\Core\Webmention();
     $pubsubhubbub = new Idno\Core\PubSubHubbub();
-throw new \RuntimeException('spooooo!!!!');
+

--- a/Idno/start.php
+++ b/Idno/start.php
@@ -31,9 +31,12 @@
             }
 
             $error_message = "Fatal Error: {$error['file']}:{$error['line']} - \"{$error['message']}\", on page {$server_name}{$request_uri}";
+            $message_text = explode("\n", $error['message'])[0];
 
             $title = $heading = "Oh no! Known experienced a problem!";
-            $body = "<p>Known experienced a problem with this page and couldn't continue. The technical details are as follows:</p>";
+            $body = "<p>Known experienced a problem with this page and couldn't continue.</p>";
+            $body .= "<p><strong>$message_text</strong></p>";
+            $body .= "<p>The technical details are as follows:</p>";
             $body .= "<pre>$error_message</pre>";
 
             if (file_exists(dirname(dirname(__FILE__)) . '/support.inc')) {

--- a/Idno/start.php
+++ b/Idno/start.php
@@ -99,7 +99,7 @@
         $title = 'Installation incomplete';
         $heading = 'Your Known installation is incomplete!';
         $body = '<p>It looks like you\'re running Known directly from a GitHub checkout. You need to run "composer install" to fetch other required packages!</p>';
-        $helplink = "<a href=\"http://docs.withknown.com/en/latest/install/instructions/\">Read installation details.</a>";
+        $helplink = "<a href=\"http://docs.withknown.com/en/latest/install/instructions/\">Read installation instructions.</a>";
         
         include(dirname(dirname(__FILE__)) . '/statics/error-page.php');
         exit();

--- a/Idno/start.php
+++ b/Idno/start.php
@@ -94,7 +94,15 @@
     if (file_exists(dirname(dirname(__FILE__)) . '/vendor/autoload.php')) {
         require_once(dirname(dirname(__FILE__)) . '/vendor/autoload.php');
     } else {
-        die('Could not find autoload.php, did you run "composer install" ..?');
+        http_response_code(500);
+        
+        $title = 'Installation incomplete';
+        $heading = 'Your Known installation is incomplete!';
+        $body = '<p>It looks like you\'re running Known directly from a GitHub checkout. You need to run "composer install" to fetch other required packages!</p>';
+        $helplink = "<a href=\"http://docs.withknown.com/en/latest/install/instructions/\">Read installation details.</a>";
+        
+        include(dirname(dirname(__FILE__)) . '/statics/error-page.php');
+        exit();
     }
     
     // We're making heavy use of the Symfony ClassLoader to load our classes

--- a/Idno/start.php
+++ b/Idno/start.php
@@ -32,15 +32,17 @@
 
             $error_message = "Fatal Error: {$error['file']}:{$error['line']} - \"{$error['message']}\", on page {$server_name}{$request_uri}";
 
-            echo "<h1>Oh no! Known experienced a problem!</h1>";
-            echo "<p>Known experienced a problem with this page and couldn't continue. The technical details are as follows:</p>";
-            echo "<pre>$error_message</pre>";
+            $title = $heading = "Oh no! Known experienced a problem!";
+            $body = "<p>Known experienced a problem with this page and couldn't continue. The technical details are as follows:</p>";
+            $body .= "<pre>$error_message</pre>";
 
             if (file_exists(dirname(dirname(__FILE__)) . '/support.inc')) {
                 include dirname(dirname(__FILE__)) . '/support.inc';
             } else {
-                echo '<p>If you continue to have problems, <a href="https://withknown.com/opensource" target="_blank">open source users have a number of resources available.</a></p>';
+                $helplink = '<a href="https://withknown.com/opensource" target="_blank">Connect to other open source users for help.</a>';
             }
+            
+            include(dirname(dirname(__FILE__)) . '/statics/error-page.php');
 
             $stats = \Idno\Core\Idno::site()->statistics();
             if (!empty($stats)) {
@@ -143,3 +145,4 @@
     $webfinger    = new Idno\Core\Webfinger();
     $webmention   = new Idno\Core\Webmention();
     $pubsubhubbub = new Idno\Core\PubSubHubbub();
+throw new \RuntimeException('spooooo!!!!');

--- a/statics/db.php
+++ b/statics/db.php
@@ -1,37 +1,19 @@
 <!doctype html>
-<html>
-    <head>
-        <title>
-            Database error
-        </title>
-        <style>
-            body {
-                width: 70%;
-                background-color: #fefefe;
-                font-family: Helvetica, Arial, sans-serif;
-                color: #333;
-                text-align: left;
-                margin: auto;
-                margin-top: 5em;
-            }
-            p {
-                line-height: 1.5em;
-            }
-        </style>
-    </head>
-    <body>
-        <h1>
+<?php
 
-            Oh no! We couldn't connect to the database.
-
-        </h1>
+    $title = 'Database error';
+    $heading = 'Oh no! We couldn\'t connect to the database.';
+    $body = "
         <p>
             This probably means that the database settings changed, this Known site hasn't been set up yet, or
             there's a database problem.
         </p>
-        <?php if (!empty($message)) echo $message; ?>
-        <p>
-            <a href="http://docs.withknown.com">See the Known documentation for help.</a>
-        </p>
-    </body>
-</html>
+        $message
+        
+    ";
+    $helplink = "
+        <a href=\"http://docs.withknown.com\">See the Known documentation for help.</a>
+    ";
+        
+   require_once(dirname(__FILE__) . '/error-page.php');
+    

--- a/statics/error-page.php
+++ b/statics/error-page.php
@@ -26,6 +26,7 @@
                 font-weight: 800;
                 font-size: 150px;
                 color: #ccc;
+                margin-bottom: 50px;
             }
             
             .link-buttons {

--- a/statics/error-page.php
+++ b/statics/error-page.php
@@ -31,8 +31,8 @@
             
             .link-buttons {
                 margin-top: 70px;
-                background-color: #0063dc;
-                
+                background-color: #357ebd;
+                border-radius: 4px;
                 padding: 10px 40px;
                 font-weight: 600;
                 max-width: 40%;

--- a/statics/error-page.php
+++ b/statics/error-page.php
@@ -1,0 +1,64 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        
+        <title>
+            <?= $title; ?>
+        </title>
+        
+        <style>
+            body {
+                width: 60%;
+                background-color: #fefefe;
+                font-family: Helvetica, Arial, sans-serif;
+                color: #333;
+                text-align: left;
+                margin: auto;
+                margin-top: 5em;
+            }
+            p {
+                line-height: 1.5em;
+                text-align: justify;
+            }
+            h1.error-code {
+                font-weight: 800;
+                font-size: 150px;
+                color: #ccc;
+            }
+            
+            .link-buttons {
+                margin-top: 50px;
+            }
+            .link-buttons a {
+                background-color: #0063dc;
+                color: #fefefe;
+                padding: 10px 40px;
+                font-weight: 600;
+                text-decoration: none;
+            }
+        </style>
+    </head>
+    <body>
+        <h1 class="error-code">
+            <?= http_response_code(); ?>
+        </h1>
+        
+        <h2>
+
+            <?= $heading; ?>
+
+        </h2>
+        
+        <div class="body-text">
+            <?= $body; ?>
+        </div>
+        
+        <?php if (!empty($helplink)) { ?>
+        <div class="link-buttons">
+            <?= $helplink; ?>
+        </div>
+        <?php } ?>
+    </body>
+</html>

--- a/statics/error-page.php
+++ b/statics/error-page.php
@@ -38,6 +38,12 @@
                 font-weight: 600;
                 text-decoration: none;
             }
+            pre {
+                overflow: auto;
+                margin: 15px;
+                margin-top: 30px;
+                color: #777;
+            }
         </style>
     </head>
     <body>

--- a/statics/error-page.php
+++ b/statics/error-page.php
@@ -29,13 +29,15 @@
             }
             
             .link-buttons {
-                margin-top: 50px;
-            }
-            .link-buttons a {
+                margin-top: 70px;
                 background-color: #0063dc;
-                color: #fefefe;
+                
                 padding: 10px 40px;
                 font-weight: 600;
+                max-width: 40%;
+            }
+            .link-buttons a {
+                color: #fefefe;
                 text-decoration: none;
             }
             pre {


### PR DESCRIPTION
## Here's what I fixed or added:

Added a static error message template

## Here's why I did it:

Bring things a little bit more up to date, making things more professional looking in run up to 1.0

## Checklist:

- [x] This pull request addresses a single issue
- [x] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.
