### PR TITLE
Adding a notification email preheader

### DIFF
--- a/Idno/Core/Email.php
+++ b/Idno/Core/Email.php
@@ -87,27 +87,28 @@ namespace Idno\Core {
          * @param array $vars
          * @return mixed
          */
-        function setHTMLBodyFromTemplate($template_name, $vars = array())
+        function setHTMLBodyFromTemplate($template_name, $vars = array(), array $shellVars = [])
         {
             $t = clone \Idno\Core\Idno::site()->template();
             $t->setTemplateType('email');
             $body = $t->__($vars)->draw($template_name);
 
-            return $this->setHTMLBody($body);
+            return $this->setHTMLBody($body, true, $shellVars);
         }
 
         /**
          * Sets the HTML body of the message (optionally setting it inside the email pageshell as defined by the email template)
          * @param $body The formatted HTML body text of the message
          * @param bool $shell Should the message be placed inside the pageshell? Default: true
+         * @param array $shellVars Variables to pass to the page shell template
          * @return mixed
          */
-        function setHTMLBody($body, $shell = true)
+        function setHTMLBody($body, $shell = true, array $shellVars = [])
         {
             if ($shell) {
                 $t = clone \Idno\Core\Idno::site()->template();
                 $t->setTemplateType('email');
-                $message = $t->__(array('body' => $body))->draw('shell');
+                $message = $t->__(array_merge(array('body' => $body), $shellVars))->draw('shell');
             } else {
                 $message = $body;
             }

--- a/Idno/Entities/Notification.php
+++ b/Idno/Entities/Notification.php
@@ -94,6 +94,11 @@ namespace Idno\Entities {
         {
             $this->verb = $verb;
         }
+        
+        function getVerb() 
+        {
+            return $this->verb;
+        }
 
         /**
          * Optionally, an array describing the object of the

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -98,10 +98,17 @@ namespace Idno\Entities {
                                     'user'         => $user,
                                     'notification' => $notification,
                                 ];
+                                
+                                $t = clone \Idno\Core\Idno::site()->template();
+                                $t->setTemplateType('email');
+                                $shellvars = [];
+                                if ($preheader = $t->__($vars)->draw('content/notification/preheader/'.$notification->getVerb())) {
+                                    $shellvars['preheader'] = $preheader;
+                                }
 
                                 $email = new Email();
                                 $email->setSubject($notification->getMessage());
-                                $email->setHTMLBodyFromTemplate($notification->getMessageTemplate(), $vars);
+                                $email->setHTMLBodyFromTemplate($notification->getMessageTemplate(), $vars, $shellvars);
                                 $email->setTextBodyFromTemplate($notification->getMessageTemplate(), $vars);
                                 $email->addTo($user->email);
                                 $email->send();

--- a/templates/email/content/notification/preheader/like.tpl.php
+++ b/templates/email/content/notification/preheader/like.tpl.php
@@ -1,0 +1,9 @@
+<?php
+$notification = $vars['notification'];
+$annotation   = $notification->getObject();
+$post         = $notification->getTarget();
+?>
+<?php echo $annotation['owner_name']?>liked <?php echo $post->getNotificationTitle()?>.
+<?php
+
+    unset($this->vars['notification']);

--- a/templates/email/content/notification/preheader/mention.tpl.php
+++ b/templates/email/content/notification/preheader/mention.tpl.php
@@ -1,0 +1,8 @@
+<?php
+$notification = $vars['notification'];
+$annotation   = $notification->getObject();
+$target       = $notification->getTarget();
+?><?php echo $annotation['owner_name']?> mentioned you on <?php echo $annotation['permalink'];?>.
+
+<?php
+    unset($this->vars['notification']);

--- a/templates/email/content/notification/preheader/reply.tpl.php
+++ b/templates/email/content/notification/preheader/reply.tpl.php
@@ -4,6 +4,6 @@ $annotation   = $notification->getObject();
 $post         = $notification->getTarget();
 ?>
 <?php echo $annotation['owner_name']?> replied to <?php echo $post->getNotificationTitle()?>.
-?>
+
 <?php
     unset($this->vars['notification']);

--- a/templates/email/content/notification/preheader/reply.tpl.php
+++ b/templates/email/content/notification/preheader/reply.tpl.php
@@ -1,0 +1,9 @@
+<?php
+$notification = $vars['notification'];
+$annotation   = $notification->getObject();
+$post         = $notification->getTarget();
+?>
+<?php echo $annotation['owner_name']?> replied to <?php echo $post->getNotificationTitle()?>.
+?>
+<?php
+    unset($this->vars['notification']);

--- a/templates/email/content/notification/preheader/rsvp.tpl.php
+++ b/templates/email/content/notification/preheader/rsvp.tpl.php
@@ -4,6 +4,6 @@ $annotation   = $notification->getObject();
 $post         = $notification->getTarget();
 ?>
 <?php echo $annotation['owner_name']?> RSVPed <?php echo $annotation['object']->getNotificationTitle()?>.
-?>
+
 <?php
     unset($this->vars['notification']);

--- a/templates/email/content/notification/preheader/rsvp.tpl.php
+++ b/templates/email/content/notification/preheader/rsvp.tpl.php
@@ -1,0 +1,9 @@
+<?php
+$notification = $vars['notification'];
+$annotation   = $notification->getObject();
+$post         = $notification->getTarget();
+?>
+<?php echo $annotation['owner_name']?> RSVPed <?php echo $annotation['object']->getNotificationTitle()?>.
+?>
+<?php
+    unset($this->vars['notification']);

--- a/templates/email/content/notification/preheader/share.tpl.php
+++ b/templates/email/content/notification/preheader/share.tpl.php
@@ -1,0 +1,9 @@
+<?php
+$notification = $vars['notification'];
+$annotation   = $notification->getObject();
+$post         = $notification->getTarget();
+?>
+<?php echo $annotation['owner_name']?> shared <?php echo $post->getNotificationTitle()?>.
+
+<?php
+    unset($this->vars['notification']);


### PR DESCRIPTION
## Here's what I fixed or added:

To the html notification template, adding a preheader.

## Here's why I did it:

This allows some email clients (especially mobile) to display the most relevant information first.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
