### PR TITLE
Closes #2240: Return api-token on user login 

### DIFF
--- a/Idno/Pages/Session/Login.php
+++ b/Idno/Pages/Session/Login.php
@@ -33,7 +33,7 @@ namespace Idno\Pages\Session {
             ];
             
             // If user is logged in and we got this far, this is an api login so lets return a user api token (#2240)
-            if (\Idno\Core\Idno::site()->session()->isLoggedOn() && \Idno\Core\Idno::site()->template()->getTemplateType() != 'default') {
+            if (\Idno\Core\Idno::site()->session()->isLoggedOn() && \Idno\Core\Idno::site()->template()->getTemplateType() != 'default' && $this->isSSL()) {
                 $user = \Idno\Core\Idno::site()->session()->currentUser();
                 $vars['api-token'] = $user->getAPIkey();
             }


### PR DESCRIPTION
## Here's what I fixed or added:
This patch modifies the session/login endpoint slightly so that it will, when hit by a non-default tempate (e.g. API), will generate and return the logged in user's API token.
## Here's why I did it:
API onboarding is hard, and asking individual users to generate OAuth2 applications or enter a long api token string is not feasible. 

I believe the solution is to generate and retrieve the api-token on session/login, after the login process has been completed successfully. I believe this is not a security hole as the user will have passed security checks at this point, and this is no different to hitting the api token endpoint.

Well, that's not actually quite true (see #831), tokens are stored clear in the database and so if that is compromised is will cause problems. Scope for this is limited with this patch as token is only generated for people who hit the login page as an API user. Long term or in a hosted environment, these tokens should be stored in a secure key store.
## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
