### PR TITLE
Update purifiier.php to allow more default iframes

### DIFF
--- a/Idno/Core/Purifier.php
+++ b/Idno/Core/Purifier.php
@@ -20,7 +20,9 @@ namespace Idno\Core {
                 'player.vimeo.com/video/',
                 'embed.radiopublic.com/e',
                 'w.soundcloud.com/player/',
-                'maps.google.com/'
+                'maps.google.com/',
+                'archive.org/embed',
+                'cdn.knightlab.com'
             ];
 
             if (!empty(Idno::site()->config()->allowedIframes) && is_array(Idno::site()->config()->allowedIframes)) {


### PR DESCRIPTION
adding archive.org and the Knight Lab CDN to default iFrames allowes


## Here's what I fixed or added:
I added archive.org/embed
I added cdn.knightlab.com

## Here's why I did it:
these are very common places for media and we should encourage greater archive.org over YouTube for openly licensed material. 

## Checklist:

- [ x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
