### PR TITLE
Redirect to known.min.js in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,7 +11,7 @@
     RewriteCond $1::%{REQUEST_URI} ^(.*)::(.*?)\1$
     RewriteRule ^(.*)$ - [ENV=BASE:%2]
 
-    RewriteRule ^js/canary\.js$ %{ENV:BASE}/js/default.js [L]
+    RewriteRule ^js/canary\.js$ %{ENV:BASE}/js/known.min.js [L]
 
     # The query string cache trick doesn't really work, so use rewrite rules instead
     RewriteRule ^js/[0-9]+/(.*)$ %{ENV:BASE}/js/$1 [L]    

--- a/warmup/WebInstaller.php
+++ b/warmup/WebInstaller.php
@@ -81,7 +81,7 @@ class WebInstaller extends \Idno\Core\Installer
         if (!WebInstaller::installer()->rewriteWorking()) {
             $messages .= '<p>Rewriting appears to be disabled. Usually this means "AllowOverride None" is set in apache2.conf ';
             $messages .= 'which prevents Known\'s .htaccess from doing its thing. We tried to fetch a URL that should redirect ';
-            $messages .= 'to default.js</p>';
+            $messages .= 'to known.min.js</p>';
             $messages .= '<p>You can usually fix this by setting <code>AllowOverride All</code> in your Apache configuration.</p>';
             $ok = false;
         }

--- a/warmup/webserver-configs/htaccess-2.4.dist
+++ b/warmup/webserver-configs/htaccess-2.4.dist
@@ -11,7 +11,7 @@
     RewriteCond $1::%{REQUEST_URI} ^(.*)::(.*?)\1$
     RewriteRule ^(.*)$ - [ENV=BASE:%2]
 
-    RewriteRule ^js/canary\.js$ %{ENV:BASE}/js/default.js [L]
+    RewriteRule ^js/canary\.js$ %{ENV:BASE}/js/known.min.js [L]
 
     # The query string cache trick doesn't really work, so use rewrite rules instead
     RewriteRule ^js/[0-9]+/(.*)$ %{ENV:BASE}/js/$1 [L]    

--- a/warmup/webserver-configs/htaccess.dist
+++ b/warmup/webserver-configs/htaccess.dist
@@ -11,7 +11,7 @@
     RewriteCond $1::%{REQUEST_URI} ^(.*)::(.*?)\1$
     RewriteRule ^(.*)$ - [ENV=BASE:%2]
 
-    RewriteRule ^js/canary\.js$ %{ENV:BASE}/js/default.js [L]
+    RewriteRule ^js/canary\.js$ %{ENV:BASE}/js/known.min.js [L]
 
     # The query string cache trick doesn't really work, so use rewrite rules instead
     RewriteRule ^js/[0-9]+/(.*)$ %{ENV:BASE}/js/$1 [L]    


### PR DESCRIPTION
The AllowOverride check tests that a redirect .htaccess works
Since js/default.js does not exist anymore we redirect to js/known.min.js


## Here's what I fixed or added:
During install, there was a hardstop error that said the AllowOverride was not set to All in apache2.conf.

What actually happened was that the check was wrong because it was trying to redirect from js/canary.js to js/default.js and default.js did not exist anymore so that the error was incorrect.

Now, .htaccess redirects from js/canary.js to js/known.min.js so the AllowOverride check during install works.

## Here's why I did it:
The user can proceed with the install now.

## Checklist:

- [x] This pull request addresses a single issue
- [x] If this code includes interface changes, I've included screenshots in this Pull Request thread
screenshot of changed error message which now references known.min.js instead of default.js.
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [x] I've added tests where applicable, and...
- [x] I can run the unit tests successfully.
got 7 failures from master branch

Error message with fixed file name.
![known_issue_fixed](https://user-images.githubusercontent.com/49365518/56660269-6a6c0800-665c-11e9-8e2b-007b5e2e63af.png)
