### PR TITLE
Security: Adding some sanitisation to notifications and webmentions

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -2251,6 +2251,8 @@ namespace Idno\Common {
             $owner_url = strip_tags(filter_var($owner_url, FILTER_SANITIZE_URL));
             $owner_image = strip_tags(filter_var($owner_image, FILTER_SANITIZE_URL));
             $annotation_url = strip_tags(filter_var($annotation_url, FILTER_SANITIZE_URL));
+            $owner_name = strip_tags($owner_name);
+            $title = strip_tags($title);
             
             if (empty($subtype)) return false;
             if (empty($annotation_url)) {

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -2248,6 +2248,10 @@ namespace Idno\Common {
          */
         function addAnnotation($subtype, $owner_name, $owner_url, $owner_image, $content, $annotation_url = null, $time = null, $title = '', $extra_fields = [], $send_notification = true)
         {
+            $owner_url = strip_tags(filter_var($owner_url, FILTER_SANITIZE_URL));
+            $owner_image = strip_tags(filter_var($owner_image, FILTER_SANITIZE_URL));
+            $annotation_url = strip_tags(filter_var($annotation_url, FILTER_SANITIZE_URL));
+            
             if (empty($subtype)) return false;
             if (empty($annotation_url)) {
                 $annotation_url = $this->getURL() . '/annotations/' . md5(time() . $content); // Invent a URL for this annotation

--- a/templates/default/content/notification/wrapper.tpl.php
+++ b/templates/default/content/notification/wrapper.tpl.php
@@ -1,16 +1,21 @@
 <?php
     $annotation = $notification->getObject();
     $post       = $notification->getTarget();
+    
+    $owner_image = htmlspecialchars($annotation['owner_image']);
+    $owner_url = htmlspecialchars($annotation['owner_url']);
+    $content = $annotation['content'];
+    $owner_name = htmlspecialchars($annotation['owner_name']);
 
 if (!empty($post)) {
     ?>
 
         <div class="row idno-entry idno-entry-notification-reply notification <?php echo $notification->isRead() ? 'notification-read' : 'notification-unread' ?>">
             <div class="col-md-1 col-md-offset-1 owner h-card visible-md visible-lg">
-            <?php if (isset($annotation['owner_image'])) { ?>
+            <?php if (isset($owner_image)) { ?>
                     <p>
-                        <a href="<?php echo $annotation['owner_url'] ?>" class="u-url icon-container">
-                            <img class="u-photo" src="<?php echo $annotation['owner_image'] ?>"/></a><br/>
+                        <a href="<?php echo $owner_url ?>" class="u-url icon-container">
+                            <img class="u-photo" src="<?php echo $owner_image ?>"/></a><br/>
                     </p>
             <?php } ?>
             </div>
@@ -18,15 +23,17 @@ if (!empty($post)) {
                 class="col-md-8 idno-notification-reply idno-object idno-content">
             <?php if (empty($vars['hide-body'])) { ?>
                     <div class="e-content entry-content">
-                        <?php if (!empty($annotation['content'])) {
-                            $this->autop($this->parseURLs($this->parseHashtags($this->parseUsers(htmlentities($annotation['content'], ENT_QUOTES, 'UTF-8')))));
-} ?>
+                        <?php 
+                        if (!empty($content)) {
+                            $this->autop($this->parseURLs($this->parseHashtags($this->parseUsers(htmlentities($content, ENT_QUOTES, 'UTF-8')))));
+                        } 
+                        ?>
                     </div>
             <?php } ?>
                 <div class="footer">
                     <div class="permalink">
                             <?php /*<span class="notification-icon"><?= $icon ?></span> */ ?>
-                            <a href="<?php echo $annotation['owner_url'] ?>"><?php echo $annotation['owner_name'] ?></a> <?php echo $interaction ?>
+                            <a href="<?php echo $owner_url ?>"><?php echo $owner_name ?></a> <?php echo $interaction ?>
                             <a href="<?php echo $post->getDisplayURL(); ?>"><?php echo \Idno\Core\Idno::site()->template()->sampleTextChars($post->getNotificationTitle(), 60); ?></a>
                             <time datetime="<?php echo date('c', $notification->created) ?>"
                                   class="dt-published"><?php echo strftime('%c', $notification->created) ?></time>                 

--- a/templates/default/entity/annotations/likes.tpl.php
+++ b/templates/default/entity/annotations/likes.tpl.php
@@ -15,7 +15,7 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo $annotation['owner_url']?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">
@@ -23,7 +23,7 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
                         <a href="<?php echo htmlspecialchars($annotation['owner_url'])?>"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a>
                     <?php echo \Idno\Core\Idno::site()->language()->_('liked this post'); ?>
                     </p>
-                    <p><small><a href="<?php echo $permalink?>"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo $permalink?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
+                    <p><small><a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
                 </div>
             <?php
             $this->annotation_permalink = $locallink;

--- a/templates/default/entity/annotations/mentions.tpl.php
+++ b/templates/default/entity/annotations/mentions.tpl.php
@@ -11,22 +11,22 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo $annotation['owner_url']?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <a href="<?php echo htmlspecialchars($annotation['owner_url'])?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">
                     <p><?php echo \Idno\Core\Idno::site()->language()->_('Mentioned in'); ?>: <a href="<?php echo $permalink?>"><?php
 
                     if (!empty($annotation['title'])) {
-                        echo $annotation['title'];
+                        echo htmlspecialchars($annotation['title']);
                     } else {
-                        echo $permalink;
+                        echo htmlspecialchars($permalink);
                     }
 
                     ?></a></p>
                     <p><small><a href="<?php echo htmlspecialchars($annotation['owner_url'])?>"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a>,
-                            <a href="<?php echo $permalink?>"><?php echo date('M d Y', $annotation['time']);?></a>
-                            on <a href="<?php echo $permalink?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
+                            <a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo date('M d Y', $annotation['time']);?></a>
+                            on <a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
                 </div>
                 <?php
                 $this->annotation_permalink = $locallink;

--- a/templates/default/entity/annotations/rsvps.tpl.php
+++ b/templates/default/entity/annotations/rsvps.tpl.php
@@ -16,14 +16,14 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo $annotation['owner_url']?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">
                     <p>
-                        <strong><?php echo $annotation['content']?></strong>
+                        <strong><?php echo strip_tags($annotation['content']); ?></strong>
                     </p>
-                    <p><small><a href="<?php echo $permalink?>"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo $permalink?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
+                    <p><small><a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
                 </div>
             </div>
         <?php

--- a/templates/default/entity/annotations/shares.tpl.php
+++ b/templates/default/entity/annotations/shares.tpl.php
@@ -12,15 +12,15 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo $annotation['owner_url']?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">
                     <p>
                         <a href="<?php echo htmlspecialchars($annotation['owner_url'])?>"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a>
-                        <a href="<?php echo $permalink?>"><?php echo \Idno\Core\Idno::site()->language()->_('reshared this post'); ?></a>
+                        <a href="<?php echo htmlspecialchars($permalink)?>"><?php echo \Idno\Core\Idno::site()->language()->_('reshared this post'); ?></a>
                     </p>
-                    <p><small><a href="<?php echo $permalink?>"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo $permalink?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
+                    <p><small><a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
                 </div>
             </div>
         <?php


### PR DESCRIPTION
## Here's what I fixed or added:

Added sanitisation

## Here's why I did it:

Webmentions can be badly formatted at times, and potentially this is exploitable. 

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.
