### PR TITLE
Update Purifier.php

### DIFF
--- a/Idno/Core/Purifier.php
+++ b/Idno/Core/Purifier.php
@@ -15,6 +15,7 @@ namespace Idno\Core {
             }
 
             $allowedIframes = [
+                'www.youtube-nocookie.com/embed/',
                 'www.youtube.com/embed/',
                 'player.vimeo.com/video/',
                 'embed.radiopublic.com/e',


### PR DESCRIPTION
Adds `'www.youtube-nocookie.com/embed/'` to `allowedIframes`.


## Here's what I fixed or added:
Added 'www.youtube-nocookie.com/embed/' so I can embed Youtube iframe with the enhanced privacy promise.

## Here's why I did it:
I'd like to avoid setting unnecessary cookies on my site.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
