### PR TITLE
Remove unused webignition libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,6 @@ Third party libraries are licensed separately.
 * Steve Clay's AutoP, which is distributed under the MIT License. Source: https://code.google.com/p/mrclay/
 * Aaron Parecki's Webmention Client, which is distributed under the Apache 2.0 license. Source: https://github.com/aaronpk/mention-client
 * Barnaby Walters's Microformats 2 Parser, which is distributed under the MIT License. Source: https://github.com/indieweb/php-mf2
-* Webignition URL libraries, which are distributed under the MIT license.
-  * Absolute URL deriver. Source: https://github.com/webignition/absolute-url-deriver
-  * URL. Source: https://github.com/webignition/url
 * FitVids.js, which is distributed under the WTFPL License. Source: http://fitvidsjs.com/
 * Leaflet.js, which is distributed under the BSD 2-Clause License. Source: http://leafletjs.com/ 
 * SwiftMailer, which is distributed under the MIT License. Source: https://github.com/swiftmailer/swiftmailer

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,6 @@
         "torophp/torophp": "dev-master",
         "mf2/mf2": "0.4.6",
         "swiftmailer/swiftmailer": "5.2.1",
-        "webignition/absolute-url-deriver": "1.5.2",
-        "webignition/url": "1.9.8",
         "fortawesome/font-awesome": "5.7.2",
         "twbs/bootstrap": "3.3.2",
         "components/jquery": "3.2.1",


### PR DESCRIPTION
## Here's what I fixed or added:

Remove unused `webignition` libraries from `composer.json`  Transitively removes `idna-convert` and `ip-utils`:

```
webignition/absolute-url-deriver 1.5.2 Derives an absolute URL from relative and source URLs
|--php >=5.6.0
`--webignition/url >=1.9.8
   |--etechnika/idna-convert 1.0.*
   |  `--php >=5.3.0
   |--php >=5.3.0
   `--xrstf/ip-utils v1.0.0
      `--php >=5.3.0
webignition/url 1.9.8 Represents a URL, a library to be used in many other places. Applies semantically-lossless normalisation for comparisons.
|--etechnika/idna-convert 1.0.*
|  `--php >=5.3.0
|--php >=5.3.0
`--xrstf/ip-utils v1.0.0
   `--php >=5.3.0
```

## Here's why I did it:

General tidiness

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the unit tests successfully.
