### PR TITLE
Closes #2453: Switching to composer class loader

### DIFF
--- a/Idno/start.php
+++ b/Idno/start.php
@@ -105,41 +105,18 @@
         exit();
     }
 
-    // We're making heavy use of the Symfony ClassLoader to load our classes
-    global $known_loader;
-    $known_loader = new \Symfony\Component\ClassLoader\ClassLoader();
-
-    /**
-     * Retrieve the loader
-     * @return \Symfony\Component\ClassLoader\UniversalClassLoader
-     */
-    function &loader()
-    {
-        global $known_loader;
-
-        return $known_loader;
-    }
-
-    // Register our main namespaces (all idno classes adhere to the PSR-0 standard)
-
-    // idno trunk classes (i.e., the main framework) are in /idno
-    $known_loader->addPrefix('Idno', dirname(dirname(__FILE__)));
+    
     // Host for the purposes of extra paths
     if (!empty($_SERVER['HTTP_HOST'])) {
+        
         $host = strtolower($_SERVER['HTTP_HOST']);
         $host = str_replace('www.', '', $host);
         define('KNOWN_MULTITENANT_HOST', $host);
-        // idno plugins are located in /IdnoPlugins and must have their own namespace
-        $known_loader->addPrefix('IdnoPlugins', array(dirname(dirname(__FILE__)), dirname(dirname(__FILE__)) . '/hosts/' . $host));
-        // idno themes are located in /Themes and must have their own namespace
-        $known_loader->addPrefix('Themes', array(dirname(dirname(__FILE__)), dirname(dirname(__FILE__)) . '/hosts/' . $host));
+        
     }
 
     // Shims
     include 'shims.php';
-
-    // Register the autoloader
-    $known_loader->register();
 
     // Register the idno-templates folder as the place to look for templates in Bonita
     \Idno\Core\Bonita\Main::additionalPath(dirname(dirname(__FILE__)));

--- a/Tests/_bootstrap.php
+++ b/Tests/_bootstrap.php
@@ -26,12 +26,6 @@ try {
     // Load Known framework
     require_once(dirname(dirname(__FILE__)) . '/Idno/start.php');
 
-    // Register test classes with class loader
-    loader()->addPrefix('Tests', dirname(dirname(__FILE__)));
-
-    // TODO: Initialise and populate test DB
-
-
 } catch (Exception $ex) {
     echo $ex->getMessage();
 }

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,15 @@
       "docs": "http://docs.withknown.com",
       "irc": "irc://irc.freenode.net/knownchat"
     },
+    "autoload": {
+        "psr-4": {
+            "Idno\\": "Idno/",
+	    "IdnoPlugins\\": ["IdnoPlugins/", "IdnoPlugins.local/"],
+	    "Themes\\": "Themes/",
+	    "ConsolePlugins\\": "ConsolePlugins/",
+	    "Tests\\": "Tests/"
+        }
+    },
     "require-dev": {
         "mapkyca/known-phpcs": "^1.0",
         "mapkyca/known-language-tools": "^1.0"

--- a/known.php
+++ b/known.php
@@ -9,30 +9,9 @@
     } else {
         die('Could not find autoload.php, did you run "composer install" ..?');
     }
-        
-    // Load Symfony
-    global $known_loader;
-    $known_loader = new \Symfony\Component\ClassLoader\ClassLoader();
-    $known_loader->register();
-
-    /**
-     * Retrieve the loader
-     * @return \Symfony\Component\ClassLoader\UniversalClassLoader
-     */
-function &loader()
-{
-    global $known_loader;
-
-    return $known_loader;
-}
 
     // Register console namespace
     use Symfony\Component\Console\Application;
-
-
-    // Known core namespaces
-    $known_loader->addPrefix('Idno', dirname(__FILE__));
-    $known_loader->addPrefix('ConsolePlugins', dirname(__FILE__));
 
     // Create new console application
     global $console;

--- a/warmup/CLI/CLIInstaller.php
+++ b/warmup/CLI/CLIInstaller.php
@@ -1,16 +1,12 @@
 #!/usr/bin/php -q
 <?php
-    // Load external libraries
-    if (file_exists(dirname(dirname(dirname(__FILE__))) . '/vendor/autoload.php')) {
-        require_once(dirname(dirname(dirname(__FILE__))) . '/vendor/autoload.php');
-    } else {
-        die('Could not find autoload.php, did you run "composer install" ..?');
-    }
 
-    // Load Symfony
-    global $known_loader;
-    $known_loader = new \Symfony\Component\ClassLoader\UniversalClassLoader();
-    $known_loader->register();
+// Load external libraries
+if (file_exists(dirname(dirname(dirname(__FILE__))) . '/vendor/autoload.php')) {
+    require_once(dirname(dirname(dirname(__FILE__))) . '/vendor/autoload.php');
+} else {
+    die('Could not find autoload.php, did you run "composer install" ..?');
+}
 
 /**
  * Load Idno


### PR DESCRIPTION


## Here's what I fixed or added:
Closes #2453: Switching to composer class loader
## Here's why I did it:
Replacing Symfony classloader as it's now deprecated by the project. Composer's class loader is also faster, so there's that.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
