### PR TITLE
don't show Facebook+Bridgy under Interactions

### DIFF
--- a/IdnoPlugins/Bridgy/languages/bridgy.pot
+++ b/IdnoPlugins/Bridgy/languages/bridgy.pot
@@ -19,7 +19,7 @@ msgid "is a service that pulls social interactions - such as likes and retweets 
 msgstr ""
 
 #: ./templates/default/bridgy/account.tpl.php:16
-msgid "If you send content from Known to Facebook or Twitter, use Bridgy to save comments and interactions from those networks to the original post on your Known site."
+msgid "If you send content from Known to Twitter, use Bridgy to save comments and interactions from those networks to the original post on your Known site."
 msgstr ""
 
 #: ./templates/default/bridgy/account.tpl.php:18

--- a/IdnoPlugins/Bridgy/templates/default/bridgy/account.tpl.php
+++ b/IdnoPlugins/Bridgy/templates/default/bridgy/account.tpl.php
@@ -13,7 +13,7 @@
         <p class="explanation">
             <a href="https://www.brid.gy"><?php echo \Idno\Core\Idno::site()->language()->_('Bridgy'); ?></a> <?php echo \Idno\Core\Idno::site()->language()->_('is a service that pulls social interactions - such as likes and retweets - back to your website.'); ?></p>
 
-        <p class="explanation"><?php echo \Idno\Core\Idno::site()->language()->_('If you send content from Known to Facebook or Twitter, use Bridgy to save comments and interactions from those networks to the original post on your Known site.'); ?></p>
+        <p class="explanation"><?php echo \Idno\Core\Idno::site()->language()->_('If you send content from Known to Twitter, use Bridgy to save comments and interactions from those networks to the original post on your Known site.'); ?></p>
 
         <p class="explanation"><?php echo \Idno\Core\Idno::site()->language()->_('To get started, activate Bridgy for the social network.'); ?></p>
 
@@ -23,7 +23,7 @@
 <div class="row" id="account-area">
 
         <div class="col-md-6 col-md-offset-1">
-        <?php if ($vars['facebook_enabled']) { ?>
+<!--        <?php if ($vars['facebook_enabled']) { ?>
             <form action="https://www.brid.gy/delete/start" method="post">
             <input type="hidden" name="feature" value="listen" />
             <input type="hidden" name="key" value="<?php echo $vars['facebook_key']?>" />
@@ -47,7 +47,7 @@
                 <?php echo \Idno\Core\Idno::site()->language()->_('Bridgy pulls in comments and likes from Facebook.'); ?>
             </p>
         </form>
-        <?php } ?>
+        <?php } ?> -->
 
         <?php if ($vars['twitter_enabled']) { ?>
         <form action="https://www.brid.gy/delete/start" method="post">


### PR DESCRIPTION
## Here's what I fixed or added:
Removed Facebook + Bridgy from Interactons page in Account Setiings

## Here's why I did it:
Bridgy quit supporting Facebook [more than a year ago](https://brid.gy/about#rip-facebook).

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
