### PR TITLE
Deprecate PHP 7.0

### DIFF
--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -295,9 +295,9 @@ namespace Idno\Core {
          */
         public static function checkPHPVersion()
         {
-            if (version_compare(phpversion(), '7.0') >= 0) {
+            if (version_compare(phpversion(), '7.1') >= 0) {
                 return 'ok';
-            } else if (version_compare(phpversion(), '5.6') >= 0) {
+            } else if (version_compare(phpversion(), '7.0') >= 0) {
                 return 'warn';
             } else {
                 return 'fail';

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "ext-curl": "*",
         "ext-date": "*",
         "ext-dom": "*",

--- a/css/scss/known.scss
+++ b/css/scss/known.scss
@@ -7,5 +7,6 @@
 @import "known/settings-template.scss";
 @import "known/pagination.scss";
 @import "known/notifications.scss";
+@import "known/spinner.scss";
 
 @import "known/bootstrap3.scss";

--- a/css/scss/known.scss
+++ b/css/scss/known.scss
@@ -6,4 +6,6 @@
 @import "known/unfurl.scss";
 @import "known/settings-template.scss";
 @import "known/pagination.scss";
+@import "known/notifications.scss";
+
 @import "known/bootstrap3.scss";

--- a/css/scss/known/base.scss
+++ b/css/scss/known/base.scss
@@ -1649,63 +1649,6 @@ tr.items {
 }
 
 
-/* Saving Interaction */
-.spinner {
-  margin: 20px auto 0;
-  width: 90px;
-  text-align: center;
-}
-
-.bounce1 {
-  background-color: #af474f;
-}
-
-.bounce2 {
-  background-color: #ffb280;
-}
-
-.bounce3 {
-  background-color: #ffcc66;
-}
-
-.spinner > div {
-  width: 18px;
-  height: 18px;
-/*  background-color: #4c93cb; */
-
-  border-radius: 100%;
-  display: inline-block;
-  -webkit-animation: bouncedelay 1.4s infinite ease-in-out;
-  animation: bouncedelay 1.4s infinite ease-in-out;
-  /* Prevent first frame from flickering when animation starts */
-  -webkit-animation-fill-mode: both;
-  animation-fill-mode: both;
-}
-
-.spinner .bounce1 {
-  -webkit-animation-delay: -0.32s;
-  animation-delay: -0.32s;
-}
-
-.spinner .bounce2 {
-  -webkit-animation-delay: -0.16s;
-  animation-delay: -0.16s;
-}
-
-@-webkit-keyframes bouncedelay {
-  0%, 80%, 100% { -webkit-transform: scale(0.0) }
-  40% { -webkit-transform: scale(1.0) }
-}
-
-@keyframes bouncedelay {
-  0%, 80%, 100% {
-    transform: scale(0.0);
-    -webkit-transform: scale(0.0);
-  } 40% {
-    transform: scale(1.0);
-    -webkit-transform: scale(1.0);
-  }
-}
 
 .progress-striped .bar {
     background-color: #4c93cb;

--- a/css/scss/known/base.scss
+++ b/css/scss/known/base.scss
@@ -1828,64 +1828,6 @@ textarea.form-control {
 	color:#666;
 }
 
-/* Notifications */
-
-.notification .notification-avatar {
-    float: left;
-    margin-right: 1em;
-    max-width: 64px;
-}
-
-.notification.notification-unread  {
-    color: #333;
-    font-weight: bold;
-}
-
-.notification.notification-read  {
-    color: #666;
-    font-weight: normal;
-}
-
-.notification .panel-heading time {
-    float: right;
-}
-
-.notification .notification-avatar img {
-}
-
-.notification .notification-body {
-    overflow: off;
-    margin-left: 80px;
-}
-
-.notification blockquote {
-    font-size: 1em;
-}
-
-.notification .icon-container {
-    width: 30px;
-    height: 30px;
-}
-
-.notification .idno-content {
-    padding: 0.1em;
-    border-bottom: 1px dotted #ccc;
-    padding-bottom: 15px;
-    padding-top: 10px;
-}
-
-.notification .permalink {
-    width: 100%;
-}
-
-.unread-notification-count {
-    font-size: 0.8em;
-    font-weight: bold;
-    color: #f00;
-    position: relative;
-    top: -0.5em;
-    left: -0.2em;
-}
 
 /* Media player */
 

--- a/css/scss/known/notifications.scss
+++ b/css/scss/known/notifications.scss
@@ -1,0 +1,59 @@
+
+/* Notifications */
+
+.notification .notification-avatar {
+    float: left;
+    margin-right: 1em;
+    max-width: 64px;
+}
+
+.notification.notification-unread  {
+    color: #333;
+    font-weight: bold;
+}
+
+.notification.notification-read  {
+    color: #666;
+    font-weight: normal;
+}
+
+.notification .panel-heading time {
+    float: right;
+}
+
+.notification .notification-avatar img {
+}
+
+.notification .notification-body {
+    overflow: off;
+    margin-left: 80px;
+}
+
+.notification blockquote {
+    font-size: 1em;
+}
+
+.notification .icon-container {
+    width: 30px;
+    height: 30px;
+}
+
+.notification .idno-content {
+    padding: 0.1em;
+    border-bottom: 1px dotted #ccc;
+    padding-bottom: 15px;
+    padding-top: 10px;
+}
+
+.notification .permalink {
+    width: 100%;
+}
+
+.unread-notification-count {
+    font-size: 0.8em;
+    font-weight: bold;
+    color: #f00;
+    position: relative;
+    top: -0.5em;
+    left: -0.2em;
+}

--- a/css/scss/known/spinner.scss
+++ b/css/scss/known/spinner.scss
@@ -1,0 +1,58 @@
+
+/* Saving Interaction */
+.spinner {
+  margin: 20px auto 0;
+  width: 90px;
+  text-align: center;
+}
+
+.bounce1 {
+  background-color: #af474f;
+}
+
+.bounce2 {
+  background-color: #ffb280;
+}
+
+.bounce3 {
+  background-color: #ffcc66;
+}
+
+.spinner > div {
+  width: 18px;
+  height: 18px;
+/*  background-color: #4c93cb; */
+
+  border-radius: 100%;
+  display: inline-block;
+  -webkit-animation: bouncedelay 1.4s infinite ease-in-out;
+  animation: bouncedelay 1.4s infinite ease-in-out;
+  /* Prevent first frame from flickering when animation starts */
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+}
+
+.spinner .bounce1 {
+  -webkit-animation-delay: -0.32s;
+  animation-delay: -0.32s;
+}
+
+.spinner .bounce2 {
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+}
+
+@-webkit-keyframes bouncedelay {
+  0%, 80%, 100% { -webkit-transform: scale(0.0) }
+  40% { -webkit-transform: scale(1.0) }
+}
+
+@keyframes bouncedelay {
+  0%, 80%, 100% {
+    transform: scale(0.0);
+    -webkit-transform: scale(0.0);
+  } 40% {
+    transform: scale(1.0);
+    -webkit-transform: scale(1.0);
+  }
+}

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -4,7 +4,7 @@ Known _requires_ the following server components:
 
 + A Web Server that supports URL rewriting (Apache + mod_rewrite recommended).
 + If you are using Apache, you also need to make sure support for .htaccess is enabled (using [the AllowOverride All directive](https://help.ubuntu.com/community/EnablingUseOfApacheHtaccessFiles)).
-+ PHP 7.0 or above.
++ PHP 7.1 or above.
 + MySQL 5+ / MariaDB, MongoDB, Postgres or SQLite3. We recommend MySQL / MariaDB.
 
 Known can either be installed at the root of a domain or subdomain, or in a subdirectory.


### PR DESCRIPTION
## Here's what I fixed or added:

PHP 7.0 support set to WARN, PHP 5.6 and below dropped entirely

## Here's why I did it:

7.0 is EOL

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the unit tests successfully.
