### PR TITLE
Permit the use of <div> in rich text blocks

### DIFF
--- a/templates/default/forms/input/richtext.tpl.php
+++ b/templates/default/forms/input/richtext.tpl.php
@@ -75,7 +75,7 @@ if (!empty($vars['label'])) {
             remove_script_host : false,
             convert_urls : true,
             valid_children : "+body[style]",
-            invalid_elements: 'div,section',
+            invalid_elements: 'section',
             valid_styles : 'font-style,color,text-align,text-decoration,float,display,margin-left,margin-right',
             file_picker_callback: function (callback, value, meta) {
                 filePickerDialog(callback, value, meta);


### PR DESCRIPTION



## Here's what I fixed or added:
Permit the use of <div> in rich text blocks
## Here's why I did it:
Some people want to section out their content with div blocks.

Since the only way they can do this is via the html editor, lets assume that people who get
this far have some idea what they're doing, and lets let them add blocks that they can mark up
how they wish.

Closes #2317
## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
