### PR TITLE
avoid exposing git folders

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -22,6 +22,7 @@
     RewriteRule ^(.*)$ %{ENV:BASE}/index.php?/$1 [L,QSA]
     RewriteRule ^Uploads.* - [F]
 </IfModule>
+RedirectMatch 403 "^/(.git|.github)/.*$"
 <Files  ~ "\.dist$">
   Order allow,deny
   Deny from all

--- a/.htaccess
+++ b/.htaccess
@@ -4,6 +4,8 @@
     RewriteEngine on
     #RewriteBase /
 
+    RewriteRule ^\.git(|hub)/ - [F]
+
     RewriteCond %{HTTP:Authorization} ^(.+)$
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
@@ -22,7 +24,6 @@
     RewriteRule ^(.*)$ %{ENV:BASE}/index.php?/$1 [L,QSA]
     RewriteRule ^Uploads.* - [F]
 </IfModule>
-RedirectMatch 403 "^/(.git|.github)/.*$"
 <Files  ~ "\.dist$">
   Order allow,deny
   Deny from all

--- a/warmup/webserver-configs/htaccess-2.4.dist
+++ b/warmup/webserver-configs/htaccess-2.4.dist
@@ -4,6 +4,8 @@
     RewriteEngine on
     #RewriteBase /
 
+    RewriteRule ^\.git(|hub)/ - [F]
+
     RewriteCond %{HTTP:Authorization} ^(.+)$
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 

--- a/warmup/webserver-configs/htaccess.dist
+++ b/warmup/webserver-configs/htaccess.dist
@@ -4,6 +4,8 @@
     RewriteEngine on
     #RewriteBase /
 
+    RewriteRule ^\.git(|hub)/ - [F]
+
     RewriteCond %{HTTP:Authorization} ^(.+)$
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 

--- a/warmup/webserver-configs/nginx.conf
+++ b/warmup/webserver-configs/nginx.conf
@@ -90,6 +90,10 @@ http {
     location /configuration/ {
       deny all;
     }
+
+    location /\.git(|hub)/ {
+      deny all;
+    }
   }
 }
 


### PR DESCRIPTION
## Here's what I fixed or added:
`.htaccess` line to 403 `.git` and `.github` directories

## Here's why I did it:
I feels insecure for those sites running on git version to expose git boilerplate.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
