### PR TITLE
Downgrading symfony console to 3.4.22

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "tinymce/tinymce": "4.1.7",
         "symfony/class-loader": "2.3.0",
         "symfony/event-dispatcher": "2.1.0",
-        "symfony/console": "^4.2",
+        "symfony/console": "3.4.22",
         "symfony/http-foundation": "2.3.0",
         "simplepie/simplepie": "1.4",
         "mapkyca/mrclay_autop_known": "dev-master",


### PR DESCRIPTION



## Here's what I fixed or added:
Downgrading symfony console to 3.4.22
## Here's why I did it:
The 4.x branch requires PHP 7.1 minimum, and my debian install is ooooold.
## Checklist:

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to Known's style guide
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.