### PR TITLE
Display whether you're running Known from a package in diagnostics

### DIFF
--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -82,7 +82,19 @@ namespace Idno\Pages\Admin {
                         'status'  => 'Ok'
                     ];
                 }
-
+            }
+            
+            // Check to see if this is an official package
+            if ($revision = \Idno\Core\Version::get('revision')) {
+                $basics['report']['package'] = [
+                    'status'  => 'Ok'
+                ];
+            } else {
+                $basics['status']             = 'Failure';
+                $basics['report']['package'] = [
+                    'status'  => 'Warning',
+                    'message' => 'You appear to be running directly from a git checkout. While this is fine, you might find a pre-packaged version of Known more stable.'
+                ];
             }
 
             // Check SSL


### PR DESCRIPTION


## Here's what I fixed or added:
Display whether you're running Known from a package in diagnostics
## Here's why I did it:
Detect and warn if you're running directly from a git/composer checkout or an unofficial (soon to be official) package build.

This was done to hopefully help the few folk who are having issues using composer, and nudging them towards the (un)official packages.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.