### PR TITLE
Fix detectBrowserLanguage() and constructor

### DIFF
--- a/Idno/Core/Language.php
+++ b/Idno/Core/Language.php
@@ -44,8 +44,8 @@ namespace Idno\Core {
             // Set locale, now we have one.
             putenv("LANG=" . $language);
             putenv("LANGUAGE=" . $language);
-            putenv("LC_ALL=" . $language);
-            setlocale(LC_ALL, $language);
+            putenv("LC_ALL=" . $language . '.UTF-8');
+            setlocale(LC_ALL, $language . '.UTF-8');
 
             parent::__construct();
         }
@@ -194,13 +194,15 @@ namespace Idno\Core {
         {
 
             $length = 2; // Short form
-            if ($full)
-                $length = 5;
-
+            
             $lang = "";
 
             if (!empty($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+                if ($full)
+                    $length = strpos($_SERVER['HTTP_ACCEPT_LANGUAGE'], ',');
+
                 $lang = preg_replace("/[^a-zA-Z\-_\s]/", "", substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, $length));
+                $lang = str_replace('-', '_', $lang);
             }
 
             // If running as console app, detect via environment


### PR DESCRIPTION
Locales exist that do not fit the 2 or 5 characters assumed by the existing code.

.UTF-8 suffix makes php’s date() output match content encoding of the rest of the page.

Returned value has always been hyphenated, gettext language code expects underscore.

## Here's what I fixed or added:

## Here's why I did it:

## Checklist:

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
