### PR TITLE
Make the member service variables of the Idno class private

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Idno/.idea/.name
 
 .vagrant
 .elasticbeanstalk
+.phpunit.result.cache
 
 node_modules
 .sass-cache

--- a/Idno/Caching/ArrayCache.php
+++ b/Idno/Caching/ArrayCache.php
@@ -23,14 +23,14 @@ namespace Idno\Caching {
 
             if (isset($this->cache[$key])) {
                 if (\Idno\Core\Idno::site()->config()->debug) {
-                    \Idno\Core\Idno::site()->logging->debug("Loading $key");
+                    \Idno\Core\Idno::site()->logging()->debug("Loading $key");
                 }
 
                 return $this->cache[$key];
             }
 
             if (\Idno\Core\Idno::site()->config()->debug) {
-                \Idno\Core\Idno::site()->logging->debug("$key not cached");
+                \Idno\Core\Idno::site()->logging()->debug("$key not cached");
             }
 
             return false;
@@ -44,7 +44,7 @@ namespace Idno\Caching {
         public function store($key, $value)
         {
             if (\Idno\Core\Idno::site()->config()->debug)
-                \Idno\Core\Idno::site()->logging->debug("Caching $key");
+                \Idno\Core\Idno::site()->logging()->debug("Caching $key");
 
             $this->cache[$key] = $value;
 

--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -582,7 +582,7 @@ namespace Idno\Core {
          */
         function hasSSL()
         {
-            if (substr_count(site()->config()->getURL(), 'https://') || !empty($this->config->force_ssl)) {
+            if (substr_count(site()->config()->getURL(), 'https://') || !empty($this->config()->force_ssl)) {
                 return true;
             }
 

--- a/Idno/Core/Event.php
+++ b/Idno/Core/Event.php
@@ -20,7 +20,7 @@ namespace Idno\Core {
         function __construct($data = array())
         {
             $this->data       = $data;
-            $this->dispatcher = site()->dispatcher;
+            $this->dispatcher = site()->events();
         }
 
         /**

--- a/Idno/Core/Hub.php
+++ b/Idno/Core/Hub.php
@@ -76,8 +76,8 @@ namespace Idno\Core {
                 ));
 
                 if ($results['response'] == 401) {
-                    \Idno\Core\Idno::site()->config->hub_settings = array();
-                    \Idno\Core\Idno::site()->config->save();
+                    \Idno\Core\Idno::site()->config()->hub_settings = array();
+                    \Idno\Core\Idno::site()->config()->save();
                     $user->hub_settings = array();
                     $user->save();
                     if ($user->getUUID() == \Idno\Core\Idno::site()->session()->currentUserUUID()) {
@@ -98,11 +98,11 @@ namespace Idno\Core {
          */
         function loadDetails()
         {
-            if (!empty(\Idno\Core\Idno::site()->config->hub_settings['auth_token']) && !empty(\Idno\Core\Idno::site()->config->hub_settings['secret'])) {
-                $this->setAuthToken(\Idno\Core\Idno::site()->config->hub_settings['auth_token']);
-                $this->setSecret(\Idno\Core\Idno::site()->config->hub_settings['secret']);
+            if (!empty(\Idno\Core\Idno::site()->config()->hub_settings['auth_token']) && !empty(\Idno\Core\Idno::site()->config()->hub_settings['secret'])) {
+                $this->setAuthToken(\Idno\Core\Idno::site()->config()->hub_settings['auth_token']);
+                $this->setSecret(\Idno\Core\Idno::site()->config()->hub_settings['secret']);
 
-                return \Idno\Core\Idno::site()->config->hub_settings;
+                return \Idno\Core\Idno::site()->config()->hub_settings;
             }
 
             return false;
@@ -152,11 +152,11 @@ namespace Idno\Core {
                 if (!empty($details)) {
                     try {
                         if (!$this->userIsRegistered(\Idno\Core\Idno::site()->session()->currentUser())) {
-                            \Idno\Core\Idno::site()->logging->info("User isn't registered on hub; registering ...");
+                            \Idno\Core\Idno::site()->logging()->info("User isn't registered on hub; registering ...");
                             $this->registerUser(\Idno\Core\Idno::site()->session()->currentUser());
                         }
                     } catch (\Exception $e) {
-                        \Idno\Core\Idno::site()->logging->error('Exception registering user on hub', ['error' => $e]);
+                        \Idno\Core\Idno::site()->logging()->error('Exception registering user on hub', ['error' => $e]);
                     }
                 }
             }
@@ -172,10 +172,10 @@ namespace Idno\Core {
         function register()
         {
 
-            if (empty(\Idno\Core\Idno::site()->config->last_hub_ping)) {
+            if (empty(\Idno\Core\Idno::site()->config()->last_hub_ping)) {
                 $last_ping = 0;
             } else {
-                $last_ping = \Idno\Core\Idno::site()->config->last_hub_ping;
+                $last_ping = \Idno\Core\Idno::site()->config()->last_hub_ping;
             }
 
             if ($last_ping < (time() - 10)) { // Throttling registration pings to hub
@@ -187,9 +187,9 @@ namespace Idno\Core {
                 ));
 
                 if ($results['response'] == 200) {
-                    \Idno\Core\Idno::site()->config->load();
-                    \Idno\Core\Idno::site()->config->last_hub_ping = time();
-                    \Idno\Core\Idno::site()->config->save();
+                    \Idno\Core\Idno::site()->config()->load();
+                    \Idno\Core\Idno::site()->config()->last_hub_ping = time();
+                    \Idno\Core\Idno::site()->config()->save();
 
                     return true;
                 }
@@ -205,13 +205,13 @@ namespace Idno\Core {
          */
         function getRegistrationToken()
         {
-            if (empty(\Idno\Core\Idno::site()->config->hub_settings) || !is_array(\Idno\Core\Idno::site()->config->hub_settings)) {
-                \Idno\Core\Idno::site()->config->hub_settings = array();
+            if (empty(\Idno\Core\Idno::site()->config()->hub_settings) || !is_array(\Idno\Core\Idno::site()->config()->hub_settings)) {
+                \Idno\Core\Idno::site()->config()->hub_settings = array();
             }
-            if (!empty(\Idno\Core\Idno::site()->config->hub_settings['registration_token'])) {
-                if (!empty(\Idno\Core\Idno::site()->config->hub_settings['registration_token_expiry'])) {
-                    if (\Idno\Core\Idno::site()->config->hub_settings['registration_token_expiry'] > (time() - 600)) {
-                        return \Idno\Core\Idno::site()->config->hub_settings['registration_token'];
+            if (!empty(\Idno\Core\Idno::site()->config()->hub_settings['registration_token'])) {
+                if (!empty(\Idno\Core\Idno::site()->config()->hub_settings['registration_token_expiry'])) {
+                    if (\Idno\Core\Idno::site()->config()->hub_settings['registration_token_expiry'] > (time() - 600)) {
+                        return \Idno\Core\Idno::site()->config()->hub_settings['registration_token'];
                     }
                 }
             }
@@ -221,14 +221,14 @@ namespace Idno\Core {
 
             $hextoken = (string) bin2hex($token);
 
-            \Idno\Core\Idno::site()->config->hub_settings = array(
+            \Idno\Core\Idno::site()->config()->hub_settings = array(
                 'registration_token' => (string) bin2hex($token),
                 'registration_token_expiry' => time()
             );
 
-            \Idno\Core\Idno::site()->config->save();
+            \Idno\Core\Idno::site()->config()->save();
 
-            return \Idno\Core\Idno::site()->config->hub_settings['registration_token'];
+            return \Idno\Core\Idno::site()->config()->hub_settings['registration_token'];
         }
 
         /**
@@ -321,13 +321,13 @@ namespace Idno\Core {
          */
         function saveDetails($token, $secret)
         {
-            \Idno\Core\Idno::site()->config->load();
-            if (!is_array(\Idno\Core\Idno::site()->config->hub_settings)) {
-                \Idno\Core\Idno::site()->config->hub_settings = array();
+            \Idno\Core\Idno::site()->config()->load();
+            if (!is_array(\Idno\Core\Idno::site()->config()->hub_settings)) {
+                \Idno\Core\Idno::site()->config()->hub_settings = array();
             }
-            \Idno\Core\Idno::site()->config->hub_settings['auth_token'] = $token;
-            \Idno\Core\Idno::site()->config->hub_settings['secret']     = $secret;
-            \Idno\Core\Idno::site()->config->save();
+            \Idno\Core\Idno::site()->config()->hub_settings['auth_token'] = $token;
+            \Idno\Core\Idno::site()->config()->hub_settings['secret']     = $secret;
+            \Idno\Core\Idno::site()->config()->save();
             $this->setAuthToken($token);
             $this->setSecret($secret);
         }

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -15,29 +15,29 @@ namespace Idno\Core {
     class Idno extends \Idno\Common\Component
     {
 
-        public $db;
-        public $filesystem;
-        public $config;
-        public $session;
-        public $template;
-        public $language;
-        public $actions;
-        public $plugins;
-        public $dispatcher;
-        public $queue;
-        public $pagehandlers;
-        public $public_pages;
-        public $syndication;
+        private $db;
+        private $filesystem;
+        private $config;
+        private $session;
+        private $template;
+        private $language;
+        private $actions;
+        private $plugins;
+        private $dispatcher;
+        private $queue;
+        private $pagehandlers;
+        private $private_pages;
+        private $syndication;
         /* @var \Psr\Log\LoggerInterface $logging */
-        public $logging;
+        private $logging;
         /* @var \Idno\Core\Idno $site */
-        public static $site;
-        public $currentPage;
-        public $known_hub;
-        public $helper_robot;
-        public $reader;
-        public $cache;
-        public $statistics;
+        private static $site;
+        private $currentPage;
+        private $known_hub;
+        private $helper_robot;
+        private $reader;
+        private $cache;
+        private $statistics;
 
         function __construct()
         {
@@ -158,7 +158,7 @@ namespace Idno\Core {
             ) {
                 site()->session()->hub_connect     = time();
                 \Idno\Core\Idno::site()->known_hub = new \Idno\Core\Hub($this->config->known_hub);
-                \Idno\Core\Idno::site()->known_hub->connect();
+                \Idno\Core\Idno::site()->hub()->connect();
             }
 
             User::registerEvents();
@@ -449,6 +449,15 @@ namespace Idno\Core {
         function &reader()
         {
             return $this->reader;
+        }
+        
+        /**
+         * Return the currently registered page routing table.
+         * @return array
+         */
+        function &routing() 
+        {
+            return $this->pagehandlers;
         }
 
         /**
@@ -922,7 +931,7 @@ namespace Idno\Core {
      */
     function &site()
     {
-        return \Idno\Core\Idno::$site;
+        return \Idno\Core\Idno::site();
     }
 
 }

--- a/Idno/Core/Logging.php
+++ b/Idno/Core/Logging.php
@@ -28,9 +28,9 @@ namespace Idno\Core {
         public function __construct($loglevel_filter = 0, $identifier = null)
         {
             if (!$identifier)
-                $identifier = Idno::site()->config->host;
-            if (isset(Idno::site()->config->loglevel)) {
-                $loglevel_filter = Idno::site()->config->loglevel;
+                $identifier = Idno::site()->config()->host;
+            if (isset(Idno::site()->config()->loglevel)) {
+                $loglevel_filter = Idno::site()->config()->loglevel;
             }
 
             $this->loglevel_filter = $loglevel_filter;

--- a/Idno/Core/Plugins.php
+++ b/Idno/Core/Plugins.php
@@ -53,11 +53,11 @@ namespace Idno\Core {
                 }
             }
             if (!empty(\Idno\Core\Idno::site()->config()->alwaysplugins)) {
-                if (empty(\Idno\Core\Idno::site()->config->plugins)) \Idno\Core\Idno::site()->config->plugins = [];
-                \Idno\Core\Idno::site()->config->plugins = array_merge(\Idno\Core\Idno::site()->config->plugins, \Idno\Core\Idno::site()->config->alwaysplugins);
+                if (empty(\Idno\Core\Idno::site()->config()->plugins)) \Idno\Core\Idno::site()->config()->plugins = [];
+                \Idno\Core\Idno::site()->config()->plugins = array_merge(\Idno\Core\Idno::site()->config()->plugins, \Idno\Core\Idno::site()->config()->alwaysplugins);
             }
             if (!empty(\Idno\Core\Idno::site()->config()->plugins)) {
-                \Idno\Core\Idno::site()->config->plugins = array_unique(\Idno\Core\Idno::site()->config->plugins);
+                \Idno\Core\Idno::site()->config()->plugins = array_unique(\Idno\Core\Idno::site()->config()->plugins);
                 foreach (\Idno\Core\Idno::site()->config()->plugins as $plugin) {
                     if (!in_array($plugin, \Idno\Core\Idno::site()->config()->antiplugins)) {
                         if (is_subclass_of("IdnoPlugins\\{$plugin}\\Main", 'Idno\\Common\\Plugin')) {
@@ -291,12 +291,12 @@ namespace Idno\Core {
 
             \Idno\Core\Idno::site()->triggerEvent('plugin/load/' . $plugin);
 
-            \Idno\Core\Idno::site()->config->config['plugins'][] = $plugin;
+            \Idno\Core\Idno::site()->config()->config['plugins'][] = $plugin;
             if (!empty(\Idno\Core\Idno::site()->config()->external_plugin_path) && file_exists(\Idno\Core\Idno::site()->config()->external_plugin_path . '/IdnoPlugins/' . $plugin)) {
-                \Idno\Core\Idno::site()->config->config['directloadplugins'][$plugin] = \Idno\Core\Idno::site()->config()->external_plugin_path . '/IdnoPlugins/' . $plugin;
+                \Idno\Core\Idno::site()->config()->config['directloadplugins'][$plugin] = \Idno\Core\Idno::site()->config()->external_plugin_path . '/IdnoPlugins/' . $plugin;
             }
 
-            \Idno\Core\Idno::site()->config->config['plugins'] = array_unique(\Idno\Core\Idno::site()->config->config['plugins']);
+            \Idno\Core\Idno::site()->config()->config['plugins'] = array_unique(\Idno\Core\Idno::site()->config()->config['plugins']);
             \Idno\Core\Idno::site()->config()->save();
 
             return true;
@@ -312,12 +312,12 @@ namespace Idno\Core {
 
             if (!$this->exists($plugin))
                 return false;
-            if (($key = array_search($plugin, \Idno\Core\Idno::site()->config->config['plugins'])) !== false) {
+            if (($key = array_search($plugin, \Idno\Core\Idno::site()->config()->config['plugins'])) !== false) {
                 \Idno\Core\Idno::site()->triggerEvent('plugin/unload/' . $plugin);
-                unset(\Idno\Core\Idno::site()->config->config['plugins'][$key]);
-                unset(\Idno\Core\Idno::site()->config->config['directloadplugins'][$key]);
+                unset(\Idno\Core\Idno::site()->config()->config['plugins'][$key]);
+                unset(\Idno\Core\Idno::site()->config()->config['directloadplugins'][$key]);
 
-                \Idno\Core\Idno::site()->config->config['plugins'] = array_unique(\Idno\Core\Idno::site()->config->config['plugins']);
+                \Idno\Core\Idno::site()->config()->config['plugins'] = array_unique(\Idno\Core\Idno::site()->config()->config['plugins']);
                 \Idno\Core\Idno::site()->config()->save();
 
                 return true;

--- a/Idno/Core/PubSubHubbub.php
+++ b/Idno/Core/PubSubHubbub.php
@@ -83,15 +83,15 @@ namespace Idno\Core {
                             $following->save();
 
                             $return = Webservice::post($following->pubsub_hub, array(
-                                'hub.callback' => Idno::site()->config->url . 'pubsub/callback/' . $user->getID() . '/' . $following->getID(), // Callback, unique to each subscriber
+                                'hub.callback' => Idno::site()->config()->url . 'pubsub/callback/' . $user->getID() . '/' . $following->getID(), // Callback, unique to each subscriber
                                 'hub.mode'     => 'subscribe',
                                 'hub.verify'   => 'async', // Backwards compatibility with v0.3 hubs
                                 'hub.topic'    => $feed, // Subscribe to rss
                             ));
 
-                            Idno::site()->logging->info("Pubsub subscribed", ['response' => $return]);
+                            Idno::site()->logging()->info("Pubsub subscribed", ['response' => $return]);
                         } else
-                            Idno::site()->logging->info("Pubsub: No hubs found");
+                            Idno::site()->logging()->info("Pubsub: No hubs found");
                     }
                 }
             });
@@ -119,13 +119,13 @@ namespace Idno\Core {
                     $user->save();
 
                     $return = Webservice::post($following->pubsub_hub, array(
-                        'hub.callback' => Idno::site()->config->url . 'pubsub/callback/' . $user->getID() . '/' . $following->getID(), // Callback, unique to each subscriber
+                        'hub.callback' => Idno::site()->config()->url . 'pubsub/callback/' . $user->getID() . '/' . $following->getID(), // Callback, unique to each subscriber
                         'hub.mode'     => 'unsubscribe',
                         'hub.verify'   => 'async', // Backwards compatibility with v0.3 hubs
                         'hub.topic'    => $following->pubsub_self
                     ));
 
-                    Idno::site()->logging->info("Pubsub unsubscribed.", ['response' => $return]);
+                    Idno::site()->logging()->info("Pubsub unsubscribed.", ['response' => $return]);
                 }
             });
         }

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -70,7 +70,7 @@ namespace Idno\Core {
             }
 
             // session_cache_limiter('public // TODO: Reintroduce when page endpoints have set no-expire as appropriate
-            session_name(Idno::site()->config->sessionname);
+            session_name(Idno::site()->config()->sessionname);
             session_start();
 
             // Flag insecure sessions (so we can check state changes etc)
@@ -83,7 +83,7 @@ namespace Idno\Core {
                 $this->validate();
             } catch (\Exception $ex) {
                 // Session didn't validate, log & destroy
-                \Idno\Core\Idno::site()->logging->error('Error validating session', ['error' => $ex->getMessage()]);
+                \Idno\Core\Idno::site()->logging()->error('Error validating session', ['error' => $ex->getMessage()]);
                 header('X-KNOWN-DEBUG: Tilt!');
 
                 $_SESSION = [];

--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -56,7 +56,7 @@ namespace Idno\Core {
                                 try {
                                     $params[$k] = $v->getCurlParameters();
                                 } catch (\Exception $ex) {
-                                    \Idno\Core\Idno::site()->logging->error("Error sending $verb to $endpoint", ['error' => $ex]);
+                                    \Idno\Core\Idno::site()->logging()->error("Error sending $verb to $endpoint", ['error' => $ex]);
                                 }
                             }
                         }
@@ -197,7 +197,7 @@ namespace Idno\Core {
             $content     = substr($buffer, $header_size);
 
             if ($error = curl_error($curl_handle)) {
-                \Idno\Core\Idno::site()->logging->error('error send Webservice request', ['error' => $error]);
+                \Idno\Core\Idno::site()->logging()->error('error send Webservice request', ['error' => $error]);
             }
 
             // See if we have a HSTS header and store

--- a/Idno/Entities/File.php
+++ b/Idno/Entities/File.php
@@ -260,7 +260,7 @@ namespace Idno\Entities {
                 try {
                     return $fs->findOne(array('_id' => \Idno\Core\Idno::site()->db()->processID($id)));
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging->error($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                 }
             }
 
@@ -322,37 +322,37 @@ namespace Idno\Entities {
          */
         static function getFileDataFromAttachment($attachment)
         {
-            \Idno\Core\Idno::site()->logging->debug("getting file data from attachment", ['attachment' => $attachment]);
+            \Idno\Core\Idno::site()->logging()->debug("getting file data from attachment", ['attachment' => $attachment]);
             if (!empty($attachment['_id'])) {
-                //\Idno\Core\Idno::site()->logging->debug("Checking attachment ID");
+                //\Idno\Core\Idno::site()->logging()->debug("Checking attachment ID");
                 if ($bytes = self::getFileDataByID((string)$attachment['_id'])) {
-                    //\Idno\Core\Idno::site()->logging->debug("Retrieved some bytes");
+                    //\Idno\Core\Idno::site()->logging()->debug("Retrieved some bytes");
                     if (strlen($bytes)) {
-                        //\Idno\Core\Idno::site()->logging->debug("Bytes! " . $bytes);
+                        //\Idno\Core\Idno::site()->logging()->debug("Bytes! " . $bytes);
                         return $bytes;
                     } else {
-                        //\Idno\Core\Idno::site()->logging->debug("Sadly no bytes");
+                        //\Idno\Core\Idno::site()->logging()->debug("Sadly no bytes");
                     }
                 } else {
-                    //\Idno\Core\Idno::site()->logging->debug("No bytes retrieved");
+                    //\Idno\Core\Idno::site()->logging()->debug("No bytes retrieved");
                 }
             } else {
-                \Idno\Core\Idno::site()->logging->debug("Empty attachment _id");
+                \Idno\Core\Idno::site()->logging()->debug("Empty attachment _id");
             }
             if (!empty($attachment['url'])) {
                 try {
                     if ($bytes = @file_get_contents($attachment['url'])) {
-                        \Idno\Core\Idno::site()->logging->debug("Returning bytes");
+                        \Idno\Core\Idno::site()->logging()->debug("Returning bytes");
 
                         return $bytes;
                     } else {
-                        \Idno\Core\Idno::site()->logging->debug("Couldn't get bytes from " . $attachment['url']);
+                        \Idno\Core\Idno::site()->logging()->debug("Couldn't get bytes from " . $attachment['url']);
                     }
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging->debug("Couldn't get bytes from " . $attachment['url']);
+                    \Idno\Core\Idno::site()->logging()->debug("Couldn't get bytes from " . $attachment['url']);
                 }
             } else {
-                \Idno\Core\Idno::site()->logging->debug('Attachment url was empty ' . $attachment['url']);
+                \Idno\Core\Idno::site()->logging()->debug('Attachment url was empty ' . $attachment['url']);
             }
 
             return false;
@@ -369,7 +369,7 @@ namespace Idno\Entities {
                 try {
                     return $file->getBytes();
                 } catch (\Exception $e) {
-                    \Idno\Core\Idno::site()->logging->error($e->getMessage());
+                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
                 }
             }
 

--- a/Idno/Pages/Account/Settings/Following/Bookmarklet.php
+++ b/Idno/Pages/Account/Settings/Following/Bookmarklet.php
@@ -133,7 +133,7 @@ namespace Idno\Pages\Account\Settings\Following {
 
                     // No user found, so create it if it's remote
                     if (!\Idno\Entities\User::isLocalUUID($uuid)) {
-                        \Idno\Core\Idno::site()->logging->debug("Creating new remote user");
+                        \Idno\Core\Idno::site()->logging()->debug("Creating new remote user");
 
                         $new_user = new \Idno\Entities\RemoteUser();
 
@@ -150,19 +150,19 @@ namespace Idno\Pages\Account\Settings\Following {
 
                     }
                 } else
-                    \Idno\Core\Idno::site()->logging->debug("New user found as " . $new_user->uuid);
+                    \Idno\Core\Idno::site()->logging()->debug("New user found as " . $new_user->uuid);
 
                 if ($new_user) {
 
-                    \Idno\Core\Idno::site()->logging->debug("Trying a follow");
+                    \Idno\Core\Idno::site()->logging()->debug("Trying a follow");
 
                     if ($user->addFollowing($new_user)) {
 
-                        \Idno\Core\Idno::site()->logging->debug("User added to following");
+                        \Idno\Core\Idno::site()->logging()->debug("User added to following");
 
                         if ($user->save()) {
 
-                            \Idno\Core\Idno::site()->logging->debug("Following saved");
+                            \Idno\Core\Idno::site()->logging()->debug("Following saved");
 
                             // Ok, we've saved the new user, now, lets subscribe to their feeds
                             if ($feed = \Idno\Core\Idno::site()->reader()->getFeedObject($new_user->getURL())) {
@@ -176,7 +176,7 @@ namespace Idno\Pages\Account\Settings\Following {
 
                         }
                     } else {
-                        \Idno\Core\Idno::site()->logging->debug('Could not follow user for some reason (probably already following)');
+                        \Idno\Core\Idno::site()->logging()->debug('Could not follow user for some reason (probably already following)');
                         \Idno\Core\Idno::site()->session()->addErrorMessage(\Idno\Core\Idno::site()->language()->esc_('You\'re already following %s', [$this->getInput('name')]));
                     }
                 } else

--- a/Idno/Pages/Admin/Email.php
+++ b/Idno/Pages/Admin/Email.php
@@ -24,14 +24,14 @@ namespace Idno\Pages\Admin {
             $this->adminGatekeeper(); // Admins only
 
             $email                                                   = $this->getInput('from_email');
-            \Idno\Core\Idno::site()->config->config['smtp_host']     = $this->getInput('smtp_host');
-            \Idno\Core\Idno::site()->config->config['smtp_username'] = $this->getInput('smtp_username');
-            \Idno\Core\Idno::site()->config->config['smtp_password'] = $this->getInput('smtp_password');
-            \Idno\Core\Idno::site()->config->config['smtp_port']     = (int)$this->getInput('smtp_port');
-            \Idno\Core\Idno::site()->config->config['smtp_secure']   = $this->getInput('smtp_secure');
+            \Idno\Core\Idno::site()->config()->config['smtp_host']     = $this->getInput('smtp_host');
+            \Idno\Core\Idno::site()->config()->config['smtp_username'] = $this->getInput('smtp_username');
+            \Idno\Core\Idno::site()->config()->config['smtp_password'] = $this->getInput('smtp_password');
+            \Idno\Core\Idno::site()->config()->config['smtp_port']     = (int)$this->getInput('smtp_port');
+            \Idno\Core\Idno::site()->config()->config['smtp_secure']   = $this->getInput('smtp_secure');
 
             if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
-                \Idno\Core\Idno::site()->config->config['from_email'] = $this->getInput('from_email');
+                \Idno\Core\Idno::site()->config()->config['from_email'] = $this->getInput('from_email');
             }
 
             \Idno\Core\Idno::site()->config()->save();

--- a/Idno/Pages/Admin/Home.php
+++ b/Idno/Pages/Admin/Home.php
@@ -45,23 +45,23 @@ namespace Idno\Pages\Admin {
             $single_user          = $this->getInput('single_user') === 'true';
             $permalink_structure  = $this->getInput('permalink_structure');
 
-            if (!empty($title)) \Idno\Core\Idno::site()->config->title = $title;
-            \Idno\Core\Idno::site()->config->homepagetitle = trim($homepagetitle);
-            if (!empty($description)) \Idno\Core\Idno::site()->config->description = $description;
-            if (!empty($url)) \Idno\Core\Idno::site()->config->url = $url;
-            if (!empty($path)) \Idno\Core\Idno::site()->config->path = $path;
-            if (!empty($host)) \Idno\Core\Idno::site()->config->host = $host;
-            \Idno\Core\Idno::site()->config->hub = $hub;
-            if (!empty($items_per_page) && is_int($items_per_page)) \Idno\Core\Idno::site()->config->items_per_page = $items_per_page;
-            \Idno\Core\Idno::site()->config->open_registration    = $open_registration;
-            \Idno\Core\Idno::site()->config->walled_garden        = $walled_garden;
-            \Idno\Core\Idno::site()->config->show_privacy         = $show_privacy;
-            \Idno\Core\Idno::site()->config->indieweb_citation    = $indieweb_citation;
-            \Idno\Core\Idno::site()->config->indieweb_reference   = $indieweb_reference;
-            \Idno\Core\Idno::site()->config->user_avatar_favicons = $user_avatar_favicons;
-            \Idno\Core\Idno::site()->config->wayback_machine      = $wayback_machine;
-            \Idno\Core\Idno::site()->config->single_user          = $single_user;
-            \Idno\Core\Idno::site()->config->permalink_structure  = $permalink_structure;
+            if (!empty($title)) \Idno\Core\Idno::site()->config()->title = $title;
+            \Idno\Core\Idno::site()->config()->homepagetitle = trim($homepagetitle);
+            if (!empty($description)) \Idno\Core\Idno::site()->config()->description = $description;
+            if (!empty($url)) \Idno\Core\Idno::site()->config()->url = $url;
+            if (!empty($path)) \Idno\Core\Idno::site()->config()->path = $path;
+            if (!empty($host)) \Idno\Core\Idno::site()->config()->host = $host;
+            \Idno\Core\Idno::site()->config()->hub = $hub;
+            if (!empty($items_per_page) && is_int($items_per_page)) \Idno\Core\Idno::site()->config()->items_per_page = $items_per_page;
+            \Idno\Core\Idno::site()->config()->open_registration    = $open_registration;
+            \Idno\Core\Idno::site()->config()->walled_garden        = $walled_garden;
+            \Idno\Core\Idno::site()->config()->show_privacy         = $show_privacy;
+            \Idno\Core\Idno::site()->config()->indieweb_citation    = $indieweb_citation;
+            \Idno\Core\Idno::site()->config()->indieweb_reference   = $indieweb_reference;
+            \Idno\Core\Idno::site()->config()->user_avatar_favicons = $user_avatar_favicons;
+            \Idno\Core\Idno::site()->config()->wayback_machine      = $wayback_machine;
+            \Idno\Core\Idno::site()->config()->single_user          = $single_user;
+            \Idno\Core\Idno::site()->config()->permalink_structure  = $permalink_structure;
 
             \Idno\Core\Idno::site()->triggerEvent('admin/home/save');
 

--- a/Idno/Pages/Admin/Homepage.php
+++ b/Idno/Pages/Admin/Homepage.php
@@ -40,7 +40,7 @@ namespace Idno\Pages\Admin {
             $config->default_feed_content   = $default_feed_content;
             \Idno\Core\Idno::site()->config = $config;
 
-            if (\Idno\Core\Idno::site()->config->save()) {
+            if (\Idno\Core\Idno::site()->config()->save()) {
                 \Idno\Core\Idno::site()->session()->addMessage(\Idno\Core\Idno::site()->language()->_("The default homepage content types were saved."));
             }
             $this->forward(\Idno\Core\Idno::site()->config()->getURL() . 'admin/homepage/');

--- a/Idno/Pages/Admin/Themes.php
+++ b/Idno/Pages/Admin/Themes.php
@@ -47,12 +47,12 @@ namespace Idno\Pages\Admin {
             ) {
                 switch ($action) {
                     case 'install':
-                        \Idno\Core\Idno::site()->config->config['theme'] = $theme;
+                        \Idno\Core\Idno::site()->config()->config['theme'] = $theme;
                         Idno::site()->config()->theme                    = $theme;
                         //\Idno\Core\Idno::site()->session()->addMessage(\Idno\Core\Idno::site()->language()->_('The theme was enabled.'));
                         break;
                     case 'uninstall':
-                        \Idno\Core\Idno::site()->config->config['theme'] = '';
+                        \Idno\Core\Idno::site()->config()->config['theme'] = '';
                         break;
                 }
                 \Idno\Core\Idno::site()->config()->save();

--- a/Idno/Pages/Entity/View.php
+++ b/Idno/Pages/Entity/View.php
@@ -78,7 +78,7 @@ namespace Idno\Pages\Entity {
                 }
             }
             if (empty($object)) {
-                \Idno\Core\Idno::site()->logging->error("No object was found with ID {$this->arguments[0]}.");
+                \Idno\Core\Idno::site()->logging()->error("No object was found with ID {$this->arguments[0]}.");
 
                 return false;
             }

--- a/Idno/Pages/Hub/Register/Site.php
+++ b/Idno/Pages/Hub/Register/Site.php
@@ -14,7 +14,7 @@ namespace Idno\Pages\Hub\Register {
 
             $this->flushBrowser();
 
-            \Idno\Core\Idno::site()->logging->debug('Site registration message received');
+            \Idno\Core\Idno::site()->logging()->debug('Site registration message received');
 
             $token      = $this->getInput('token');
             $auth_token = $this->getInput('auth_token');

--- a/Idno/Pages/Hub/Register/User.php
+++ b/Idno/Pages/Hub/Register/User.php
@@ -14,7 +14,7 @@ namespace Idno\Pages\Hub\Register {
 
             $this->flushBrowser();
 
-            \Idno\Core\Idno::site()->logging->debug("Loading the user registration callback");
+            \Idno\Core\Idno::site()->logging()->debug("Loading the user registration callback");
 
             $contents   = $this->getInput('content');
             $auth_token = $this->getInput('auth_token');

--- a/Idno/Pages/Pubsubhubbub/Callback.php
+++ b/Idno/Pages/Pubsubhubbub/Callback.php
@@ -32,7 +32,7 @@ namespace Idno\Pages\Pubsubhubbub {
             $hub_challenge     = $this->getInput('hub.challenge', $this->getInput('hub_challenge'));
             $hub_lease_seconds = $this->getInput('hub.lease_seconds', $this->getInput('hub_lease_seconds'));
 
-            \Idno\Core\Idno::site()->logging->debug("Pubsub: $hub_mode verification ping ");
+            \Idno\Core\Idno::site()->logging()->debug("Pubsub: $hub_mode verification ping ");
 
             switch ($hub_mode) {
                 case 'subscribe':
@@ -48,7 +48,7 @@ namespace Idno\Pages\Pubsubhubbub {
                         $subscriber->pubsub_pending = serialize($new);
                         $subscriber->save();
 
-                        \Idno\Core\Idno::site()->logging->debug("Pubsub: $hub_challenge");
+                        \Idno\Core\Idno::site()->logging()->debug("Pubsub: $hub_challenge");
                         echo $hub_challenge;
                         exit;
                     }
@@ -60,7 +60,7 @@ namespace Idno\Pages\Pubsubhubbub {
 
         function post()
         {
-            \Idno\Core\Idno::site()->logging->debug("Pubsub: Ping received");
+            \Idno\Core\Idno::site()->logging()->debug("Pubsub: Ping received");
 
             // Since we've overloaded post, we need to parse the arguments
             $arguments = func_get_args();
@@ -80,7 +80,7 @@ namespace Idno\Pages\Pubsubhubbub {
                 $this->goneContent();
             }
 
-            \Idno\Core\Idno::site()->logging->debug("Pubsub: Ping received, pinging out...");
+            \Idno\Core\Idno::site()->logging()->debug("Pubsub: Ping received, pinging out...");
 
             \Idno\Core\Idno::site()->triggerEvent('pubsubhubbub/ping', array(
                 'subscriber'   => $subscriber,

--- a/Idno/Pages/Webmentions/Endpoint.php
+++ b/Idno/Pages/Webmentions/Endpoint.php
@@ -79,12 +79,12 @@ namespace Idno\Pages\Webmentions {
                             } else {
                                 $error      = 'no_link_found';
                                 $error_text = 'The source URI does not contain a link to the target URI.';
-                                \Idno\Core\Idno::site()->logging->warning('No link from ' . $source . ' to ' . $target);
+                                \Idno\Core\Idno::site()->logging()->warning('No link from ' . $source . ' to ' . $target);
                             }
                         } else {
                             $error      = 'source_not_found';
                             $error_text = 'The source content for ' . $source . ' could not be obtained.';
-                            \Idno\Core\Idno::site()->logging->warning('No content from '.$source);
+                            \Idno\Core\Idno::site()->logging()->warning('No content from '.$source);
                         }
                     } else {
                         $error      = 'target_not_supported';

--- a/Idno/start.php
+++ b/Idno/start.php
@@ -53,7 +53,7 @@
             }
 
             if (isset(\Idno\Core\Idno::site()->logging) && \Idno\Core\Idno::site()->logging)
-                \Idno\Core\Idno::site()->logging->error($error_message);
+                \Idno\Core\Idno::site()->logging()->error($error_message);
             else
                 error_log($error_message);
 

--- a/IdnoPlugins/Checkin/Checkin.php
+++ b/IdnoPlugins/Checkin/Checkin.php
@@ -8,7 +8,7 @@ namespace IdnoPlugins\Checkin {
 
         function getTitle()
         {
-            return \Idno\Core\Idno::site()->language->_('Checked into %s', [$this->placename]);
+            return \Idno\Core\Idno::site()->language()->_('Checked into %s', [$this->placename]);
         }
 
         function getDescription()

--- a/IdnoPlugins/StaticPages/Main.php
+++ b/IdnoPlugins/StaticPages/Main.php
@@ -62,8 +62,8 @@ namespace IdnoPlugins\StaticPages {
                 if (\Idno\Core\Idno::site()->session()->currentUser()->isAdmin()) {
                     $obj = \Idno\Common\Entity::getByID($pageId);
                     if (!empty($obj)) {
-                        \Idno\Core\Idno::site()->config->staticPages['homepage'] = $pageId;
-                        return \Idno\Core\Idno::site()->config->save();
+                        \Idno\Core\Idno::site()->config()->staticPages['homepage'] = $pageId;
+                        return \Idno\Core\Idno::site()->config()->save();
                     }
                 }
             }
@@ -82,8 +82,8 @@ namespace IdnoPlugins\StaticPages {
 
             if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {
                 if (\Idno\Core\Idno::site()->session()->currentUser()->isAdmin()) {
-                    unset(\Idno\Core\Idno::site()->config->staticPages['homepage']);
-                    return \Idno\Core\Idno::site()->config->save();
+                    unset(\Idno\Core\Idno::site()->config()->staticPages['homepage']);
+                    return \Idno\Core\Idno::site()->config()->save();
                 }
             }
 
@@ -97,8 +97,8 @@ namespace IdnoPlugins\StaticPages {
          */
         function getCurrentHomepageId()
         {
-            if (!empty(\Idno\Core\Idno::site()->config->staticPages['homepage'])) {
-                return \Idno\Core\Idno::site()->config->staticPages['homepage'];
+            if (!empty(\Idno\Core\Idno::site()->config()->staticPages['homepage'])) {
+                return \Idno\Core\Idno::site()->config()->staticPages['homepage'];
             }
             return false;
         }
@@ -118,9 +118,9 @@ namespace IdnoPlugins\StaticPages {
                     if (is_array($categories)) {
                         $categories = implode("\n", $categories);
                     }
-                    \Idno\Core\Idno::site()->config->staticPages['categories'] = $categories;
+                    \Idno\Core\Idno::site()->config()->staticPages['categories'] = $categories;
 
-                    return \Idno\Core\Idno::site()->config->save();
+                    return \Idno\Core\Idno::site()->config()->save();
 
                 }
             }

--- a/IdnoPlugins/StaticPages/Pages/View.php
+++ b/IdnoPlugins/StaticPages/Pages/View.php
@@ -64,7 +64,7 @@ namespace IdnoPlugins\StaticPages\Pages {
                 }
             }
             if (empty($object)) {
-                \Idno\Core\Idno::site()->logging->error("No object was found with ID {$this->arguments[0]}.");
+                \Idno\Core\Idno::site()->logging()->error("No object was found with ID {$this->arguments[0]}.");
 
                 return false;
             }

--- a/IdnoPlugins/Webhooks/Pages/Admin.php
+++ b/IdnoPlugins/Webhooks/Pages/Admin.php
@@ -43,8 +43,8 @@ namespace IdnoPlugins\Webhooks\Pages
                     }
                 }
             }
-            \Idno\Core\Idno::site()->config->webhook_syndication = $webhook_syndication;
-            \Idno\Core\Idno::site()->config->save();
+            \Idno\Core\Idno::site()->config()->webhook_syndication = $webhook_syndication;
+            \Idno\Core\Idno::site()->config()->save();
             $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'admin/webhooks/');
 
         }

--- a/Tests/Pages/HomepageTest.php
+++ b/Tests/Pages/HomepageTest.php
@@ -57,7 +57,7 @@ EOD;
          */
         function testWebmentionContentSingleUser()
         {
-            Idno::site()->config->single_user = true;
+            Idno::site()->config()->single_user = true;
             $this->admin(); // make sure there is an admin user
             // uniquify source to make sure we get the notification
             $source = 'http://foo.bar/homepage-mention-single-user-'.md5(time() . rand(0, 9999));
@@ -77,7 +77,7 @@ EOD;
          */
         function testWebmentionContentSingleUserNoSlash()
         {
-            Idno::site()->config->single_user = true;
+            Idno::site()->config()->single_user = true;
             $this->admin(); // make sure there is an admin user
             $source = 'http://foo.bar/homepage-mention-single-user-no-slash-'.md5(time() . rand(0, 9999));
             $target = rtrim(Idno::site()->config()->getDisplayURL(), '/');
@@ -95,7 +95,7 @@ EOD;
          */
         function testWebmentionContentMultiUser()
         {
-            Idno::site()->config->single_user = false;
+            Idno::site()->config()->single_user = false;
             $source = 'http://foo.bar/homepage-mention-multi-user-'.md5(time() . rand(0, 9999));
             $target = Idno::site()->config()->getDisplayURL();
             $notification = $this->doWebmentionContent($source, $target);

--- a/Themes/Cherwell/Pages/Admin.php
+++ b/Themes/Cherwell/Pages/Admin.php
@@ -27,7 +27,7 @@ namespace Themes\Cherwell\Pages {
         {
             $this->adminGatekeeper(); // Admins only
             if ($profile_user = $this->getInput('profile_user')) {
-                \Idno\Core\Idno::site()->config->config['cherwell']['profile_user'] = $profile_user;
+                \Idno\Core\Idno::site()->config()->config['cherwell']['profile_user'] = $profile_user;
             }
             if (!empty($_FILES['background']) && $this->getInput('action') != 'clear') {
                 if (in_array($_FILES['background']['type'], array('image/png', 'image/jpg', 'image/jpeg', 'image/gif'))) {
@@ -43,9 +43,9 @@ namespace Themes\Cherwell\Pages {
                                     }
                                 }
                             }
-                            \Idno\Core\Idno::site()->config->config['cherwell']['bg_id'] = $background;
+                            \Idno\Core\Idno::site()->config()->config['cherwell']['bg_id'] = $background;
                             $background = \Idno\Core\Idno::site()->config()->getStaticURL() . 'file/' . $background;
-                            \Idno\Core\Idno::site()->config->config['cherwell']['bg'] = $background;
+                            \Idno\Core\Idno::site()->config()->config['cherwell']['bg'] = $background;
                         }
                     }
                 }
@@ -60,9 +60,9 @@ namespace Themes\Cherwell\Pages {
                         }
                     }
                 }
-                \Idno\Core\Idno::site()->config->cherwell = [];
+                \Idno\Core\Idno::site()->config()->cherwell = [];
             }
-            \Idno\Core\Idno::site()->config->save();
+            \Idno\Core\Idno::site()->config()->save();
             $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'admin/cherwell/');
         }
 

--- a/Themes/Cherwell/templates/default/admin/cherwell.tpl.php
+++ b/Themes/Cherwell/templates/default/admin/cherwell.tpl.php
@@ -48,7 +48,7 @@
                 <input type="hidden" name="action" value="" id="action">
                 <?php
 
-                if (!empty(\Idno\Core\Idno::site()->config->cherwell['bg_id'])) {
+                if (!empty(\Idno\Core\Idno::site()->config()->cherwell['bg_id'])) {
 
                     ?>
                         <input type="button" class="btn" value="Restore default image"
@@ -78,8 +78,8 @@
                         ?>
                                 <option value="<?php echo $user->handle ?>" <?php
 
-                                if (!empty(\Idno\Core\Idno::site()->config->cherwell['profile_user'])) {
-                                    if ($user->handle == \Idno\Core\Idno::site()->config->cherwell['profile_user']) {
+                                if (!empty(\Idno\Core\Idno::site()->config()->cherwell['profile_user'])) {
+                                    if ($user->handle == \Idno\Core\Idno::site()->config()->cherwell['profile_user']) {
                                         echo 'selected';
                                     }
                                 }

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@ require_once(dirname(__FILE__) . '/Idno/start.php');
 
 // Get page routes
 
-$routes = \Idno\Core\Idno::site()->pagehandlers;
+$routes = \Idno\Core\Idno::site()->routing();
 
 // Get subdirectory
 

--- a/templates/default/admin/dependencies/plugin.tpl.php
+++ b/templates/default/admin/dependencies/plugin.tpl.php
@@ -3,7 +3,7 @@ $plugin = trim($vars['plugin']);
 $version = trim($vars['version']);
 
 $loaded_plugin = \Idno\Core\Idno::site()->plugins()->get($plugin);
-$getstored = \Idno\Core\Idno::site()->plugins->getStored();
+$getstored = \Idno\Core\Idno::site()->plugins()->getStored();
 if(!empty($getstored[$plugin]))
     $details = $getstored[$plugin];
 

--- a/templates/default/pages/home/nocontent.tpl.php
+++ b/templates/default/pages/home/nocontent.tpl.php
@@ -1,4 +1,4 @@
-<?php if (\Idno\Core\Idno::site()->currentPage->getInput('q')) {
+<?php if (\Idno\Core\Idno::site()->currentPage()->getInput('q')) {
     // Search term
     ?>
     <div class="row" style="margin-top: 5em">

--- a/templates/default/settings-shell/footerjavascript.tpl.php
+++ b/templates/default/settings-shell/footerjavascript.tpl.php
@@ -33,7 +33,7 @@ if (\Idno\Core\Idno::site()->session()->isLoggedOn()) {
     echo $this->draw('js/mentions');
 }
     // Load javascript assets
-if ((\Idno\Core\Idno::site()->currentPage()) && $scripts = \Idno\Core\Idno::site()->currentPage->getAssets('javascript')) {
+if ((\Idno\Core\Idno::site()->currentPage()) && $scripts = \Idno\Core\Idno::site()->currentPage()->getAssets('javascript')) {
     echo "<!-- Begin asset javascript -->";
     foreach ($scripts as $script) {
         ?>

--- a/templates/default/shell/css.tpl.php
+++ b/templates/default/shell/css.tpl.php
@@ -11,7 +11,7 @@
 
 <?php
     // Load style assets
-if ((\Idno\Core\Idno::site()->currentPage()) && $style = \Idno\Core\Idno::site()->currentPage->getAssets('css')) {
+if ((\Idno\Core\Idno::site()->currentPage()) && $style = \Idno\Core\Idno::site()->currentPage()->getAssets('css')) {
     foreach ($style as $css) {
         ?>
             <link href="<?php echo $css; ?>" rel="stylesheet">

--- a/templates/default/shell/footerjavascript.tpl.php
+++ b/templates/default/shell/footerjavascript.tpl.php
@@ -33,7 +33,7 @@ if (\Idno\Core\Idno::site()->session()->isLoggedOn()) {
     echo $this->draw('js/mentions');
 }
     // Load javascript assets
-if ((\Idno\Core\Idno::site()->currentPage()) && $scripts = \Idno\Core\Idno::site()->currentPage->getAssets('javascript')) {
+if ((\Idno\Core\Idno::site()->currentPage()) && $scripts = \Idno\Core\Idno::site()->currentPage()->getAssets('javascript')) {
     echo "<!-- Begin asset javascript -->";
     foreach ($scripts as $script) {
         ?>

--- a/warmup/WebInstaller.php
+++ b/warmup/WebInstaller.php
@@ -15,7 +15,7 @@ class WebInstaller extends \Idno\Core\Installer
     {
         \Idno\Core\Bonita\Main::additionalPath(dirname(__FILE__));
         $this->template = new \Idno\Core\Bonita\Templates(); // Use basic template here
-        $this->template->setTemplateType('default');
+        $this->template()->setTemplateType('default');
 
         parent::__construct();
     }


### PR DESCRIPTION



## Here's what I fixed or added:
Make the member service variables of the Idno class private
## Here's why I did it:
Service infrastructure should not be directly interfaceable, or replaceable. Making them private means that they are only accessible via the correct interface

Making this patch also fixes the widespread use of the non-standard calling convention used amongst older code and templates.

Refs #2417 

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.