### PR TITLE
Update tinymce, underscore, vanilla-fitvids, and mediaelement dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "npm-asset/bootstrap-toggle": "2.2.2",
         "npm-asset/exif-js": "2.3.0",
         "npm-asset/jquery": "3.4.1",
-        "npm-asset/mediaelement": "4.2.6",
+        "npm-asset/mediaelement": "4.2.10",
         "npm-asset/vanilla-fitvids": "1.1.0",
         "bower-asset/mention": "dev-master",
         "mapkyca/known-mongo-php-library": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "npm-asset/exif-js": "2.3.0",
         "npm-asset/jquery": "3.4.1",
         "npm-asset/mediaelement": "4.2.10",
-        "npm-asset/vanilla-fitvids": "1.1.0",
+        "npm-asset/vanilla-fitvids": "1.2.0",
         "bower-asset/mention": "dev-master",
         "mapkyca/known-mongo-php-library": "dev-master",
         "indieweb/mention-client": "1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "twbs/bootstrap": "3.4.1",
         "ezyang/htmlpurifier": "4.10",
         "rmm5t/jquery-timeago": "1.6.7",
-        "tinymce/tinymce": "5.0.5",
+        "tinymce/tinymce": "5.0.11",
         "symfony/event-dispatcher": "4.3.0",
         "symfony/console": "4.3.0",
         "symfony/http-foundation": "4.3.0",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/http-foundation": "4.3.0",
         "simplepie/simplepie": "1.5.2",
         "mapkyca/mrclay_autop_known": "dev-master",
-        "npm-asset/underscore": "1.6.0",
+        "npm-asset/underscore": "1.9.1",
         "npm-asset/bootstrap-accessibility-plugin": "1.0.7",
         "npm-asset/bootstrap-toggle": "2.2.2",
         "npm-asset/exif-js": "2.3.0",


### PR DESCRIPTION
## Here's what I fixed or added:

- tinymce to 5.0.11
  - changelog https://www.tiny.cloud/docs/changelog/
- underscore to 1.9.1
  - changelog: https://underscorejs.org/#changelog
- vanilla-fitvids plugin to 1.2.0
- mediaelement plugin to 4.2.10
  - changelog https://github.com/mediaelement/mediaelement/releases

## Here's why I did it:

Update infra components to stay up to date.

## Checklist:

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.