### PR TITLE
Twig template support

### DIFF
--- a/Idno/Core/HybridTwigTemplate.php
+++ b/Idno/Core/HybridTwigTemplate.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Hybrid twig template management class
+ *
+ * @package idno
+ * @subpackage core
+ */
+
+namespace Idno\Core {
+    
+    use Twig\Loader\FilesystemLoader;
+    use Twig\Environment;
+    
+    /**
+     * Hybrid twig template management class.
+     * 
+     * This class extends the Known template to, in addition to supporting the Known php based templates, to support
+     * the more standard twig templates.
+     */
+    class HybridTwigTemplate extends Template {
+        
+        private $twig;
+        
+        private $loader;
+        
+        public function __construct($template = false) {
+            
+            // Set up twig environment
+            $this->loader = new FilesystemLoader(\Idno\Core\Bonita\Main::getPaths());
+            $this->twig = new Environment($this->loader);
+            
+            // Update with the parent
+            return parent::__construct($template);
+        }
+        
+        /**
+         * Extension-aware version of the template drawing function
+         *
+         * @param string $templateName
+         * @param bool $returnBlank Should we return a blank string if the template doesn't exist? (Defaults to true)
+         * @param book $replacements Should we honor template replacements? (Defaults to true)
+         * @return false|string
+         */
+        function draw($templateName, $returnBlank = true, $replacements = true)
+        {
+            $result = '';
+            if (!empty($this->prepends[$templateName])) {
+                foreach ($this->prepends[$templateName] as $template) {
+                    try {
+                        $result .= $this->twig->render("{$template}.twig", $this->vars);
+                    } catch (\Exception $e) {
+                        // Ignore loading errors here
+                    }
+                    
+                }
+            }
+            $replaced = false;
+            foreach(['*', $this->getTemplateType()] as $templateType) {
+                if (!empty($this->replacements[$templateName][$templateType]) && $replacements == true) {
+                    try {
+                        $result .= $this->twig->render("{$this->replacements[$templateName][$templateType]}.twig", $this->vars);
+                    
+                        $replaced = true;
+                    } catch (\Exception $e) {
+                        // Ignore loading errors here
+                    }
+                }
+                if (!empty($this->extensions[$templateName][$templateType])) {
+                    foreach ($this->extensions[$templateName][$templateType] as $template) {
+                        try {
+                            $result .= $this->twig->render("{$template}.twig", $this->vars);
+                        } catch (\Exception $e) {
+                            // Ignore loading errors here
+                        }
+                    }
+                }
+            }
+            if (!$replaced) {
+                try {
+                    $result .= $this->twig->render("{$templateName}.twig", $this->vars);
+                } catch (\Exception $e) {
+                    // Ignore loading errors here
+                }
+            }
+            
+            return parent::draw($templateName, $returnBlank, $replacements);
+        }
+    }
+    
+}

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -113,7 +113,7 @@ namespace Idno\Core {
 
             $this->session      = new Session();
             $this->actions      = new Actions();
-            $this->template     = new Template();
+            $this->template     = new HybridTwigTemplate();
             $this->language     = new Language();
                 $this->language()->register(new GetTextTranslation()); // Register default gettext translations
             $this->syndication  = new Syndication();

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "npm-asset/vanilla-fitvids": "1.1.0",
         "bower-asset/mention": "dev-master",
         "mapkyca/known-mongo-php-library": "dev-master",
-        "indieweb/mention-client": "1.2.0"
+        "indieweb/mention-client": "1.2.0",
+        "twig/twig": "2.11"
     },
     "license": "Apache-2.0",
     "prefer-stable": true,


### PR DESCRIPTION
## Here's what I fixed or added:

Added the ability for Known to load twig templates in addition to Known Bonita templates

## Here's why I did it:

Because it's standard, and we should probably be moving towards that.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.