### PR TITLE
Adding PHPUnit to dev build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
     },
     "require-dev": {
         "mapkyca/known-phpcs": "dev-master",
-        "mapkyca/known-language-tools": "dev-master"
+        "mapkyca/known-language-tools": "dev-master",
+        "phpunit/phpunit": "^8.1"
     }
 }

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -8,9 +8,9 @@ Unit tests will automatically be run when you submit a pull request on GitHub. Y
 
 ## Running unit tests on your local machine
 
-First, ensure [PHPUnit](https://phpunit.de/) is installed. (Installation varies by system and is beyond the scope of this documentation.)
+First, ensure [PHPUnit](https://phpunit.de/) is installed. 
 
-To run all the tests, from the Known root directory simply run ```phpunit```.
+To run all the tests, from the Known root directory simply run ```vendor/phpunit/phpunit/phpunit```, assuming you're running the git checkout and composer.
 
 Some tests require a connection to your local Known instance, so if this is anything other than *http://localhost*, you need to set the ```KNOWN_DOMAIN``` environment variable.
 


### PR DESCRIPTION


## Here's what I fixed or added:
Adding PHPUnit to dev build
## Here's why I did it:
Lets make sure everyone is on the same page, and the same version, of PHPUnit

## Checklist:

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to Known's style guide
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.
