### PR TITLE
Removing unused h5f shim reference from settings template

### DIFF
--- a/templates/default/settings-shell/footerjavascript.tpl.php
+++ b/templates/default/settings-shell/footerjavascript.tpl.php
@@ -44,6 +44,4 @@ if ((\Idno\Core\Idno::site()->currentPage()) && $scripts = \Idno\Core\Idno::site
 }
 ?>
 
-<!-- HTML5 form element support for legacy browsers -->
-<script src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/npm-asset/h5f/h5f.min.js"></script>
 


### PR DESCRIPTION

## Here's what I fixed or added:
Removing unused h5f shim reference from settings template
## Here's why I did it:
Housekeeping


## Checklist:

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to Known's style guide
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.
