### PR TITLE
Upgrade simplepie from 1.4.0 to 1.5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "symfony/event-dispatcher": "2.1.0",
         "symfony/console": "3.4.22",
         "symfony/http-foundation": "2.3.0",
-        "simplepie/simplepie": "1.4",
+        "simplepie/simplepie": "1.5.2",
         "mapkyca/mrclay_autop_known": "dev-master",
         "npm-asset/underscore": "1.6.0",
         "npm-asset/bootstrap-accessibility-plugin": "1.0.6",


### PR DESCRIPTION
## Here's what I fixed or added:

SimplePie is used for importing XML files and for the latent Reader feature.  Later
releases have microformat support that may be of use.

Changelog: https://github.com/simplepie/simplepie/releases

Only extension/php level changes to overall composer state:

Before:

```
  simplepie/simplepie 1.4 A simple Atom/RSS parsing library for PHP
  `--php >=5.3.0
```

After

```
  simplepie/simplepie 1.5.2 A simple Atom/RSS parsing library for PHP
  |--ext-pcre *
  |--ext-xml *
  |--ext-xmlreader *
  `--php >=5.6.0
```

## Here's why I did it:

Modernizing dependencies

## Checklist:

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to Known's style guide
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.
