### PR TITLE
Localise timeago substitutions

### DIFF
--- a/templates/default/shell/footerjavascript.tpl.php
+++ b/templates/default/shell/footerjavascript.tpl.php
@@ -17,10 +17,23 @@ if (\Idno\Core\Idno::site()->session()->isLoggedIn()) {
 
 }
 
+$lang = \Idno\Core\Idno::site()->language()->getLanguage();
+
+$l10n = substr($lang, 0, 2);
+
+if ($lang == 'pt_BR' || substr($lang, 0, 2) == 'zh') {
+    if ($lang == 'pt_BR') {
+        $lang = strtolower($lang);
+    }
+    $l10n = str_replace('_', '-', $lang);
+}
+
 ?>
 
 <script
     src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/rmm5t/jquery-timeago/jquery.timeago.js"></script>
+<script
+    src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/rmm5t/jquery-timeago/locales/jquery.timeago.<?php echo $l10n; ?>.js"></script>
 <script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() ?>vendor/npm-asset/underscore/underscore-min.js"
         type="text/javascript"></script>
 <!--<script src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL() . 'vendor/idno/mentionjs/bootstrap-typeahead.js' ?>"


### PR DESCRIPTION
## Here's what I fixed or added:

Added in timeago locales file based on language->getLanguage()

 il y a environ 2 jours

## Here's why I did it:

Localisations are available and we aren't benefitting.

## Checklist:

- [/] This pull request addresses a single issue
- [?] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [/] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [/] I've tested my code in-browser
