### PR TITLE
Upgrade symfony/console dependency, fix CLIInstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Third party libraries are licensed separately.
   * ClassLoader. Source: https://github.com/symfony/ClassLoader
   * EventDispatcher. Source: https://github.com/symfony/EventDispatcher
   * HttpFoundation. Source: https://github.com/symfony/HttpFoundation
-  * Console. Source: https://github.com/symfony/Console
+  * Console. Source: https://github.com/symfony/console
 * ToroPHP, which is distributed under the MIT License. Source: https://github.com/anandkunal/ToroPHP/
 * Font Awesome, which is distributed under the Open Font License, version 1.1: http://fortawesome.github.io/Font-Awesome/
 * Steve Clay's AutoP, which is distributed under the MIT License. Source: https://code.google.com/p/mrclay/

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "tinymce/tinymce": "4.1.7",
         "symfony/class-loader": "2.3.0",
         "symfony/event-dispatcher": "2.1.0",
-        "symfony/console": "2.8.0",
+        "symfony/console": "^4.2",
         "symfony/http-foundation": "2.3.0",
         "simplepie/simplepie": "1.4",
         "mapkyca/mrclay_autop_known": "dev-master",

--- a/warmup/CLI/CLIInstaller.php
+++ b/warmup/CLI/CLIInstaller.php
@@ -1,5 +1,16 @@
 #!/usr/bin/php -q
 <?php
+    // Load external libraries
+    if (file_exists(dirname(dirname(dirname(__FILE__))) . '/vendor/autoload.php')) {
+        require_once(dirname(dirname(dirname(__FILE__))) . '/vendor/autoload.php');
+    } else {
+        die('Could not find autoload.php, did you run "composer install" ..?');
+    }
+
+    // Load Symfony
+    global $known_loader;
+    $known_loader = new \Symfony\Component\ClassLoader\UniversalClassLoader();
+    $known_loader->register();
 
 /**
  * Load Idno
@@ -8,18 +19,6 @@ spl_autoload_register(function($class) {
     $class = str_replace('\\', DIRECTORY_SEPARATOR, $class);
 
     $basedir = dirname(dirname(dirname(__FILE__))) . '/';
-    if (file_exists($basedir . $class . '.php')) {
-        include_once($basedir . $class . '.php');
-    }
-});
-
-/**
- * Load Symfony
- */
-spl_autoload_register(function($class) {
-    $class = str_replace('\\', DIRECTORY_SEPARATOR, $class);
-
-    $basedir = dirname(dirname(dirname(__FILE__))) . '/external/';
     if (file_exists($basedir . $class . '.php')) {
         include_once($basedir . $class . '.php');
     }


### PR DESCRIPTION
## Here's what I fixed or added:

- Upgraded the symfony/console dependency using composer
- Fixed the CLIInstaller.php imports for composter and symfony

## Here's why I did it:

I was looking at how to install using CLI and found that the existing tool was inoperative.  Also wanting to test workflow on a simple change.

## Checklist:

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to Known's style guide
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.
