### PR TITLE
Make Search placeholder localisable

### DIFF
--- a/languages/source/known.pot
+++ b/languages/source/known.pot
@@ -1471,6 +1471,10 @@ msgstr ""
 msgid "Register"
 msgstr ""
 
+#: ./templates/default/shell/toolbar/search.tpl.php:17
+msgid "Search"
+msgstr ""
+
 #: ./templates/default/shell/toolbar/main.tpl.php:1
 msgid "Skip to main content"
 msgstr ""

--- a/templates/default/shell/toolbar/search.tpl.php
+++ b/templates/default/shell/toolbar/search.tpl.php
@@ -14,7 +14,7 @@ if (!empty($vars['content'])) {
 ?>
 <form class="navbar-form navbar-left" action="<?php echo $action?>" method="get" role="search">
     <div class="form-group">
-        <input type="search" class="search-query form-control" name="q" placeholder="Search" tabindex="2" value="<?php
+        <input type="search" class="search-query form-control" name="q" placeholder="<?php echo \Idno\Core\Idno::site()->language()->_('Search'); ?>" tabindex="2" value="<?php
 
         if (!empty($currentPage)) {
             if ($q = $currentPage->getInput('q')) {


### PR DESCRIPTION
## Here's what I fixed or added:
Made the placeholder attribute use language()->_('Search')

## Here's why I did it:
Missing from localisation strings

## Checklist:

- [ / ] This pull request addresses a single issue
