### PR TITLE
Update Photo.tpl.php

### DIFF
--- a/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
+++ b/IdnoPlugins/Photo/templates/default/entity/Photo.tpl.php
@@ -79,7 +79,7 @@ if (empty($vars['feed_view']) && $vars['object']->getTitle() && $vars['object']-
                    data-title="<?php echo htmlentities(strip_tags($vars['object']->getTitle()), ENT_QUOTES, 'UTF-8'); ?>"
                    data-footer="<?php echo htmlentities(strip_tags($vars['object']->body), ENT_QUOTES, 'UTF-8'); ?>"><img
                             src="<?php echo $this->makeDisplayURL($src) ?>" class="u-photo"
-                            alt="<?php echo htmlentities(strip_tags($vars['object']->getTitle()), ENT_QUOTES, 'UTF-8'); ?>"/></a>
+                            alt="<?php echo htmlentities(strip_tags($vars['object']->getalt()), ENT_QUOTES, 'UTF-8'); ?>"/></a>
             </div>
             <?php
             $photoCount++;


### PR DESCRIPTION
trying to echo the new variable I created for alt text. I did not know I should remove the html sanitizing or keep it so people can not use tags in the alt text field.


## Here's what I fixed or added:

I added a form field for alt text to the photo page. It still needs to be added to edit.php but I wanted to check if I was on the correct path first.

I then named the variable alt

Then in Photo.tpl.php

I switched GetTitle to Getalt

## Here's why I did it:
100% probably did this incorrect but wanted to get this started as this is a critical bug for me. I have blind students in class and will not be able to use photo post types until the alt text is resolved.

Alt text is different than the title of a photo or a post.

## Checklist:

I do not meet the qualities of the checklist. My apologies

- [ X] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
