### PR TITLE
Adds override hooks to entity draw methods

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1671,9 +1671,15 @@ namespace Idno\Common {
 
             if (!empty($suffix)) $suffix = '/' . $suffix;
 
-            $return = $t->__($params)->draw('entity/' . $this->getClassName() . $suffix, false);
-            if ($return === false) {
-                $return = $t->__($params)->draw('entity/default');
+            $view_name = 'entity/' . $this->getClassName(true) . $suffix;
+
+            $return = Idno::site()->events()->triggerEvent('entity/draw', ['feed_view' => $feed_view, 'view' => $view_name, 'object' => $this], false);
+
+            if (!$return) {
+                $return = $t->__($params)->draw($view_name, false);
+                if ($return === false) {
+                    $return = $t->__($params)->draw('entity/default');
+                }
             }
 
             return $return;
@@ -1689,9 +1695,14 @@ namespace Idno\Common {
         {
             $t = \Idno\Core\Idno::site()->template();
 
-            $return = $t->__(array(
-                'object' => $this
-            ))->draw('entity/' . $this->getFullClassName(true) . '/edit');
+            $view_name = 'entity/' . $this->getClassName(true) . '/edit';
+            $return = Idno::site()->events()->triggerEvent('entity/drawEdit', ['view' => $view_name, 'object' => $this], false);
+
+            if (!$return) {
+                $return = $t->__(array(
+                    'object' => $this
+                ))->draw('entity/' . $this->getFullClassName(true) . '/edit');
+            }
 
             if ($return === false) {
                 $return = $t->__(array(


### PR DESCRIPTION
## Here's what I fixed or added:

Entity draw methods can now be completely overridden using an event.

## Here's why I did it:

Sometimes we may need to change how an entity is drawn, or suppress whether it is drawn at all. There's no good way to do this right now.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
