### PR TITLE
Deprecate PHP 7.0

### DIFF
--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -295,9 +295,9 @@ namespace Idno\Core {
          */
         public static function checkPHPVersion()
         {
-            if (version_compare(phpversion(), '7.0') >= 0) {
+            if (version_compare(phpversion(), '7.1') >= 0) {
                 return 'ok';
-            } else if (version_compare(phpversion(), '5.6') >= 0) {
+            } else if (version_compare(phpversion(), '7.0') >= 0) {
                 return 'warn';
             } else {
                 return 'fail';

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "ext-curl": "*",
         "ext-date": "*",
         "ext-dom": "*",

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -4,7 +4,7 @@ Known _requires_ the following server components:
 
 + A Web Server that supports URL rewriting (Apache + mod_rewrite recommended).
 + If you are using Apache, you also need to make sure support for .htaccess is enabled (using [the AllowOverride All directive](https://help.ubuntu.com/community/EnablingUseOfApacheHtaccessFiles)).
-+ PHP 7.0 or above.
++ PHP 7.1 or above.
 + MySQL 5+ / MariaDB, MongoDB, Postgres or SQLite3. We recommend MySQL / MariaDB.
 
 Known can either be installed at the root of a domain or subdomain, or in a subdirectory.

--- a/index.php
+++ b/index.php
@@ -15,8 +15,13 @@
  */
 
 // Check PHP version first of all
-if (version_compare(phpversion(), '5.4', '<')) {
-    header('Location: warmup/');
+if (version_compare(phpversion(), '7.0', '<')) {
+    http_response_code(500);
+    $body = "Sorry, this version of PHP is not supported.";
+    $heading = "PHP Version not supported";
+    $helplink = '<a href="http://docs.withknown.com/en/latest/install/requirements/" target="_blank">Read system requirements</a>';
+    
+    require(dirname(__FILE__) . '/statics/error-page.php');
     exit;
 }
 


### PR DESCRIPTION
## Here's what I fixed or added:

* PHP 7.0 set to warning
* PHP 5.6 support dropped completely

## Here's why I did it:

PHP 7.0 is EOL

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to Known's style guide
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the unit tests successfully.
