### PR TITLE
Make site level permissions extensible

### DIFF
--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -520,6 +520,8 @@ namespace Idno\Core {
                         }
                     }
                     
+                    return false;
+                    
                 })());
             }
 

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -472,10 +472,19 @@ namespace Idno\Core {
             }
 
             if ($user = \Idno\Entities\User::getByUUID($user_id)) {
-
-                if ($user->isAdmin()) {
-                    return true;
-                }
+                
+                return \Idno\Core\Idno::site()->events()->triggerEvent('canEdit/site', [
+                    'object' => $this, 
+                    'user_id' => $user_id,
+                    'user' => $user
+                ], (function () use ($user) {
+                    
+                    if ($user->isAdmin()) {
+                        return true;
+                    }
+                    
+                    return false;
+                })());
 
             }
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "idno/known",
     "description": "A social publishing platform.",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "type": "project",
     "homepage": "https://withknown.com/",
     "repositories": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "Known",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "devDependencies": {
         "grunt": "^1.0.4",
         "grunt-cli": "^1.3.2",

--- a/version.known
+++ b/version.known
@@ -1,2 +1,2 @@
-version = '1.0.7'
-build = 2019112701
+version = '1.0.8'
+build = 2019112801


### PR DESCRIPTION
## Here's what I fixed or added:
Making canEdit and canWrite on site extensible
## Here's why I did it:
To make things more flexible further down the road and allow plugin control of create / access
## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
