### PR TITLE
remove deprecated getPageHandler()

### DIFF
--- a/Idno/Pages/Webmentions/Endpoint.php
+++ b/Idno/Pages/Webmentions/Endpoint.php
@@ -49,11 +49,11 @@ namespace Idno\Pages\Webmentions {
                 }
 
                 // Get the page handler for target
-                if ($page = \Idno\Core\Idno::site()->getPageHandler($route)) {
+                if ($page = \Idno\Core\Idno::site()->routes()->getRoute($route)) {
                     // First of all, make sure the target page isn't the source page. Let's not webmention ourselves!
                     $webmention_ok = true;
                     if (\Idno\Common\Entity::isLocalUUID($source)) {
-                        if ($source_page = \Idno\Core\Idno::site()->getPageHandler($source)) {
+                        if ($source_page = \Idno\Core\Idno::site()->routes()->getRoute($source)) {
                             if ($source_page == $page) {
                                 $webmention_ok = false;
                             }


### PR DESCRIPTION
## Here's what I fixed or added:
removed deprecated getPageHandler() in Idno/Pages/Webmentions/Endpoint.php

## Here's why I did it:
less deprecation warnings = less errors in log = easier to debug real issues

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
