### PR TITLE
Closes #2485: Splitting search into its own table

### DIFF
--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -742,9 +742,6 @@ namespace Idno\Data {
                 $statement = $client->prepare("delete from {$collection} where _id = :id");
                 if ($statement->execute(array(':id' => $id))) {
                     
-                    $statement = $client->prepare("delete from {$collection}_search where _id = :id");
-                    $statement->execute(array(':id' => $id));
-                    
                     if ($statement = $client->prepare("delete from metadata where _id = :id")) {
                         return $statement->execute(array(':id' => $id));
                     }

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -741,6 +741,10 @@ namespace Idno\Data {
                 /* @var \PDO $client */
                 $statement = $client->prepare("delete from {$collection} where _id = :id");
                 if ($statement->execute(array(':id' => $id))) {
+                    
+                    $statement = $client->prepare("delete from {$collection}_search where _id = :id");
+                    $statement->execute(array(':id' => $id));
+                    
                     if ($statement = $client->prepare("delete from metadata where _id = :id")) {
                         return $statement->execute(array(':id' => $id));
                     }
@@ -772,6 +776,10 @@ namespace Idno\Data {
                 /* @var \PDO $client */
                 $statement = $client->prepare("delete from {$collection}");
                 if ($statement->execute()) {
+                    
+                    $statement = $client->prepare("delete from {$collection}_search");
+                    $statement->execute();
+                    
                     if ($statement = $client->prepare("delete from metadata where collection = :collection")) {
                         return $statement->execute([':collection' => $collection]);
                     }

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -593,10 +593,10 @@ namespace Idno\Data {
                                     } else {
                                         $boolean = '';
                                     }
-                                    $subwhere[]                                  = "match (`search`) against (:nonmdvalue{$non_md_variables} {$boolean})";
+                                    $subwhere[]                                  = "match (srch.`search`) against (:nonmdvalue{$non_md_variables} {$boolean})";
                                     $variables[":nonmdvalue{$non_md_variables}"] = $val;
                                 } else {
-                                    $subwhere[]                                  = "`search` like :nonmdvalue{$non_md_variables}";
+                                    $subwhere[]                                  = "srch.`search` like :nonmdvalue{$non_md_variables}";
                                     $variables[":nonmdvalue{$non_md_variables}"] = '%' . $val . '%';
                                 }
                                 $non_md_variables++;

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -658,9 +658,6 @@ namespace Idno\Data {
                 $statement = $client->prepare("delete from {$collection}");
                 if ($statement->execute()) {
                     
-                    $statement = $client->prepare("delete from {$collection}_search");
-                    $statement->execute();
-                    
                     if ($statement = $client->prepare("delete from metadata where collection = :collection")) {
                         return $statement->execute([':collection' => $collection]);
                     }

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -537,7 +537,7 @@ namespace Idno\Data {
                             //                                    $subwhere[]                                  = "match (search) against (:nonmdvalue{$non_md_variables})";
                             //                                    $variables[":nonmdvalue{$non_md_variables}"] = $val;
                             //                                } else {
-                            $subwhere[]                                  = "search like :nonmdvalue{$non_md_variables}";
+                            $subwhere[]                                  = "srch.search like :nonmdvalue{$non_md_variables}";
                             $variables[":nonmdvalue{$non_md_variables}"] = '%' . $val . '%';
                             //                                }
                             $non_md_variables++;

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -65,7 +65,7 @@ namespace Idno\Data {
                     if ($version->label === 'schema') {
                         $basedate          = $newdate = (int)$version->value;
                         $upgrade_sql_files = array();
-                        $schema_dir        = dirname(dirname(dirname(__FILE__))) . '/warmup/schemas/mysql/';
+                        $schema_dir        = dirname(dirname(dirname(__FILE__))) . '/warmup/schemas/postgres/';
                         $client            = $this->client;
 
                         foreach ([
@@ -654,6 +654,10 @@ namespace Idno\Data {
                 /* @var \PDO $client */
                 $statement = $client->prepare("delete from {$collection}");
                 if ($statement->execute()) {
+                    
+                    $statement = $client->prepare("delete from {$collection}_search");
+                    $statement->execute();
+                    
                     if ($statement = $client->prepare("delete from metadata where collection = :collection")) {
                         return $statement->execute([':collection' => $collection]);
                     }

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -74,6 +74,7 @@ namespace Idno\Data {
                             2016110301,
                             2017032001,
                             2019060501,
+                            2019121401,
                         ] as $date) {
                             if ($basedate < $date) {
                                 if ($sql = @file_get_contents($schema_dir . $date . '.sql')) {
@@ -180,15 +181,29 @@ namespace Idno\Data {
                 // Postgres 9.5 will have "on conflict do update"
                 $upsert = "update {$collection}
                                set uuid=:uuid, entity_subtype=:subtype, owner=:owner,
-                               contents=:contents, search=:search, publish_status=:status where _id=:id";
+                               contents=:contents, publish_status=:status where _id=:id";
                 $insert = "insert into {$collection}
-                               (uuid, _id, owner, entity_subtype, contents, search, publish_status)
-                               select :uuid, :id, :owner, :subtype, :contents, :search, :status";
+                               (uuid, _id, owner, entity_subtype, contents, publish_status)
+                               select :uuid, :id, :owner, :subtype, :contents, :status";
 
                 $statement = $client->prepare("with upsert as (${upsert} returning *)
                                                    ${insert} where not exists (select * from upsert)");
 
-                if ($statement->execute(array(':uuid' => $array['uuid'], ':id' => $array['_id'], ':owner' => $array['owner'], ':subtype' => $array['entity_subtype'], ':contents' => $contents, ':search' => $search, ':status' => $array['publish_status']))) {
+                if ($statement->execute(array(':uuid' => $array['uuid'], ':id' => $array['_id'], ':owner' => $array['owner'], ':subtype' => $array['entity_subtype'], ':contents' => $contents, ':status' => $array['publish_status']))) {
+                    
+                    // Update FTS
+                    $upsert = "update {$collection}_search
+                               set search=:search 
+                               where _id=:id";
+                    $insert = "insert into {$collection}_search
+                                   (_id, search)
+                                   select :id, :search";
+
+                    $statement = $client->prepare("with upsert as (${upsert} returning *)
+                                                   ${insert} where not exists (select * from upsert)");
+                    
+                                                   
+                                                   
                     if ($statement = $client->prepare("delete from metadata where _id = :id")) {
                         $statement->execute(array(':id' => $array['_id']));
                     }
@@ -326,6 +341,9 @@ namespace Idno\Data {
                 $where            = $this->build_where_from_array($parameters, $variables, $metadata_joins, $non_md_variables, 'and', $collection);
                 for ($i = 1; $i <= $metadata_joins; $i++) {
                     $query .= " left join metadata md{$i} on md{$i}.entity = {$collection}.uuid ";
+                }
+                if (isset($parameters['$search'])) {
+                    $query .= " left join {$collection}_search srch on srch._id = {$collection}._id ";
                 }
                 if (!empty($where)) {
                     $query .= ' where ' . $where . ' ';
@@ -564,6 +582,9 @@ namespace Idno\Data {
                 $where            = $this->build_where_from_array($parameters, $variables, $metadata_joins, $non_md_variables, 'and', $collection);
                 for ($i = 0; $i <= $metadata_joins; $i++) {
                     $query .= " left join metadata md{$i} on md{$i}.entity = {$collection}.uuid ";
+                }
+                if (isset($parameters['$search'])) {
+                    $query .= " left join {$collection}_search srch on srch._id = {$collection}._id ";
                 }
                 if (!empty($where)) {
                     $query .= ' where ' . $where . ' ';

--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -201,6 +201,9 @@ namespace Idno\Data {
 
                     $statement = $client->prepare("with upsert as (${upsert} returning *)
                                                    ${insert} where not exists (select * from upsert)");
+                                                  
+                    $statement->execute(array(':id' => $array['_id'], ':search' => $search));
+
                     
                                                    
                                                    

--- a/warmup/schemas/mysql/2019121401.sql
+++ b/warmup/schemas/mysql/2019121401.sql
@@ -11,6 +11,8 @@ INSERT INTO `entities_search` SELECT `_id`, `search` FROM `entities`;
 ALTER TABLE `entities` DROP COLUMN `search`;
 ALTER TABLE `entities` ENGINE=InnoDB;
 
+ALTER TABLE `entities_search` ADD CONSTRAINT `es_id_id` FOREIGN KEY (`_id`) REFERENCES `entities` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
 
 
 
@@ -25,6 +27,8 @@ INSERT INTO `reader_search` SELECT `_id`, `search` FROM `reader`;
 
 ALTER TABLE `reader` DROP COLUMN `search`;
 ALTER TABLE `reader` ENGINE=InnoDB;
+
+ALTER TABLE `reader_search` ADD CONSTRAINT `rs_id_id` FOREIGN KEY (`_id`) REFERENCES `reader` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 
 
@@ -41,6 +45,7 @@ INSERT INTO `config_search` SELECT `_id`, `search` FROM `config`;
 ALTER TABLE `config` DROP COLUMN `search`;
 ALTER TABLE `config` ENGINE=InnoDB;
 
+ALTER TABLE `config_search` ADD CONSTRAINT `cs_id_id` FOREIGN KEY (`_id`) REFERENCES `config` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 
 

--- a/warmup/schemas/mysql/2019121401.sql
+++ b/warmup/schemas/mysql/2019121401.sql
@@ -1,0 +1,47 @@
+
+CREATE TABLE IF NOT EXISTS `entities_search` (
+  `_id` varchar(32) NOT NULL,
+  `search` longtext NOT NULL,
+  PRIMARY KEY (`_id`),
+  FULLTEXT KEY `search` (`search`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `entities_search` SELECT `_id`, `search` FROM `entities`;
+
+ALTER TABLE `entities` DROP COLUMN `search`;
+ALTER TABLE `entities` ENGINE=InnoDB;
+
+
+
+
+CREATE TABLE IF NOT EXISTS `reader_search` (
+  `_id` varchar(32) NOT NULL,
+  `search` longtext NOT NULL,
+  PRIMARY KEY (`_id`),
+  FULLTEXT KEY `search` (`search`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `reader_search` SELECT `_id`, `search` FROM `reader`;
+
+ALTER TABLE `reader` DROP COLUMN `search`;
+ALTER TABLE `reader` ENGINE=InnoDB;
+
+
+
+
+CREATE TABLE IF NOT EXISTS `config_search` (
+  `_id` varchar(32) NOT NULL,
+  `search` longtext NOT NULL,
+  PRIMARY KEY (`_id`),
+  FULLTEXT KEY `search` (`search`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `config_search` SELECT `_id`, `search` FROM `config`;
+
+ALTER TABLE `config` DROP COLUMN `search`;
+ALTER TABLE `config` ENGINE=InnoDB;
+
+
+
+
+REPLACE INTO `versions` VALUES('schema', '2019121401');

--- a/warmup/schemas/mysql/mysql.sql
+++ b/warmup/schemas/mysql/mysql.sql
@@ -25,7 +25,8 @@ CREATE TABLE IF NOT EXISTS `config_search` (
   `_id` varchar(32) NOT NULL,
   `search` longtext NOT NULL,
   PRIMARY KEY (`_id`),
-  FULLTEXT KEY `search` (`search`)
+  FULLTEXT KEY `search` (`search`),
+  CONSTRAINT `cs_id_id` FOREIGN KEY (`_id`) REFERENCES `config` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------
@@ -54,7 +55,8 @@ CREATE TABLE IF NOT EXISTS `entities_search` (
   `_id` varchar(32) NOT NULL,
   `search` longtext NOT NULL,
   PRIMARY KEY (`_id`),
-  FULLTEXT KEY `search` (`search`)
+  FULLTEXT KEY `search` (`search`),
+  CONSTRAINT `es_id_id` FOREIGN KEY (`_id`) REFERENCES `entities` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------
@@ -82,7 +84,8 @@ CREATE TABLE IF NOT EXISTS `reader_search` (
   `_id` varchar(32) NOT NULL,
   `search` longtext NOT NULL,
   PRIMARY KEY (`_id`),
-  FULLTEXT KEY `search` (`search`)
+  FULLTEXT KEY `search` (`search`),
+  CONSTRAINT `rs_id_id` FOREIGN KEY (`_id`) REFERENCES `reader` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------

--- a/warmup/schemas/mysql/mysql.sql
+++ b/warmup/schemas/mysql/mysql.sql
@@ -13,13 +13,19 @@ CREATE TABLE IF NOT EXISTS `config` (
   `entity_subtype` varchar(64) NOT NULL,
   `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `contents` longblob NOT NULL,
-  `search` longtext NOT NULL,
   `publish_status` varchar(255) NOT NULL DEFAULT 'published',
   PRIMARY KEY (`uuid`),
   KEY `owner` (`owner`,`created`),
   KEY `_id` (`_id`),
   KEY `entity_subtype` (`entity_subtype`),
   KEY `publish_status` (`publish_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS `config_search` (
+  `_id` varchar(32) NOT NULL,
+  `search` longtext NOT NULL,
+  PRIMARY KEY (`_id`),
+  FULLTEXT KEY `search` (`search`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------
@@ -35,15 +41,21 @@ CREATE TABLE IF NOT EXISTS `entities` (
   `entity_subtype` varchar(64) NOT NULL,
   `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `contents` longblob NOT NULL,
-  `search` longtext NOT NULL,
   `publish_status` varchar(255) NOT NULL DEFAULT 'published',
   PRIMARY KEY (`uuid`),
   UNIQUE KEY `_id` (`_id`),
   KEY `owner` (`owner`,`created`),
   KEY `entity_subtype` (`entity_subtype`),
-  KEY `publish_status` (`publish_status`),
+  KEY `publish_status` (`publish_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+CREATE TABLE IF NOT EXISTS `entities_search` (
+  `_id` varchar(32) NOT NULL,
+  `search` longtext NOT NULL,
+  PRIMARY KEY (`_id`),
   FULLTEXT KEY `search` (`search`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------
 
@@ -58,15 +70,20 @@ CREATE TABLE IF NOT EXISTS `reader` (
   `entity_subtype` varchar(64) NOT NULL,
   `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `contents` longblob NOT NULL,
-  `search` longtext NOT NULL,
   `publish_status` varchar(255) NOT NULL DEFAULT 'published',
   PRIMARY KEY (`uuid`),
   UNIQUE KEY `_id` (`_id`),
   KEY `owner` (`owner`,`created`),
   KEY `entity_subtype` (`entity_subtype`),
-  KEY `publish_status` (`publish_status`),
+  KEY `publish_status` (`publish_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS `reader_search` (
+  `_id` varchar(32) NOT NULL,
+  `search` longtext NOT NULL,
+  PRIMARY KEY (`_id`),
   FULLTEXT KEY `search` (`search`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------
 

--- a/warmup/schemas/postgres/2019121401.sql
+++ b/warmup/schemas/postgres/2019121401.sql
@@ -9,6 +9,9 @@ INSERT INTO entities_search SELECT _id, search FROM entities;
 
 ALTER TABLE entities DROP COLUMN search;
 
+ALTER TABLE entities_search ADD CONSTRAINT es_id_id FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE;
+
+
 
 CREATE TABLE IF NOT EXISTS reader_search (
   _id varchar(32) NOT NULL,
@@ -21,6 +24,9 @@ INSERT INTO reader_search SELECT _id, search FROM reader;
 
 ALTER TABLE reader DROP COLUMN search;
 
+ALTER TABLE reader_search ADD CONSTRAINT es_id_id FOREIGN KEY (_id) REFERENCES reader (_id) ON DELETE CASCADE ON UPDATE CASCADE;
+
+
 
 CREATE TABLE IF NOT EXISTS config_search (
   _id varchar(32) NOT NULL,
@@ -31,6 +37,12 @@ CREATE TABLE IF NOT EXISTS config_search (
 INSERT INTO config_search SELECT _id, search FROM config;
 
 ALTER TABLE config DROP COLUMN search;
+
+ALTER TABLE config_search ADD CONSTRAINT es_id_id FOREIGN KEY (_id) REFERENCES config (_id) ON DELETE CASCADE ON UPDATE CASCADE;
+
+
+
+
 
 
 DELETE FROM versions WHERE label = 'schema';

--- a/warmup/schemas/postgres/2019121401.sql
+++ b/warmup/schemas/postgres/2019121401.sql
@@ -1,0 +1,37 @@
+
+CREATE TABLE IF NOT EXISTS entities_search (
+  _id varchar(32) NOT NULL,
+  search text NOT NULL,
+  PRIMARY KEY (_id)
+);
+
+INSERT INTO entities_search SELECT _id, search FROM entities;
+
+ALTER TABLE entities DROP COLUMN search;
+
+
+CREATE TABLE IF NOT EXISTS reader_search (
+  _id varchar(32) NOT NULL,
+  search text NOT NULL,
+  PRIMARY KEY (_id)
+);
+
+
+INSERT INTO reader_search SELECT _id, search FROM reader;
+
+ALTER TABLE reader DROP COLUMN search;
+
+
+CREATE TABLE IF NOT EXISTS config_search (
+  _id varchar(32) NOT NULL,
+  search text NOT NULL,
+  PRIMARY KEY (_id)
+);
+
+INSERT INTO config_search SELECT _id, search FROM config;
+
+ALTER TABLE config DROP COLUMN search;
+
+
+DELETE FROM versions WHERE label = 'schema';
+INSERT INTO versions VALUES('schema', '2019121401');

--- a/warmup/schemas/postgres/postgres.sql
+++ b/warmup/schemas/postgres/postgres.sql
@@ -13,7 +13,6 @@ CREATE TABLE IF NOT EXISTS config (
   entity_subtype varchar(64) NOT NULL,
   created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   contents text NOT NULL,
-  search text NOT NULL,
   publish_status varchar(255) NOT NULL DEFAULT 'published',
   PRIMARY KEY (uuid)
 );
@@ -21,6 +20,12 @@ CREATE INDEX c__id ON config (_id);
 CREATE INDEX c_owner ON config (owner);
 CREATE INDEX c_entity_subtype ON config (entity_subtype);
 CREATE INDEX c_publish_status ON config (publish_status);
+
+CREATE TABLE IF NOT EXISTS config_search (
+  _id varchar(32) NOT NULL,
+  search text NOT NULL,
+  PRIMARY KEY (_id)
+);
 
 -- --------------------------------------------------------
 
@@ -44,7 +49,13 @@ CREATE INDEX e_owner ON entities (owner, created);
 CREATE INDEX e_entity_subtype ON entities (entity_subtype);
 CREATE INDEX e_publish_status ON entities (publish_status);
 
--- FULL TEXT ?
+
+CREATE TABLE IF NOT EXISTS entities_search (
+  _id varchar(32) NOT NULL,
+  search text NOT NULL,
+  PRIMARY KEY (_id)
+);
+
 
 
 
@@ -61,7 +72,6 @@ CREATE TABLE IF NOT EXISTS reader (
   entity_subtype varchar(64) NOT NULL,
   created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   contents text NOT NULL,
-  search text NOT NULL,
   publish_status varchar(255) NOT NULL DEFAULT 'published',
   PRIMARY KEY (uuid)
 );
@@ -69,6 +79,14 @@ CREATE TABLE IF NOT EXISTS reader (
 CREATE INDEX r_owner ON reader (owner, created);
 CREATE INDEX r_entity_subtype ON reader (entity_subtype);
 CREATE INDEX r_publish_status ON reader (publish_status);
+
+
+CREATE TABLE IF NOT EXISTS reader_search (
+  _id varchar(32) NOT NULL,
+  search text NOT NULL,
+  PRIMARY KEY (_id)
+);
+
 
 -- --------------------------------------------------------
 

--- a/warmup/schemas/postgres/postgres.sql
+++ b/warmup/schemas/postgres/postgres.sql
@@ -24,7 +24,8 @@ CREATE INDEX c_publish_status ON config (publish_status);
 CREATE TABLE IF NOT EXISTS config_search (
   _id varchar(32) NOT NULL,
   search text NOT NULL,
-  PRIMARY KEY (_id)
+  PRIMARY KEY (_id),
+  FOREIGN KEY (_id) REFERENCES config (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- --------------------------------------------------------
@@ -53,7 +54,8 @@ CREATE INDEX e_publish_status ON entities (publish_status);
 CREATE TABLE IF NOT EXISTS entities_search (
   _id varchar(32) NOT NULL,
   search text NOT NULL,
-  PRIMARY KEY (_id)
+  PRIMARY KEY (_id),
+  FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 
@@ -84,7 +86,8 @@ CREATE INDEX r_publish_status ON reader (publish_status);
 CREATE TABLE IF NOT EXISTS reader_search (
   _id varchar(32) NOT NULL,
   search text NOT NULL,
-  PRIMARY KEY (_id)
+  PRIMARY KEY (_id),
+  FOREIGN KEY (_id) REFERENCES reader (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 


### PR DESCRIPTION
## Here's what I fixed or added:

Split search column into its own table

## Here's why I did it:

Slowly improving data model by splitting the full text search column into its own table. Later to be dispensed with for some proper search tool like elastic search

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
