### PR TITLE
Warn for 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ php:
  - 7.2
  - 7.3
 
+matrix:
+  allow_failures:
+    - php: 7.1
+
 # Configure different DB environments
 env:
   - DB=mysql

--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -295,9 +295,9 @@ namespace Idno\Core {
          */
         public static function checkPHPVersion()
         {
-            if (version_compare(phpversion(), '7.1') >= 0) {
+            if (version_compare(phpversion(), '7.2') >= 0) {
                 return 'ok';
-            } else if (version_compare(phpversion(), '7.0') >= 0) {
+            } else if (version_compare(phpversion(), '7.1') >= 0) {
                 return 'warn';
             } else {
                 return 'fail';


### PR DESCRIPTION
## Here's what I fixed or added:
Moving warning from 7.0 to 7.1, and ok from 7.2 onwards
## Here's why I did it:
7.1 is now in extended support, and php unit is now failing for it
## Checklist:

- [x] This pull request addresses a single issue
- [x] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
