### PR TITLE
Associates object with a page when a permalink

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -881,7 +881,7 @@ namespace Idno\Common {
          * @param bool $status Is this a permalink? Defaults to 'true'
          * @param object $entity Optionally, an entity this page is associated with
          */
-        function setPermalink($status = true, $entity = null)
+        function setPermalink(bool $status = true, Entity $entity = null)
         {
             $this->isPermalinkPage = $status;
             if ($status && $entity) $this->setEntity($entity);

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -42,6 +42,10 @@ namespace Idno\Common {
         // to no, but you can use $this->setPermalink() to change this
         private $isPermalinkPage = false;
 
+        // If this page is associated with a particular entity, we'll
+        // store it here so we can access it in shell templates etc
+        private $entity = null;
+
         // Is this an XmlHTTPRequest (AJAX) call?
         public $xhr = false;
 
@@ -848,13 +852,39 @@ namespace Idno\Common {
         }
 
         /**
-         * Is this page a permalink for an object? This should be set to 'true'
-         * if it is.
-         * @param bool $status Is this a permalink? Defaults to 'true'
+         * Sets the entity on the page to the specified object
+         * @param object $entity
          */
-        function setPermalink($status = true)
+        function setEntity($entity) {
+            $this->entity = $entity;
+        }
+
+        /**
+         * Returns the entity associated with this page, if it exists
+         * @param $entity
+         * @return object|null
+         */
+        function getEntity($entity) {
+            return $this->entity;
+        }
+
+        /**
+         * Removes any entity associated with this page
+         */
+        function removeEntity() {
+            $this->entity = null;
+        }
+
+        /**
+         * Is this page a permalink for an object? This should be set to 'true'
+         * if it is. Optionally, we can also associate the page with the object here.
+         * @param bool $status Is this a permalink? Defaults to 'true'
+         * @param object $entity Optionally, an entity this page is associated with
+         */
+        function setPermalink($status = true, $entity = null)
         {
             $this->isPermalinkPage = $status;
+            if ($status && $entity) $this->setEntity($entity);
         }
 
         /**

--- a/Idno/Pages/Entity/View.php
+++ b/Idno/Pages/Entity/View.php
@@ -39,7 +39,7 @@ namespace Idno\Pages\Entity {
             }
 
             $this->setOwner($object->getOwner());
-            $this->setPermalink(); // This is a permalink
+            $this->setPermalink(true, $object); // This is a permalink
 
             $this->lastModifiedGatekeeper($object->updated); // 304 if we've not updated the object
 

--- a/Idno/Pages/User/View.php
+++ b/Idno/Pages/User/View.php
@@ -18,7 +18,6 @@ namespace Idno\Pages\User {
     {
 
         // Handle GET requests to the entity
-
         function getContent()
         {
 

--- a/Idno/Pages/User/View.php
+++ b/Idno/Pages/User/View.php
@@ -31,7 +31,7 @@ namespace Idno\Pages\User {
 
             // Users own their own profiles
             $this->setOwner($user);
-            $this->setPermalink(); // This is a permalink
+            $this->setPermalink(true, $user); // This is a permalink
 
             if (!empty($this->arguments[1])) { // If we're on the friendly content-specific URL
                 if ($friendly_types = explode('/', $this->arguments[1])) {

--- a/Tests/Pages/User/ViewTest.php
+++ b/Tests/Pages/User/ViewTest.php
@@ -7,7 +7,6 @@ namespace Tests\Pages\User {
 
     class ViewTest extends \Tests\KnownTestCase
     {
-
         function testWebmentionContent()
         {
             $user = $this->user();
@@ -48,8 +47,6 @@ EOD;
             $profile->webmentionContent($source, $target, $sourceResp, $sourceMf2);
             $this->assertFalse($notification);
         }
-
     }
-
 }
 

--- a/Tests/Pages/User/ViewTest.php
+++ b/Tests/Pages/User/ViewTest.php
@@ -8,6 +8,16 @@ namespace Tests\Pages\User {
     class ViewTest extends \Tests\KnownTestCase
     {
 
+        function testPagePermalink()
+        {
+            $user = $this->user();
+            $page = \Idno\Core\Idno::site()->routes()->getRoute('/profile/' . $user->getHandle());
+
+            $this->assertTrue($page->isPermalink());
+            $this->assertEquals($page->getEntity()->getUUID(), $user->getUUID());
+
+        }
+
         function testWebmentionContent()
         {
             $user = $this->user();
@@ -18,12 +28,12 @@ namespace Tests\Pages\User {
                 $notification = $eventdata['notification'];
             });
 
-            $source = 'http://karenpage.com/looking-for-information-' . md5(time() . rand(0, 9999));
+            $source = 'http://karenpage.dummy/looking-for-information-' . md5(time() . rand(0, 9999));
             $target = $user->getURL();
 
             $sourceContent = <<<EOD
 <div class="h-entry">
-  <a class="p-author h-card" href="http://karenpage.com/">Karen Page</a>
+  <a class="p-author h-card" href="http://karenpage.dummy/">Karen Page</a>
   <span class="p-name e-content">
     Hey <a href="$target">You</a> I'm trying to get some information on Frank Castle
   </span>
@@ -37,11 +47,11 @@ EOD;
             $profile->webmentionContent($source, $target, $sourceResp, $sourceMf2);
 
             $this->assertTrue($notification !== false);
-            $this->assertEquals('http://karenpage.com/', $notification['actor']);
+            $this->assertEquals('http://karenpage.dummy/', $notification['actor']);
 
-            $this->assertEquals('You were mentioned by Karen Page on karenpage.com', $notification['message']);
+            $this->assertEquals('You were mentioned by Karen Page on karenpage.dummy', $notification['message']);
             $this->assertEquals('Karen Page', $notification['object']['owner_name']);
-            $this->assertEquals('http://karenpage.com/', $notification['object']['owner_url']);
+            $this->assertEquals('http://karenpage.dummy/', $notification['object']['owner_url']);
 
             // make sure second webmention for the same source does not create another notification
             $notification = false;

--- a/Tests/Pages/User/ViewTest.php
+++ b/Tests/Pages/User/ViewTest.php
@@ -8,16 +8,6 @@ namespace Tests\Pages\User {
     class ViewTest extends \Tests\KnownTestCase
     {
 
-        function testPagePermalink()
-        {
-            $user = $this->user();
-            $page = \Idno\Core\Idno::site()->routes()->getRoute('/profile/' . $user->getHandle());
-
-            $this->assertTrue($page->isPermalink());
-            $this->assertEquals($page->getEntity()->getUUID(), $user->getUUID());
-
-        }
-
         function testWebmentionContent()
         {
             $user = $this->user();


### PR DESCRIPTION
## Here's what I fixed or added:

Permalink pages now actually set the object into metadata.

## Here's why I did it:

I want to be able to reference the object itself outside of its display shell. This is an easy way to put the object somewhere the whole page, all templates, and other hooks can access it.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [x] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
