### PR TITLE
Mongo error to use new error template

### DIFF
--- a/Idno/Data/Mongo.php
+++ b/Idno/Data/Mongo.php
@@ -72,7 +72,7 @@ namespace Idno\Data {
                 ]));
             } catch (\MongoConnectionException $e) {
                 http_response_code(500);
-                echo '<p>Unfortunately we couldn\'t connect to the database:</p><p>' . $e->getMessage() . '</p>';
+                $message = '<p>Unfortunately we couldn\'t connect to the database:</p><p>' . $e->getMessage() . '</p>';
                 exit;
             }
 


### PR DESCRIPTION


## Here's what I fixed or added:
Mongo error to use new error template
## Here's why I did it:
A bit of housekeeping to make the mongodb connection error message use the new failsafe error template.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.