### PR TITLE
Consistently use getStaticURL for js/css/img assets

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1007,7 +1007,7 @@ namespace Idno\Common {
                 return $page->getIcon();
             }
 
-            return \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/logo_k.png';
+            return \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/logo_k.png';
         }
 
         /**

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -1079,7 +1079,7 @@ namespace Idno\Common {
          */
         public function getIcon()
         {
-            $icon = \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/logo_k.png';
+            $icon = \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/logo_k.png';
 
             if (\Idno\Core\Idno::site()->config()->user_avatar_favicons) {
                 if ($user = \Idno\Core\Idno::site()->currentPage()->getOwner()) {

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -724,21 +724,21 @@ namespace Idno\Core {
 
             // Set our defaults (TODO: Set these cleaner, perhaps through the template system)
             $icons['defaults'] = [
-                'default'     => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/logo_k.png',
-                'default_16'  => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/logo_k_16.png',
-                'default_32'  => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/logo_k_32.png',
-                'default_36'  => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/logo_k_36.png',
-                'default_48'  => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/logo_k_48.png',
-                'default_64'  => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/logo_k_64.png',
-                'default_96'  => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/logo_k_96.png',
+                'default'     => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/logo_k.png',
+                'default_16'  => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/logo_k_16.png',
+                'default_32'  => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/logo_k_32.png',
+                'default_36'  => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/logo_k_36.png',
+                'default_48'  => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/logo_k_48.png',
+                'default_64'  => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/logo_k_64.png',
+                'default_96'  => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/logo_k_96.png',
 
                 // Apple logos
-                'default_57'  => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/apple-icon-57x57.png',
-                'default_72'  => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/apple-icon-72x72.png',
-                'default_114' => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/apple-icon-114x114.png',
-                'default_144' => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/apple-icon-144x144.png',
+                'default_57'  => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/apple-icon-57x57.png',
+                'default_72'  => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/apple-icon-72x72.png',
+                'default_114' => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/apple-icon-114x114.png',
+                'default_144' => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/apple-icon-144x144.png',
 
-                'default_192' => \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/logos/logo_k_192.png',
+                'default_192' => \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/logos/logo_k_192.png',
             ];
 
             // If we're on a page, see if that has a specific icon

--- a/Idno/Entities/Reader/FeedItem.php
+++ b/Idno/Entities/Reader/FeedItem.php
@@ -88,7 +88,7 @@ namespace Idno\Entities\Reader {
             $bn     = hexdec(substr(md5($this->getUUID()), 0, 15));
             $number = 1 + ($bn % 5);
 
-            return \Idno\Core\Idno::site()->config()->url . 'gfx/users/default-' . str_pad($number, 2, '0', STR_PAD_LEFT) . '.png';
+            return \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/users/default-' . str_pad($number, 2, '0', STR_PAD_LEFT) . '.png';
         }
 
         /**

--- a/Idno/Pages/File/Picker.php
+++ b/Idno/Pages/File/Picker.php
@@ -14,7 +14,7 @@ namespace Idno\Pages\File {
         function getContent()
         {
 
-            $this->setAsset("exif-js", \Idno\Core\Idno::site()->config()->getDisplayURL() . 'vendor/npm-asset/exif-js/exif.js', 'javascript');
+            $this->setAsset("exif-js", \Idno\Core\Idno::site()->config()->getStaticURL() . 'vendor/npm-asset/exif-js/exif.js', 'javascript');
 
             $template   = 'file/picker/image';
             $t          = \Idno\Core\Idno::site()->template();

--- a/IdnoPlugins/Checkin/templates/default/checkin/head.tpl.php
+++ b/IdnoPlugins/Checkin/templates/default/checkin/head.tpl.php
@@ -1,6 +1,6 @@
-<link rel="stylesheet" href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>IdnoPlugins/Checkin/external/leaflet/leaflet.min.css"/>
+<link rel="stylesheet" href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>IdnoPlugins/Checkin/external/leaflet/leaflet.min.css"/>
 <!--[if lte IE 8]>
-<link rel="stylesheet" href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>IdnoPlugins/Checkin/external/leaflet/leaflet.min.ie.css"/>
+<link rel="stylesheet" href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>IdnoPlugins/Checkin/external/leaflet/leaflet.min.ie.css"/>
 <![endif]-->
-<script type="text/javascript" src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>IdnoPlugins/Checkin/external/leaflet/leaflet.js"></script>
-<script type="text/javascript" src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>IdnoPlugins/Checkin/external/stamen-maps/tile.stamen.min.js"></script>
+<script type="text/javascript" src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>IdnoPlugins/Checkin/external/leaflet/leaflet.js"></script>
+<script type="text/javascript" src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>IdnoPlugins/Checkin/external/stamen-maps/tile.stamen.min.js"></script>

--- a/IdnoPlugins/Checkin/templates/default/entity/Checkin/edit.tpl.php
+++ b/IdnoPlugins/Checkin/templates/default/entity/Checkin/edit.tpl.php
@@ -99,4 +99,4 @@
 
 <?php echo $this->draw('entity/edit/footer');?>
 
-<script src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>IdnoPlugins/Checkin/checkin.min.js"></script>
+<script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>IdnoPlugins/Checkin/checkin.min.js"></script>

--- a/IdnoPlugins/Comments/Pages/Post.php
+++ b/IdnoPlugins/Comments/Pages/Post.php
@@ -39,7 +39,7 @@ namespace IdnoPlugins\Comments\Pages {
                     if (empty($icon)) {
                         $bn = hexdec(substr(md5($url), 0, 15));
                         $number = 1 + ($bn % 5);
-                        $icon = \Idno\Core\Idno::site()->config()->url . 'gfx/users/default-'. str_pad($number, 2, '0', STR_PAD_LEFT) .'.png';
+                        $icon = \Idno\Core\Idno::site()->config()->getStaticURL(). 'gfx/users/default-'. str_pad($number, 2, '0', STR_PAD_LEFT) .'.png';
                     }
                     $object->addAnnotation('reply', $name, $url, $icon, $body);
                     $this->forward($object->getDisplayURL());

--- a/IdnoPlugins/Comments/templates/default/comments/public/form.tpl.php
+++ b/IdnoPlugins/Comments/templates/default/comments/public/form.tpl.php
@@ -12,7 +12,7 @@ if (!\Idno\Core\Idno::site()->session()->isLoggedOn() && $object instanceof \Idn
         <div class="row annotation-add">
             <div class="col-md-2 owner h-card hidden-sm hidden-xs">
                 <div class="u-url icon-container"><img class="u-photo"
-                                                       src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>gfx/users/default-00.png"/>
+                                                       src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>gfx/users/default-00.png"/>
                 </div>
             </div>
             <div class="col-md-10 idno-comment-container" id="comment-form-<?= $uuid; ?>">

--- a/IdnoPlugins/Media/templates/default/media/shell/head.tpl.php
+++ b/IdnoPlugins/Media/templates/default/media/shell/head.tpl.php
@@ -1,1 +1,1 @@
-<script src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>IdnoPlugins/Media/external/wavesurfer/dist/wavesurfer.min.js"></script>
+<script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>IdnoPlugins/Media/external/wavesurfer/dist/wavesurfer.min.js"></script>

--- a/IdnoPlugins/Photo/Main.php
+++ b/IdnoPlugins/Photo/Main.php
@@ -25,7 +25,7 @@ namespace IdnoPlugins\Photo {
         function registerEventHooks()
         {
             \Idno\Core\Idno::site()->addEventHook('page/get', function (\Idno\Core\Event $event) {
-                \Idno\Core\Idno::site()->currentPage()->setAsset("exif-js", \Idno\Core\Idno::site()->config()->getDisplayURL() . 'vendor/npm-asset/exif-js/exif.js', 'javascript');
+                \Idno\Core\Idno::site()->currentPage()->setAsset("exif-js", \Idno\Core\Idno::site()->config()->getStaticURL() . 'vendor/npm-asset/exif-js/exif.js', 'javascript');
             });
         }
 

--- a/IdnoPlugins/StaticPages/templates/default/staticpages/admin.tpl.php
+++ b/IdnoPlugins/StaticPages/templates/default/staticpages/admin.tpl.php
@@ -232,7 +232,7 @@
             }
 
         ?>
-        <script type="text/javascript" src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>IdnoPlugins/StaticPages/external/html5sortable/html.sortable.min.js"></script>
+        <script type="text/javascript" src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>IdnoPlugins/StaticPages/external/html5sortable/html.sortable.min.js"></script>
         <script type="text/javascript">
             $('.sortable-categories').sortable({
                 items: '[data-value]',

--- a/Themes/Black/templates/default/black/shell/head.tpl.php
+++ b/Themes/Black/templates/default/black/shell/head.tpl.php
@@ -1,2 +1,2 @@
-<link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>Themes/Black/css/default.min.css" rel="stylesheet">
+<link href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>Themes/Black/css/default.min.css" rel="stylesheet">
 

--- a/Themes/Black/templates/default/shell/footer.tpl.php
+++ b/Themes/Black/templates/default/shell/footer.tpl.php
@@ -1,4 +1,4 @@
 <div class="blank-footer">    
-        <p><a href="https://withknown.com/?utm_source=footer&utm_medium=installation" class="u-platform"><img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>gfx/logos/logo_k.png" style="height: 1.5em"></a></p>
+        <p><a href="https://withknown.com/?utm_source=footer&utm_medium=installation" class="u-platform"><img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>gfx/logos/logo_k.png" style="height: 1.5em"></a></p>
 
 </div>

--- a/Themes/Cherwell/Controller.php
+++ b/Themes/Cherwell/Controller.php
@@ -40,16 +40,15 @@ namespace Themes\Cherwell {
         {
 
             if (!empty(\Idno\Core\Idno::site()->config()->cherwell['bg_id'])) {
-                return \Idno\Core\Idno::site()->config()->getDisplayURL() . 'file/' . \Idno\Core\Idno::site()->config()->cherwell['bg_id'];
+                return \Idno\Core\Idno::site()->config()->getStaticURL() . 'file/' . \Idno\Core\Idno::site()->config()->cherwell['bg_id'];
             } else {
-                return \Idno\Core\Idno::site()->config()->getDisplayURL() . 'Themes/Cherwell/img/cherwell.jpg';
+                return \Idno\Core\Idno::site()->config()->getStaticURL() . 'Themes/Cherwell/img/cherwell.jpg';
             }
 
         }
         
         function registerTranslations()
         {
-
             \Idno\Core\Idno::site()->language()->register(
                 new \Idno\Core\GetTextTranslation(
                     'cherwell', dirname(__FILE__) . '/languages/'

--- a/Themes/Cherwell/Pages/Admin.php
+++ b/Themes/Cherwell/Pages/Admin.php
@@ -44,7 +44,7 @@ namespace Themes\Cherwell\Pages {
                                 }
                             }
                             \Idno\Core\Idno::site()->config->config['cherwell']['bg_id'] = $background;
-                            $background = \Idno\Core\Idno::site()->config()->getDisplayURL() . 'file/' . $background;
+                            $background = \Idno\Core\Idno::site()->config()->getStaticURL() . 'file/' . $background;
                             \Idno\Core\Idno::site()->config->config['cherwell']['bg'] = $background;
                         }
                     }

--- a/Themes/Cherwell/templates/default/cherwell/shell/head.tpl.php
+++ b/Themes/Cherwell/templates/default/cherwell/shell/head.tpl.php
@@ -1,4 +1,4 @@
-<link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>Themes/Cherwell/css/default.min.css" rel="stylesheet">
+<link href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>Themes/Cherwell/css/default.min.css" rel="stylesheet">
 <style>
     body {
         background-image: url(<?php echo Themes\Cherwell\Controller::getBackgroundImageURL()?>);

--- a/Themes/Fauvists/templates/default/fauvists/shell/head.tpl.php
+++ b/Themes/Fauvists/templates/default/fauvists/shell/head.tpl.php
@@ -1,1 +1,1 @@
-<link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>Themes/Fauvists/css/default.min.css" rel="stylesheet">
+<link href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>Themes/Fauvists/css/default.min.css" rel="stylesheet">

--- a/Themes/Green/templates/default/green/shell/head.tpl.php
+++ b/Themes/Green/templates/default/green/shell/head.tpl.php
@@ -1,1 +1,1 @@
-<link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>Themes/Green/css/default.min.css" rel="stylesheet">
+<link href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>Themes/Green/css/default.min.css" rel="stylesheet">

--- a/Themes/Green/templates/default/shell/footer.tpl.php
+++ b/Themes/Green/templates/default/shell/footer.tpl.php
@@ -1,4 +1,4 @@
 <div class="green-footer">    
-        <p><a href="https://withknown.com/?utm_source=footer&utm_medium=installation" class="u-platform"><img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>gfx/logos/logo_k_wht.png" style="height: 1.5em"></a></p>
+        <p><a href="https://withknown.com/?utm_source=footer&utm_medium=installation" class="u-platform"><img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>gfx/logos/logo_k_wht.png" style="height: 1.5em"></a></p>
 
 </div>

--- a/Themes/Kandinsky/templates/default/kandinsky/shell/head.tpl.php
+++ b/Themes/Kandinsky/templates/default/kandinsky/shell/head.tpl.php
@@ -1,1 +1,1 @@
-<link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>Themes/Kandinsky/css/default.min.css" rel="stylesheet">
+<link href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>Themes/Kandinsky/css/default.min.css" rel="stylesheet">

--- a/Themes/Kandinsky/templates/default/shell/footer.tpl.php
+++ b/Themes/Kandinsky/templates/default/shell/footer.tpl.php
@@ -1,3 +1,3 @@
 <div class="warm-footer">    
-        <p><a href="https://withknown.com/?utm_source=footer&utm_medium=installation" class="u-platform"><img style="height:1.5em" src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>gfx/logos/logo_k_red_50.png"></a></p>
+        <p><a href="https://withknown.com/?utm_source=footer&utm_medium=installation" class="u-platform"><img style="height:1.5em" src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>gfx/logos/logo_k_red_50.png"></a></p>
 </div>

--- a/Themes/MarketStreet/templates/default/marketstreet/shell/head.tpl.php
+++ b/Themes/MarketStreet/templates/default/marketstreet/shell/head.tpl.php
@@ -1,2 +1,2 @@
-<link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>Themes/MarketStreet/css/default.min.css" rel="stylesheet">
+<link href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>Themes/MarketStreet/css/default.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=Merriweather:300,300i,400,400i,700,700i" rel="stylesheet">

--- a/Themes/Solo/templates/default/solo/shell/head.tpl.php
+++ b/Themes/Solo/templates/default/solo/shell/head.tpl.php
@@ -1,1 +1,1 @@
-<link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>Themes/Solo/css/default.min.css" rel="stylesheet">
+<link href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>Themes/Solo/css/default.min.css" rel="stylesheet">

--- a/docs/developers/themes/index.md
+++ b/docs/developers/themes/index.md
@@ -68,7 +68,7 @@ To add a custom, static CSS file, you might want to `extend` the `shell/head` th
 
 You would then create a new template file in `/Themes/PDXCarpet/templates/default/pdxcarpet/shell/head.tpl.php` with some HTML to be injected into the page header::
 
-    <link href="<?= \Idno\Core\Idno::site()->config()->getDisplayURL() ?>Themes/PDXCarpet/css/default.css" rel="stylesheet">
+    <link href="<?= \Idno\Core\Idno::site()->config()->getStaticURL() ?>Themes/PDXCarpet/css/default.css" rel="stylesheet">
 
 Finally, you'd create a normal static CSS file in `/Themes/PDXCarpet/css/default.css`.
 

--- a/templates/default/account/notifications.tpl.php
+++ b/templates/default/account/notifications.tpl.php
@@ -25,7 +25,7 @@ if (!empty($items)) {
         <?php echo \Idno\Core\Idno::site()->language()->_("You don't have any notifications yet. But we love you anyway!"); ?>
         </p>
         <p style="text-align: center">
-            <img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>gfx/robots/feedback.png">
+            <img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>gfx/robots/feedback.png">
         </p>
 
     </div>

--- a/templates/default/account/settings/following/mf2user.tpl.php
+++ b/templates/default/account/settings/following/mf2user.tpl.php
@@ -14,7 +14,7 @@ if (empty($photo)) {
 
     $bn = hexdec(substr(md5($properties['url'][0]), 0, 15));
     $number = 1 + ($bn % 5);
-    $photo = \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/users/default-'. str_pad($number, 2, '0', STR_PAD_LEFT) .'.png';
+    $photo = \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/users/default-'. str_pad($number, 2, '0', STR_PAD_LEFT) .'.png';
 } else {
     $photo = \Idno\Core\Idno::site()->template()->getProxiedImageUrl($properties['photo'][0], 300, 'square');
 }

--- a/templates/default/account/settings/tools.tpl.php
+++ b/templates/default/account/settings/tools.tpl.php
@@ -27,7 +27,7 @@
         </div>
     <div class="col-md-4 col-md-offset-1">
         <p>
-            <img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>gfx/other/bookmarklet-mouse.png" alt="bookmarklet-mouse" class="img-responsive" />
+            <img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>gfx/other/bookmarklet-mouse.png" alt="bookmarklet-mouse" class="img-responsive" />
         </p>
         </div>
 </div>
@@ -35,7 +35,7 @@
 
 <div class="row">
     <div class="col-md-4 col-md-offset-1">
-        <img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>gfx/other/bookmarklet.png" alt="bookmarklet" class="img-responsive"  />
+        <img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>gfx/other/bookmarklet.png" alt="bookmarklet" class="img-responsive"  />
     </div>
     <div class="col-md-4 col-md-offset-1">
         <p>

--- a/templates/default/admin/about.tpl.php
+++ b/templates/default/admin/about.tpl.php
@@ -9,7 +9,7 @@
 </div>
 <div class="row" style="margin-top: 1em">
     <div class="col-md-1 col-md-offset-3 col-xs-3">
-        <a href="https://withknown.com"><img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>gfx/logos/logo_k.png" style="width: 70px; border: 0"></a>
+        <a href="https://withknown.com"><img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>gfx/logos/logo_k.png" style="width: 70px; border: 0"></a>
     </div>
     <div class="col-md-5">
         <p style="font-size: 1.6em"><a href="https://withknown.com/?utm_source=admin&utm_medium=installation"><?php echo \Idno\Core\Idno::site()->language()->_('Known'); ?></a> <?php echo \Idno\Core\Idno::site()->language()->_('is a social publishing platform for groups and individuals.'); ?></p>

--- a/templates/default/admin/import.tpl.php
+++ b/templates/default/admin/import.tpl.php
@@ -15,7 +15,7 @@
 </div>
 <div class="row import">
     <div class="col-md-1 col-md-offset-1">
-        <img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>gfx/other/known.png" alt="Known" class="img-responsive">
+        <img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>gfx/other/known.png" alt="Known" class="img-responsive">
     </div>
     <div class="col-md-9">
         <form action="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>admin/import/" method="post" enctype="multipart/form-data">
@@ -55,7 +55,7 @@
 </div>
 <div class="row import">
     <div class="col-md-1 col-md-offset-1">
-        <img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>gfx/other/wordpress.png" alt="WordPress" class="img-responsive">
+        <img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>gfx/other/wordpress.png" alt="WordPress" class="img-responsive">
     </div>
     <div class="col-md-9">      
         <form action="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>admin/import/" method="post" enctype="multipart/form-data">
@@ -96,7 +96,7 @@
 </div>
 <div class="row import">
     <div class="col-md-1 col-md-offset-1">
-        <img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>gfx/other/blogger.png" alt="Blogger" class="img-responsive">
+        <img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>gfx/other/blogger.png" alt="Blogger" class="img-responsive">
     </div>
     <div class="col-md-9">      
         <form action="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>admin/import/" method="post" enctype="multipart/form-data">

--- a/templates/default/admin/themes/theme.tpl.php
+++ b/templates/default/admin/themes/theme.tpl.php
@@ -23,7 +23,7 @@ if (!empty($vars['theme'])) {
         }
     } else {
         $vars['theme']['shortname'] = 'default';
-        $src = \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/themes/default.png';
+        $src = \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/themes/default.png';
     }
     if (!empty($src)) {
 

--- a/templates/default/assets/fitvids.tpl.php
+++ b/templates/default/assets/fitvids.tpl.php
@@ -1,2 +1,2 @@
 <!-- Video shim -->
-<script src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() . 'vendor/npm-asset/vanilla-fitvids/jquery.fitvids.js' ?>"></script>
+<script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() . 'vendor/npm-asset/vanilla-fitvids/jquery.fitvids.js' ?>"></script>

--- a/templates/default/assets/mediaelementplayer.tpl.php
+++ b/templates/default/assets/mediaelementplayer.tpl.php
@@ -1,5 +1,5 @@
 <!-- Flexible media player -->
 <script
-    src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/npm-asset/mediaelement/build/mediaelement-and-player.min.js"></script>
+    src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/npm-asset/mediaelement/build/mediaelement-and-player.min.js"></script>
 <link rel="stylesheet"
-      href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/npm-asset/mediaelement/build/mediaelementplayer.min.css"/>
+      href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/npm-asset/mediaelement/build/mediaelementplayer.min.css"/>

--- a/templates/default/entity/User/icon.tpl.php
+++ b/templates/default/entity/User/icon.tpl.php
@@ -2,5 +2,5 @@
 
     $bn = hexdec(substr(md5($vars['user']->uuid), 0, 15));
     $number = 1 + ($bn % 5);
-    echo \Idno\Core\Idno::site()->config()->getDisplayURL() . 'gfx/users/default-'. str_pad(abs($number), 2, '0', STR_PAD_LEFT) .'.png';
+    echo \Idno\Core\Idno::site()->config()->getStaticURL() . 'gfx/users/default-'. str_pad(abs($number), 2, '0', STR_PAD_LEFT) .'.png';
 

--- a/templates/default/file/picker/donejs.tpl.php
+++ b/templates/default/file/picker/donejs.tpl.php
@@ -2,7 +2,7 @@
 
 if (!empty($vars['file'])) {
 
-    $fileplot = 'parent.tinymce.activeEditor.windowManager.getParams().oninsert("'.\Idno\Core\Idno::site()->config()->getDisplayURL() . 'file/' . $vars['file']->file['_id'].'");';
+    $fileplot = 'parent.tinymce.activeEditor.windowManager.getParams().oninsert("'.\Idno\Core\Idno::site()->config()->getStaticURL() . 'file/' . $vars['file']->file['_id'].'");';
 
 } else {
 

--- a/templates/default/js/known.tpl.php
+++ b/templates/default/js/known.tpl.php
@@ -18,6 +18,7 @@ $known = [
     ],
     'config' => [
         'displayUrl' => \Idno\Core\Idno::site()->config()->getDisplayURL(),
+        'staticUrl' => \Idno\Core\Idno::site()->config()->getStaticURL(),
         'debug' => !empty(\Idno\Core\Idno::site()->config()->debug)
     ],
     'page' => [

--- a/templates/default/onboarding/begin.tpl.php
+++ b/templates/default/onboarding/begin.tpl.php
@@ -2,7 +2,7 @@
 
     <div>
 
-        <div class="h-register"><img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>gfx/onboarding/logo_black.png"
+        <div class="h-register"><img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>gfx/onboarding/logo_black.png"
                                      alt="Known" class="img-responsive"></div>
 
         <p class="p-register"><?php echo \Idno\Core\Idno::site()->language()->_('Known is your space for sharing content and discussing ideas.'); ?></p>
@@ -10,15 +10,15 @@
         <div class="container" style="margin-bottom: 1 em; margin-top: 2em">
             <div class="row row-centered">
                 <div class="scoot col-centered col-max">
-                    <img class="img-responsive" src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>gfx/onboarding/kite.png" alt="<?php echo \Idno\Core\Idno::site()->language()->_('Take a picture'); ?>"
+                    <img class="img-responsive" src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>gfx/onboarding/kite.png" alt="<?php echo \Idno\Core\Idno::site()->language()->_('Take a picture'); ?>"
                          width="100%">
                 </div>
                 <div class="scoot col-centered col-max">
-                    <img class="img-responsive" src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>gfx/onboarding/text.png" alt="<?php echo \Idno\Core\Idno::site()->language()->_('Share a message'); ?>"
+                    <img class="img-responsive" src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>gfx/onboarding/text.png" alt="<?php echo \Idno\Core\Idno::site()->language()->_('Share a message'); ?>"
                          width="100%">
                 </div>
                 <div class="scoot col-centered col-max">
-                    <img class="img-responsive" src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>gfx/onboarding/map.png" alt="<?php echo \Idno\Core\Idno::site()->language()->_('Save your location'); ?>"
+                    <img class="img-responsive" src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>gfx/onboarding/map.png" alt="<?php echo \Idno\Core\Idno::site()->language()->_('Save your location'); ?>"
                          width="100%">
                 </div>
             </div>

--- a/templates/default/pages/403.tpl.php
+++ b/templates/default/pages/403.tpl.php
@@ -23,7 +23,7 @@ if (!\Idno\Core\Idno::site()->session()->isLoggedIn()) {
                     </p>                    
                 </div>
                 <div class="col-md-5">
-                    <img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>gfx/robots/aleph_403.png" alt="Robot with a stop sign">
+                    <img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>gfx/robots/aleph_403.png" alt="Robot with a stop sign">
                 </div>                
             </div>
         </div>

--- a/templates/default/pages/404.tpl.php
+++ b/templates/default/pages/404.tpl.php
@@ -9,7 +9,7 @@
             </p>             
         </div>
         <div class="col-md-5">
-            <img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>gfx/robots/aleph_404.png" alt="Robot with a missing sign">
+            <img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>gfx/robots/aleph_404.png" alt="Robot with a missing sign">
         </div>        
     </div>
 </div>

--- a/templates/default/pages/410.tpl.php
+++ b/templates/default/pages/410.tpl.php
@@ -11,7 +11,7 @@
             </p>            
         </div>
         <div class="col-md-5">
-            <img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>gfx/robots/aleph_410.png" alt="Robot with a gone sign">
+            <img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>gfx/robots/aleph_410.png" alt="Robot with a gone sign">
         </div>
         
     </div>

--- a/templates/default/robot/post.tpl.php
+++ b/templates/default/robot/post.tpl.php
@@ -5,7 +5,7 @@
 
             <div class="robot-head" style="width: 100px; height: 130px; float: left">
                 <p style="text-align: center">
-                    <img src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>gfx/robots/1.png"/></a><br/>
+                    <img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>gfx/robots/1.png"/></a><br/>
                     Aleph
                 </p>
             </div>

--- a/templates/default/settings-shell/css.tpl.php
+++ b/templates/default/settings-shell/css.tpl.php
@@ -6,4 +6,4 @@
 
 <!-- Mention styles -->
 <link rel="stylesheet" type="text/css"
-      href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/bower-asset/mention/recommended-styles.css">
+      href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/bower-asset/mention/recommended-styles.css">

--- a/templates/default/settings-shell/footerjavascript.tpl.php
+++ b/templates/default/settings-shell/footerjavascript.tpl.php
@@ -8,10 +8,10 @@ if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {
     ?>
         <!-- WYSIWYG editor -->
         <script
-            src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/tinymce/tinymce/tinymce.min.js"
+            src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/tinymce/tinymce/tinymce.min.js"
             type="text/javascript"></script>
         <script
-            src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/tinymce/tinymce/jquery.tinymce.min.js"
+            src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/tinymce/tinymce/jquery.tinymce.min.js"
             type="text/javascript"></script>
         <?php
 
@@ -20,12 +20,12 @@ if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {
 ?>
 
 <script
-    src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/rmm5t/jquery-timeago/jquery.timeago.js"></script>
-<script src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/npm-asset/underscore/underscore-min.js"
+    src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/rmm5t/jquery-timeago/jquery.timeago.js"></script>
+<script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/npm-asset/underscore/underscore-min.js"
         type="text/javascript"></script>
-<!--<script src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() . 'vendor/bower-asset/mention/bootstrap-typeahead.js' ?>"
+<!--<script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() . 'vendor/bower-asset/mention/bootstrap-typeahead.js' ?>"
         type="text/javascript"></script>
-<script src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() . 'vendor/bower-asset/mention/mention.js' ?>"
+<script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() . 'vendor/bower-asset/mention/mention.js' ?>"
         type="text/javascript"></script> -->
 
 <?php

--- a/templates/default/shell/bootstrap.tpl.php
+++ b/templates/default/shell/bootstrap.tpl.php
@@ -20,7 +20,7 @@
 <link rel="stylesheet"
     href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/fortawesome/font-awesome/css/all.min.css">
 <link rel="stylesheet"
-    href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/fortawesome/font-awesome/css/v4-shims.min.css">
+    href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/fortawesome/font-awesome/css/v4-shims.min.css">
 
 <style>
     body {

--- a/templates/default/shell/css.tpl.php
+++ b/templates/default/shell/css.tpl.php
@@ -7,7 +7,7 @@
 
 <!-- Mention styles -->
 <link rel="stylesheet" type="text/css"
-      href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/bower-asset/mention/recommended-styles.css">
+      href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/bower-asset/mention/recommended-styles.css">
 
 <?php
     // Load style assets

--- a/templates/default/shell/footerjavascript.tpl.php
+++ b/templates/default/shell/footerjavascript.tpl.php
@@ -8,10 +8,10 @@ if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {
     ?>
         <!-- WYSIWYG editor -->
         <script
-            src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/tinymce/tinymce/tinymce.min.js"
+            src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/tinymce/tinymce/tinymce.min.js"
             type="text/javascript"></script>
         <script
-            src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/tinymce/tinymce/jquery.tinymce.min.js"
+            src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/tinymce/tinymce/jquery.tinymce.min.js"
             type="text/javascript"></script>
         <?php
 
@@ -20,12 +20,12 @@ if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {
 ?>
 
 <script
-    src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/rmm5t/jquery-timeago/jquery.timeago.js"></script>
-<script src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/npm-asset/underscore/underscore-min.js"
+    src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/rmm5t/jquery-timeago/jquery.timeago.js"></script>
+<script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/npm-asset/underscore/underscore-min.js"
         type="text/javascript"></script>
-<!--<script src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() . 'vendor/bower-asset/mention/bootstrap-typeahead.js' ?>"
+<!--<script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() . 'vendor/bower-asset/mention/bootstrap-typeahead.js' ?>"
         type="text/javascript"></script>
-<script src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() . 'vendor/bower-asset/mention/mention.js' ?>"
+<script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() . 'vendor/bower-asset/mention/mention.js' ?>"
         type="text/javascript"></script> -->
 
 <?php

--- a/templates/default/shell/simple.tpl.php
+++ b/templates/default/shell/simple.tpl.php
@@ -54,7 +54,7 @@ if (empty($vars['description'])) {
               href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>content/all?_t=rss"/>
         <link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>webmention/" rel="http://webmention.org/"/>
         <link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>webmention/" rel="webmention"/>
-        <link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>css/known-simple.min.css" rel="stylesheet">
+        <link href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>css/known-simple.min.css" rel="stylesheet">
         <link href="//fonts.googleapis.com/css?family=Pontano+Sans" rel="stylesheet" type="text/css">
         <link href="//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800" rel='stylesheet' type='text/css'>
         <script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/components/jquery/jquery.min.js"></script>
@@ -66,19 +66,19 @@ if (empty($vars['description'])) {
 
             ?>
 
-                <link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/twbs/bootstrap/dist/css/bootstrap.min.css"
+                <link href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/twbs/bootstrap/dist/css/bootstrap.min.css"
                       rel="stylesheet">
                 <link rel="stylesheet"
-                      href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/fortawesome/font-awesome/css/all.min.css">
+                      href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/fortawesome/font-awesome/css/all.min.css">
                 <link rel="stylesheet"
-                      href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>vendor/fortawesome/font-awesome/css/v4-shims.min.css">
+                      href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/fortawesome/font-awesome/css/v4-shims.min.css">
                 <style>
                     body {
                         padding-top: 10px; /* 60px to make the container go all the way to the bottom of the topbar */
                     }
                 </style>
                 <link
-                    href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() . 'external/bootstrap/' ?>assets/css/bootstrap-responsive.css"
+                    href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() . 'external/bootstrap/' ?>assets/css/bootstrap-responsive.css"
                     rel="stylesheet">
 
             <?php
@@ -88,8 +88,8 @@ if (empty($vars['description'])) {
         ?>
 
         <!-- Syndication -->
-        <link href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>vendor/npm-asset/bootstrap-toggle/css/bootstrap2-toggle.min.css" rel="stylesheet" />
-        <script src="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>vendor/npm-asset/bootstrap-toggle/js/bootstrap2-toggle.min.js"></script>
+        <link href="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>vendor/npm-asset/bootstrap-toggle/css/bootstrap2-toggle.min.css" rel="stylesheet" />
+        <script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>vendor/npm-asset/bootstrap-toggle/js/bootstrap2-toggle.min.js"></script>
 
     </head>
     <body class="<?php


### PR DESCRIPTION
## Here's what I fixed or added:

Replaced usages of `config()->getDisplayURL()` and `config()->url` that serve images, javascript, or css with `config()->getStaticURL()`

## Here's why I did it:

- Address consistency issue
- Allow for performance wins that come from CDN usage.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.
