### PR TITLE
Ensure that all annotation links have rel="nofollow"

### DIFF
--- a/templates/default/entity/annotations/likes.tpl.php
+++ b/templates/default/entity/annotations/likes.tpl.php
@@ -15,15 +15,15 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" class="icon-container" rel="nofollow"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">
                     <p>
-                        <a href="<?php echo htmlspecialchars($annotation['owner_url'])?>"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a>
+                        <a href="<?php echo htmlspecialchars($annotation['owner_url'])?>" rel="nofollow"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a>
                     <?php echo \Idno\Core\Idno::site()->language()->_('liked this post'); ?>
                     </p>
-                    <p><small><a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
+                    <p><small><a href="<?php echo htmlspecialchars($permalink) ?>" rel="nofollow"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo htmlspecialchars($permalink) ?>" rel="nofollow"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
                 </div>
             <?php
             $this->annotation_permalink = $locallink;

--- a/templates/default/entity/annotations/mentions.tpl.php
+++ b/templates/default/entity/annotations/mentions.tpl.php
@@ -11,11 +11,11 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo htmlspecialchars($annotation['owner_url'])?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <a href="<?php echo htmlspecialchars($annotation['owner_url'])?>" rel="nofollow" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">
-                    <p><?php echo \Idno\Core\Idno::site()->language()->_('Mentioned in'); ?>: <a href="<?php echo $permalink?>"><?php
+                    <p><?php echo \Idno\Core\Idno::site()->language()->_('Mentioned in'); ?>: <a href="<?php echo $permalink?>" rel="nofollow"><?php
 
                     if (!empty($annotation['title'])) {
                         echo htmlspecialchars($annotation['title']);
@@ -24,9 +24,9 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
                     }
 
                     ?></a></p>
-                    <p><small><a href="<?php echo htmlspecialchars($annotation['owner_url'])?>"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a>,
-                            <a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo date('M d Y', $annotation['time']);?></a>
-                            on <a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
+                    <p><small><a href="<?php echo htmlspecialchars($annotation['owner_url'])?>" rel="nofollow"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a>,
+                            <a href="<?php echo htmlspecialchars($permalink) ?>" rel="nofollow"><?php echo date('M d Y', $annotation['time']);?></a>
+                            on <a href="<?php echo htmlspecialchars($permalink) ?>" rel="nofollow"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
                 </div>
                 <?php
                 $this->annotation_permalink = $locallink;

--- a/templates/default/entity/annotations/replies.tpl.php
+++ b/templates/default/entity/annotations/replies.tpl.php
@@ -11,7 +11,7 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row u-comment h-cite">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo strip_tags($annotation['owner_url']) ?>" class="icon-container"><img
+                        <a href="<?php echo strip_tags($annotation['owner_url']) ?>" rel="nofollow" class="icon-container"><img
                                     src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL(strip_tags($annotation['owner_image'])) ?>"/></a>
                     </p>
                 </div>
@@ -20,11 +20,11 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
                     <p>
                         <small>
                     <span class="p-author h-card">
-                        <a class="u-photo" href="<?php echo strip_tags($annotation['owner_image']) ?>"></a>
+                        <a class="u-photo" rel="nofollow" href="<?php echo strip_tags($annotation['owner_image']) ?>"></a>
                         <a class="p-name u-url"
-                           href="<?php echo htmlspecialchars(strip_tags($annotation['owner_url'])) ?>"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8') ?></a></span>,
-                            <a href="<?php echo $permalink ?>"><?php echo date('M d Y', $annotation['time']); ?></a>
-                            on <a href="<?php echo $permalink ?>" class="u-url"><?php echo parse_url($permalink, PHP_URL_HOST) ?></a>
+                           href="<?php echo htmlspecialchars(strip_tags($annotation['owner_url'])) ?>" rel="nofollow"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8') ?></a></span>,
+                            <a href="<?php echo $permalink ?>" rel="nofollow"><?php echo date('M d Y', $annotation['time']); ?></a>
+                            on <a href="<?php echo $permalink ?>" rel="nofollow" class="u-url"><?php echo parse_url($permalink, PHP_URL_HOST) ?></a>
                         </small>
                     </p>
                 </div>

--- a/templates/default/entity/annotations/rsvps.tpl.php
+++ b/templates/default/entity/annotations/rsvps.tpl.php
@@ -16,14 +16,14 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" rel="nofollow" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">
                     <p>
                         <strong><?php echo strip_tags($annotation['content']); ?></strong>
                     </p>
-                    <p><small><a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
+                    <p><small><a href="<?php echo htmlspecialchars($permalink) ?>" rel="nofollow"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo htmlspecialchars($permalink) ?>" rel="nofollow"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
                 </div>
             </div>
         <?php

--- a/templates/default/entity/annotations/shares.tpl.php
+++ b/templates/default/entity/annotations/shares.tpl.php
@@ -12,15 +12,15 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" rel="nofollow" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">
                     <p>
-                        <a href="<?php echo htmlspecialchars($annotation['owner_url'])?>"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a>
-                        <a href="<?php echo htmlspecialchars($permalink)?>"><?php echo \Idno\Core\Idno::site()->language()->_('reshared this post'); ?></a>
+                        <a href="<?php echo htmlspecialchars($annotation['owner_url'])?>" rel="nofollow"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a>
+                        <a href="<?php echo htmlspecialchars($permalink)?>" rel="nofollow"><?php echo \Idno\Core\Idno::site()->language()->_('reshared this post'); ?></a>
                     </p>
-                    <p><small><a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo htmlspecialchars($permalink) ?>"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
+                    <p><small><a href="<?php echo htmlspecialchars($permalink) ?>" rel="nofollow"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo htmlspecialchars($permalink) ?>" rel="nofollow"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
                 </div>
             </div>
         <?php


### PR DESCRIPTION



## Here's what I fixed or added:
Ensure that all annotation links have rel="nofollow"
## Here's why I did it:
We should not be endorsing or passing on any pagerank to links in any pings.
## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.