### PR TITLE
Localise bootstrap toggles and rearrange localisation template

### DIFF
--- a/Idno/Pages/Account/Register.php
+++ b/Idno/Pages/Account/Register.php
@@ -140,7 +140,7 @@ namespace Idno\Pages\Account {
                         \Idno\Core\Idno::site()->session()->addErrorMessage(\Idno\Core\Idno::site()->language()->_("Usernames can only have letters, numbers and underscores."));
                     }
                     if (substr_count($handle, '/')) {
-                        \Idno\Core\Idno::site()->session()->addErrorMessage(\Idno\Core\Idno::site()->language()->_("Usernames can't contain a slash ('/') character."));
+                        \Idno\Core\Idno::site()->session()->addErrorMessage(\Idno\Core\Idno::site()->language()->_("Usernames can't contain a slash %s character.", ["('/')"]));
                     }
                     if (!empty($handleuser)) {
                         \Idno\Core\Idno::site()->session()->addErrorMessage(\Idno\Core\Idno::site()->language()->_("Unfortunately, someone is already using that username. Please choose another."));
@@ -161,7 +161,7 @@ namespace Idno\Pages\Account {
                 \Idno\Core\Idno::site()->session()->logUserOn($user);
                 $this->forward();
             } else {
-                \Idno\Core\Idno::site()->session()->addMessageAtStart("We couldn't register you.");
+                \Idno\Core\Idno::site()->session()->addMessageAtStart(\Idno\Core\Idno::site()->language()->_("We couldn't register you."));
                 $this->forward($_SERVER['HTTP_REFERER']);
             }
 

--- a/Idno/Pages/Admin/Users.php
+++ b/Idno/Pages/Admin/Users.php
@@ -165,7 +165,7 @@ namespace Idno\Pages\Admin {
                                 \Idno\Core\Idno::site()->session()->addMessage(\Idno\Core\Idno::site()->language()->_("Your username is too long."));
                             }
                             if (substr_count($handle, '/')) {
-                                \Idno\Core\Idno::site()->session()->addMessage(\Idno\Core\Idno::site()->language()->_("Usernames can't contain a slash ('/') character."));
+                                \Idno\Core\Idno::site()->session()->addMessage(\Idno\Core\Idno::site()->language()->_("Usernames can't contain a slash %s character.", ["('/')"]));
                             }
                             if (!empty($handleuser)) {
                                 \Idno\Core\Idno::site()->session()->addMessage(\Idno\Core\Idno::site()->language()->_("Unfortunately, someone is already using that username. Please choose another."));

--- a/languages/source/known.pot
+++ b/languages/source/known.pot
@@ -2,16 +2,92 @@
 msgid "No domain specified for cache"
 msgstr ""
 
+#: ./Idno/Common/Entity.php:692
+msgid "There was a problem syndicating."
+msgstr ""
+
+#: ./Idno/Common/Page.php:397
+msgid "Invalid token."
+msgstr ""
+
+#: ./Idno/Common/Page.php:414
+msgid "Something went wrong."
+msgstr ""
+
+#: ./Idno/Common/Page.php:479
+msgid "Attempted to redirect page to a non local URL."
+msgstr ""
+
+#: ./Idno/Common/Page.php:569
+msgid "The page you were on timed out."
+msgstr ""
+
+#: ./Idno/Common/Page.php:583
+msgid "Couldn't say anything about execution, probably something went wrong"
+msgstr ""
+
+#: ./Idno/Common/Page.php:741
+msgid "This content isn't here."
+msgstr ""
+
+#: ./Idno/Common/Page.php:757
+msgid "This page can't be found."
+msgstr ""
+
+#: ./Idno/Common/Plugin.php:87
+msgid "Plugin %s doesn't have a version"
+msgstr ""
+
+#: ./Idno/Core/AsynchronousQueue.php:61
+msgid "No event passed"
+msgstr ""
+
+#: ./Idno/Core/AsynchronousQueue.php:64
+msgid "Event passed is not a queued event, and so can't be dispatched"
+msgstr ""
+
+#: ./Idno/Core/AsynchronousQueue.php:67
+msgid "Sorry, this event has already been dispatched (but not yet cleaned up)"
+msgstr ""
+
+#: ./Idno/Core/AsynchronousQueue.php:76
+msgid "Invalid user (%s) given for runAsContext, aborting"
+msgstr ""
+
+#: ./Idno/Core/Email.php:16
+msgid "Something went wrong and we couldn't create the email message to send."
+msgstr ""
+
+#: ./Idno/Core/Service.php:24
+msgid "Missing X-Known-Service-Signature, service call is not possible."
+msgstr ""
+
+#: ./Idno/Core/Service.php:27
+msgid "Sorry, signature doesn't match up."
+msgstr ""
+
+#: ./Idno/Core/Service.php:44
+msgid "Missing site secret"
+msgstr ""
+
+#: ./Idno/Core/Service.php:53
+msgid "Url not provided to token generation."
+msgstr ""
+
+#: ./Idno/Core/Service.php:86
+msgid "Response from service endpoint was not json"
+msgstr ""
+
+#: ./Idno/Core/Service.php:98
+msgid "No result from endpoint."
+msgstr ""
+
 #: ./Idno/Core/Session.php:136
 msgid "Session funnybusiness: "
 msgstr ""
 
 #: ./Idno/Core/Session.php:509
 msgid "Warning: Access credentials were sent over a non-secured connection! To disable this warning set disable_cleartext_warning in your config.ini"
-msgstr ""
-
-#: ./Idno/Core/Email.php:16
-msgid "Something went wrong and we couldn't create the email message to send."
 msgstr ""
 
 #: ./Idno/Core/Time.php:89
@@ -38,544 +114,16 @@ msgstr ""
 msgid "behind"
 msgstr ""
 
-#: ./Idno/Core/Webservice.php:431
-msgid "Your version of PHP doesn't support CURLFile."
-msgstr ""
-
 #: ./Idno/Core/TokenProvider.php:32
 msgid "Token was generated using an a cryptographically weak algorithm, this probably means your version of OpenSSL is broken or very old."
 msgstr ""
 
-#: ./Idno/Core/Service.php:24
-msgid "Missing X-Known-Service-Signature, service call is not possible."
+#: ./Idno/Core/Webservice.php:431
+msgid "Your version of PHP doesn't support CURLFile."
 msgstr ""
 
-#: ./Idno/Core/Service.php:27
-msgid "Sorry, signature doesn\'t match up."
-msgstr ""
-
-#: ./Idno/Core/Service.php:44
-msgid "Missing site secret"
-msgstr ""
-
-#: ./Idno/Core/Service.php:53
-msgid "Url not provided to token generation."
-msgstr ""
-
-#: ./Idno/Core/Service.php:86
-msgid "Response from service endpoint was not json"
-msgstr ""
-
-#: ./Idno/Core/Service.php:98
-msgid "No result from endpoint."
-msgstr ""
-
-#: ./Idno/Core/AsynchronousQueue.php:61
-msgid "No event passed"
-msgstr ""
-
-#: ./Idno/Core/AsynchronousQueue.php:64
-msgid "Event passed is not a queued event, and so can\'t be dispatched"
-msgstr ""
-
-#: ./Idno/Core/AsynchronousQueue.php:67
-msgid "Sorry, this event has already been dispatched (but not yet cleaned up)"
-msgstr ""
-
-#: ./Idno/Core/AsynchronousQueue.php:76
-msgid "Invalid user (%s) given for runAsContext, aborting"
-msgstr ""
-
-#: ./Idno/Stats/Timer.php:39
-msgid "Timer %s has not been started."
-msgstr ""
-
-#: ./Idno/Pages/Search/User.php:23
-msgid "Invalid sort type %s"
-msgstr ""
-
-#: ./Idno/Pages/Search/User.php:27
-msgid "Invalid sort order %s"
-msgstr ""
-
-#: ./Idno/Pages/Onboarding/Begin.php:23
-msgid "Welcome to Known"
-msgstr ""
-
-#: ./Idno/Pages/Onboarding/Profile.php:22
-msgid "Create your profile"
-msgstr ""
-
-#: ./Idno/Pages/Onboarding/Connect.php:25
-msgid "Connect some networks"
-msgstr ""
-
-#: ./Idno/Pages/Following/Home.php:17
-msgid "Following"
-msgstr ""
-
-#: ./Idno/Pages/Following/Add.php:23
-msgid "We couldn't find a feed at that site."
-msgstr ""
-
-#: ./Idno/Pages/Following/Confirm.php:50
-msgid "You're following %s!"
-msgstr ""
-
-#: ./Idno/Pages/Annotation/Delete.php:42
-msgid "The annotation was deleted."
-msgstr ""
-
-#: ./Idno/Pages/Service/Security/CSRFToken.php:16
-msgid "URL missing"
-msgstr ""
-
-#: ./Idno/Pages/Service/Web/ImageProxy.php:77
-msgid "There was a problem decoding the url"
-msgstr ""
-
-#: ./Idno/Pages/Service/Web/ImageProxy.php:81
-msgid "No url specified"
-msgstr ""
-
-#: ./Idno/Pages/Service/Web/ImageProxy.php:222
-msgid "Could not save temporary file"
-msgstr ""
-
-#: ./Idno/Pages/Service/Web/ImageProxy.php:253
-msgid "Looks like something went wrong, image was zero bytes big!"
-msgstr ""
-
-#: ./Idno/Pages/Service/Web/UrlUnfurl.php:20
-msgid "You need to specify a working URL"
-msgstr ""
-
-#: ./Idno/Pages/Service/Web/UrlUnfurl.php:69
-msgid "Url %s could not be unfurled"
-msgstr ""
-
-#: ./Idno/Pages/Entity/View.php:125
-msgid "%s was deleted."
-msgstr ""
-
-#: ./Idno/Pages/Entity/Attachment/Delete.php:21
-msgid "We couldn't find the post."
-msgstr ""
-
-#: ./Idno/Pages/Entity/Delete.php:45
-msgid "We couldn't find the post to delete."
-msgstr ""
-
-#: ./Idno/Pages/Entity/Withdraw.php:48
-msgid "We removed copies on all the syndicated sites."
-msgstr ""
-
-#: ./Idno/Pages/File/Picker.php:57
-msgid "You can only upload images."
-msgstr ""
-
-#: ./Idno/Pages/Session/Login.php:42
-msgid "Sign in"
-msgstr ""
-
-#: ./Idno/Pages/Session/Login.php:67
-msgid "Oops! It looks like your password isn't correct. Please try again."
-msgstr ""
-
-#: ./Idno/Pages/Session/Login.php:72
-msgid "Oops! We couldn't find your username or email address. Please check you typed it correctly and try again."
-msgstr ""
-
-#: ./Idno/Pages/Session/CurrentUser.php:36
-msgid "The %s profile for %s"
-msgstr ""
-
-#: ./Idno/Pages/Session/Logout.php:24
-msgid "You've signed out. See you soon!"
-msgstr ""
-
-#: ./Idno/Pages/Webmentions/Endpoint.php:19
-msgid "Webmention endpoint"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Import.php:18
-msgid "Import data"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Import.php:33
-msgid "You need to upload an import file to continue."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Import.php:35
-msgid "We couldn't open the file you uploaded. Please try again."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Import.php:37
-msgid "Your import has started. We'll email you when it's done."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:32
-msgid "User Management"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:50
-msgid "%s was given administration rights."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:58
-msgid "%s was stripped of their administration rights."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:65
-msgid "%s was removed from your site."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:91
-msgid "%d invitations were sent."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:93
-msgid "Your invitation was sent."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:95
-msgid "Something went wrong and we couldn't send emails to your recipients."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:97
-msgid "No email addresses were found or all the people you invited are already members of this site."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:105
-msgid "The invitation was removed."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:119
-msgid "The invitation was resent."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:128
-msgid "You can't add any more users to your site."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:141
-msgid "Please make sure your passwords match and aren't empty."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:143
-msgid "Please enter a username and email address."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:162
-msgid "Please create a username."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:165
-msgid "Your username is too long."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:168
-msgid "Usernames can't contain a slash ('/"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:171
-msgid "Unfortunately, someone is already using that username. Please choose another."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:174
-msgid "Hey, it looks like there's already an account with that email address. Did you forget your login?"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:178
-msgid "That doesn't seem like it's a valid email address."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:182
-msgid "User %s was created. You may wish to email them to let them know."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:205
-msgid "%d emails were blocked."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:207
-msgid "The email address was blocked."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:209
-msgid "No email addresses were found."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:230
-msgid "%d emails were unblocked."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Users.php:232
-msgid "The email address was unblocked."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Email.php:17
-msgid "Email"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Homepage.php:25
-msgid "Homepage"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Homepage.php:42
-msgid "The default homepage content types were saved."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Export.php:17
-msgid "Export data"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Home.php:21
-msgid "Administration"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Dependencies.php:20
-msgid "Dependencies"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Themes.php:22
-msgid "Themes"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Themes.php:52
-msgid "The theme was enabled."
-msgstr ""
-
-#: ./Idno/Pages/Admin/About.php:20
-msgid "About Known"
-msgstr ""
-
-#: ./Idno/Pages/Admin/EmailTest.php:26
-msgid "Test email sent to %s"
-msgstr ""
-
-#: ./Idno/Pages/Admin/EmailTest.php:28
-msgid "There was a problem sending a test message to %s."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Logs.php:19
-msgid "Log capture"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Statistics.php:16
-msgid "Something went wrong, either no statistics were returned or it wasn't in the correct format."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Statistics.php:27
-msgid "Statistics"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Plugins.php:23
-msgid "Plugins"
-msgstr ""
-
-#: ./Idno/Pages/Admin/Plugins.php:44
-msgid "The plugin was enabled."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Plugins.php:58
-msgid "The plugin was disabled."
-msgstr ""
-
-#: ./Idno/Pages/Admin/Diagnostics.php:56
-msgid "Diagnostics"
-msgstr ""
-
-#: ./Idno/Pages/User/Edit.php:30
-msgid "Edit profile: %s"
-msgstr ""
-
-#: ./Idno/Pages/Account/Password.php:26
-msgid "Password recovery email sent"
-msgstr ""
-
-#: ./Idno/Pages/Account/Password.php:29
-msgid "Recover password"
-msgstr ""
-
-#: ./Idno/Pages/Account/Password.php:63
-msgid "Oh no! We couldn't find an account associated with that email address."
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:37
-msgid "Sorry, could not find any users on that page, perhaps they need to mark up their profile in <a href=\\"http://microformats.org/wiki/microformats-2\\">Microformats</a>?"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:51
-msgid "Page did not contain any <a href=\\"http://microformats.org/wiki/microformats-2\\">Microformats</a> markup... doing my best with what I have!"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:60
-msgid "Found users"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:64
-msgid "Sorry, there was a problem parsing the page!"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:66
-msgid "Sorry, %s could not be retrieved!"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:149
-msgid "There was a problem saving the new remote user."
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:170
-msgid "You are now following %s, would you like to subscribe to their feed?"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:175
-msgid "You are now following %s"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:180
-msgid "You\'re already following %s"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:183
-msgid "Sorry, that user doesn\'t exist!"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:185
-msgid "No UUID, please try that again!"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Feedback.php:19
-msgid "Send feedback"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Feedback.php:42
-msgid "Thanks! We received your feedback."
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Tools.php:26
-msgid "Tools and Apps"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Notifications.php:20
-msgid "Notification settings"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Notifications.php:39
-msgid "Your notification preferences were saved."
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/Following.php:20
-msgid "Following settings"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings/FeedbackConfirm.php:17
-msgid "Thank you for your feedback!"
-msgstr ""
-
-#: ./Idno/Pages/Account/Export.php:20
-msgid "Export Data"
-msgstr ""
-
-#: ./Idno/Pages/Account/Register.php:27
-msgid "This site is closed to new users."
-msgstr ""
-
-#: ./Idno/Pages/Account/Register.php:31
-msgid "Your invitation doesn't seem to be valid, or has expired."
-msgstr ""
-
-#: ./Idno/Pages/Account/Register.php:39
-msgid "Create a new account"
-msgstr ""
-
-#: ./Idno/Pages/Account/Register.php:140
-msgid "Usernames can only have letters, numbers and underscores."
-msgstr ""
-
-#: ./Idno/Pages/Account/Register.php:152
-msgid "Please check that your passwords match and that your password is at least 7 characters long."
-msgstr ""
-
-#: ./Idno/Pages/Account/Register.php:160
-msgid "You've registered! You're ready to get started. Why not add a post to say hello?"
-msgstr ""
-
-#: ./Idno/Pages/Account/Password/Reset.php:27
-msgid "Reset password"
-msgstr ""
-
-#: ./Idno/Pages/Account/Password/Reset.php:35
-msgid "The password reset code wasn't valid. They expire after three hours, so you might need to try again."
-msgstr ""
-
-#: ./Idno/Pages/Account/Password/Reset.php:58
-msgid "Your password was reset!"
-msgstr ""
-
-#: ./Idno/Pages/Account/Password/Reset.php:64
-msgid "Sorry, your passwords either don\'t match, or are too weak"
-msgstr ""
-
-#: ./Idno/Pages/Account/Notifications.php:36
-msgid "Notifications"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings.php:20
-msgid "Account settings"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings.php:50
-msgid "Someone is already using %s as their email address."
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings.php:56
-msgid "Your password has been updated."
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings.php:59
-msgid "Sorry, your password is too weak"
-msgstr ""
-
-#: ./Idno/Pages/Account/Settings.php:66
-msgid "Your details were saved."
-msgstr ""
-
-#: ./Idno/Common/Entity.php:692
-msgid "There was a problem syndicating."
-msgstr ""
-
-#: ./Idno/Common/Plugin.php:87
-msgid "Plugin %s doesn\'t have a version"
-msgstr ""
-
-#: ./Idno/Common/Page.php:397
-msgid "Invalid token."
-msgstr ""
-
-#: ./Idno/Common/Page.php:414
-msgid "Something went wrong."
-msgstr ""
-
-#: ./Idno/Common/Page.php:479
-msgid "Attempted to redirect page to a non local URL."
-msgstr ""
-
-#: ./Idno/Common/Page.php:569
-msgid "The page you were on timed out."
-msgstr ""
-
-#: ./Idno/Common/Page.php:583
-msgid "Couldn't say anything about execution, probably something went wrong"
-msgstr ""
-
-#: ./Idno/Common/Page.php:741
-msgid "This content isn\'t here."
-msgstr ""
-
-#: ./Idno/Common/Page.php:757
-msgid "This page can\'t be found."
+#: ./Idno/Data/Mongo.php:38
+msgid "It looks like you don't have the new mongodb driver installed (<a href=\"https://secure.php.net/manual/en/set.mongodb.php\">https://secure.php.net/manual/en/set.mongodb.php</a>)\n\nMake sure you have it installed and configured, e.g. by running \"pecl install mongodb;\""
 msgstr ""
 
 #: ./Idno/Entities/GenericDataItem.php:43
@@ -630,68 +178,1036 @@ msgstr ""
 msgid "Check that your upload directory is writeable by the web server and try again."
 msgstr ""
 
-#: ./Idno/Data/Mongo.php:38
-msgid "It looks like you don't have the new mongodb driver installed (<a href=\\"https://secure.php.net/manual/en/set.mongodb.php\\">https://secure.php.net/manual/en/set.mongodb.php</a>)\n\nMake sure you have it installed and configured, e.g. by running \\"pecl install mongodb;\\""
+#: ./Idno/Pages/Account/Export.php:20
+msgid "Export Data"
 msgstr ""
 
-#: ./templates/default/content/feed/end.tpl.php:13
-msgid "published this"
+#: ./Idno/Pages/Account/Notifications.php:36
+msgid "Notifications"
 msgstr ""
 
-#: ./templates/default/content/feed/end.tpl.php:28
-msgid "star"
+#: ./Idno/Pages/Account/Password.php:26
+msgid "Password recovery email sent"
 msgstr ""
 
-#: ./templates/default/content/feed/end.tpl.php:30
-msgid "stars"
+#: ./Idno/Pages/Account/Password.php:29
+msgid "Recover password"
 msgstr ""
 
-#: ./templates/default/content/feed/end.tpl.php:48
-msgid "comment"
+#: ./Idno/Pages/Account/Password.php:63
+msgid "Oh no! We couldn't find an account associated with that email address."
 msgstr ""
 
-#: ./templates/default/content/feed/end.tpl.php:50
-msgid "comments"
+#: ./Idno/Pages/Account/Password/Reset.php:27
+msgid "Reset password"
 msgstr ""
 
-#: ./templates/default/content/feed/end.tpl.php:106
-msgid "Also on"
+#: ./Idno/Pages/Account/Password/Reset.php:35
+msgid "The password reset code wasn't valid. They expire after three hours, so you might need to try again."
 msgstr ""
 
-#: ./templates/default/content/annotation/edit.tpl.php:5
-msgid "Delete"
+#: ./Idno/Pages/Account/Password/Reset.php:58
+msgid "Your password was reset!"
 msgstr ""
 
-#: ./templates/default/content/end.tpl.php:55
-msgid "Star this!"
+#: ./Idno/Pages/Account/Password/Reset.php:64
+msgid "Sorry, your passwords either don't match, or are too weak"
 msgstr ""
 
-#: ./templates/default/content/unfurl.tpl.php:11
-msgid "Refresh preview"
+#: ./Idno/Pages/Account/Register.php:27
+msgid "This site is closed to new users."
 msgstr ""
 
-#: ./templates/default/content/unfurl.tpl.php:12
-msgid "Remove preview"
+#: ./Idno/Pages/Account/Register.php:31
+msgid "Your invitation doesn't seem to be valid, or has expired."
 msgstr ""
 
-#: ./templates/default/content/edit.tpl.php:8
-msgid "Edit"
+#: ./Idno/Pages/Account/Register.php:39
+msgid "Create a new account"
 msgstr ""
 
-#: ./templates/default/content/edit.tpl.php:9
-msgid "Are you sure you want to permanently delete this entry?"
+#: ./Idno/Pages/Account/Register.php:80
+msgid "Please enter a username and email address."
 msgstr ""
 
-#: ./templates/default/content/access.tpl.php:34
-msgid "Public"
+#: ./Idno/Pages/Account/Register.php:134
+msgid "Please create a username."
 msgstr ""
 
-#: ./templates/default/content/access.tpl.php:36
-msgid "Members only"
+#: ./Idno/Pages/Account/Register.php:137
+msgid "Your username is too long."
 msgstr ""
 
-#: ./templates/default/content/access.tpl.php:38
-msgid "Private"
+#: ./Idno/Pages/Account/Register.php:140
+msgid "Usernames can only have letters, numbers and underscores."
+msgstr ""
+
+#: ./Idno/Pages/Account/Register.php:143
+msgid "Usernames can't contain a slash %s character."
+msgstr ""
+
+#: ./Idno/Pages/Account/Register.php:146
+msgid "Unfortunately, someone is already using that username. Please choose another."
+msgstr ""
+
+#: ./Idno/Pages/Account/Register.php:149
+msgid "Hey, it looks like there's already an account with that email address. Did you forget your login?"
+msgstr ""
+
+#: ./Idno/Pages/Account/Register.php:152
+msgid "Please check that your passwords match and that your password is at least 7 characters long."
+msgstr ""
+
+#: ./Idno/Pages/Account/Register.php:156
+msgid "That doesn't seem like it's a valid email address."
+msgstr ""
+
+#: ./Idno/Pages/Account/Register.php:160
+msgid "You've registered! You're ready to get started. Why not add a post to say hello?"
+msgstr ""
+
+#: ./Idno/Pages/Account/Register.php:164
+msgid "We couldn't register you."
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/FeedbackConfirm.php:17
+msgid "Thank you for your feedback!"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Feedback.php:19
+msgid "Send feedback"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Feedback.php:42
+msgid "Thanks! We received your feedback."
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:37
+msgid "Sorry, could not find any users on that page, perhaps they need to mark up their profile in <a href=\"http://microformats.org/wiki/microformats-2\">Microformats</a>?"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:51
+msgid "Page did not contain any <a href=\"http://microformats.org/wiki/microformats-2\">Microformats</a> markup... doing my best with what I have!"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:60
+msgid "Found users"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:64
+msgid "Sorry, there was a problem parsing the page!"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:66
+msgid "Sorry, %s could not be retrieved!"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:149
+msgid "There was a problem saving the new remote user."
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:170
+msgid "You are now following %s, would you like to subscribe to their feed?"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:175
+msgid "You are now following %s"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:180
+msgid "You're already following %s"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:183
+msgid "Sorry, that user doesn't exist!"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following/Bookmarklet.php:185
+msgid "No UUID, please try that again!"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Following.php:20
+msgid "Following settings"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Notifications.php:20
+msgid "Notification settings"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Notifications.php:39
+msgid "Your notification preferences were saved."
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings.php:20
+msgid "Account settings"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings.php:50
+msgid "Someone is already using %s as their email address."
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings.php:56
+msgid "Your password has been updated."
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings.php:59
+msgid "Sorry, your password is too weak"
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings.php:66
+msgid "Your details were saved."
+msgstr ""
+
+#: ./Idno/Pages/Account/Settings/Tools.php:26
+msgid "Tools and Apps"
+msgstr ""
+
+#: ./Idno/Pages/Admin/About.php:20
+msgid "About Known"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Dependencies.php:20
+msgid "Dependencies"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Diagnostics.php:56
+msgid "Diagnostics"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Email.php:17
+msgid "Email"
+msgstr ""
+
+#: ./Idno/Pages/Admin/EmailTest.php:26
+msgid "Test email sent to %s"
+msgstr ""
+
+#: ./Idno/Pages/Admin/EmailTest.php:28
+msgid "There was a problem sending a test message to %s."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Export.php:17
+msgid "Export data"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Homepage.php:25
+msgid "Homepage"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Homepage.php:42
+msgid "The default homepage content types were saved."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Home.php:21
+msgid "Administration"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Import.php:18
+msgid "Import data"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Import.php:33
+msgid "You need to upload an import file to continue."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Import.php:35
+msgid "We couldn't open the file you uploaded. Please try again."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Import.php:37
+msgid "Your import has started. We'll email you when it's done."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Logs.php:19
+msgid "Log capture"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Plugins.php:23
+msgid "Plugins"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Plugins.php:44
+msgid "The plugin was enabled."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Plugins.php:58
+msgid "The plugin was disabled."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Statistics.php:16
+msgid "Something went wrong, either no statistics were returned or it wasn't in the correct format."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Statistics.php:27
+msgid "Statistics"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Themes.php:22
+msgid "Themes"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Themes.php:52
+msgid "The theme was enabled."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:32
+msgid "User Management"
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:50
+msgid "%s was given administration rights."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:58
+msgid "%s was stripped of their administration rights."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:65
+msgid "%s was removed from your site."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:91
+msgid "%d invitations were sent."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:93
+msgid "Your invitation was sent."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:95
+msgid "Something went wrong and we couldn't send emails to your recipients."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:97
+msgid "No email addresses were found or all the people you invited are already members of this site."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:105
+msgid "The invitation was removed."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:119
+msgid "The invitation was resent."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:128
+msgid "You can't add any more users to your site."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:141
+msgid "Please make sure your passwords match and aren't empty."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:182
+msgid "User %s was created. You may wish to email them to let them know."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:205
+msgid "%d emails were blocked."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:207
+msgid "The email address was blocked."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:209
+msgid "No email addresses were found."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:230
+msgid "%d emails were unblocked."
+msgstr ""
+
+#: ./Idno/Pages/Admin/Users.php:232
+msgid "The email address was unblocked."
+msgstr ""
+
+#: ./Idno/Pages/Annotation/Delete.php:42
+msgid "The annotation was deleted."
+msgstr ""
+
+#: ./Idno/Pages/Entity/Attachment/Delete.php:21
+msgid "We couldn't find the post."
+msgstr ""
+
+#: ./Idno/Pages/Entity/Delete.php:45
+msgid "We couldn't find the post to delete."
+msgstr ""
+
+#: ./Idno/Pages/Entity/Delete.php:52
+msgid "%s was deleted."
+msgstr ""
+
+#: ./Idno/Pages/Entity/Withdraw.php:48
+msgid "We removed copies on all the syndicated sites."
+msgstr ""
+
+#: ./Idno/Pages/File/Picker.php:57
+msgid "You can only upload images."
+msgstr ""
+
+#: ./Idno/Pages/Following/Add.php:23
+msgid "We couldn't find a feed at that site."
+msgstr ""
+
+#: ./Idno/Pages/Following/Confirm.php:50
+msgid "You're following %s!"
+msgstr ""
+
+#: ./Idno/Pages/Following/Home.php:17
+msgid "Following"
+msgstr ""
+
+#: ./Idno/Pages/Onboarding/Begin.php:23
+msgid "Welcome to Known"
+msgstr ""
+
+#: ./Idno/Pages/Onboarding/Connect.php:25
+msgid "Connect some networks"
+msgstr ""
+
+#: ./Idno/Pages/Onboarding/Profile.php:22
+msgid "Create your profile"
+msgstr ""
+
+#: ./Idno/Pages/Search/User.php:23
+msgid "Invalid sort type %s"
+msgstr ""
+
+#: ./Idno/Pages/Search/User.php:27
+msgid "Invalid sort order %s"
+msgstr ""
+
+#: ./Idno/Pages/Service/Security/CSRFToken.php:16
+msgid "URL missing"
+msgstr ""
+
+#: ./Idno/Pages/Service/Web/ImageProxy.php:77
+msgid "There was a problem decoding the url"
+msgstr ""
+
+#: ./Idno/Pages/Service/Web/ImageProxy.php:81
+msgid "No url specified"
+msgstr ""
+
+#: ./Idno/Pages/Service/Web/ImageProxy.php:222
+msgid "Could not save temporary file"
+msgstr ""
+
+#: ./Idno/Pages/Service/Web/ImageProxy.php:253
+msgid "Looks like something went wrong, image was zero bytes big!"
+msgstr ""
+
+#: ./Idno/Pages/Service/Web/UrlUnfurl.php:20
+msgid "You need to specify a working URL"
+msgstr ""
+
+#: ./Idno/Pages/Service/Web/UrlUnfurl.php:69
+msgid "Url %s could not be unfurled"
+msgstr ""
+
+#: ./Idno/Pages/Session/CurrentUser.php:36
+msgid "The %s profile for %s"
+msgstr ""
+
+#: ./Idno/Pages/Session/Login.php:42
+msgid "Sign in"
+msgstr ""
+
+#: ./Idno/Pages/Session/Login.php:67
+msgid "Oops! It looks like your password isn't correct. Please try again."
+msgstr ""
+
+#: ./Idno/Pages/Session/Login.php:72
+msgid "Oops! We couldn't find your username or email address. Please check you typed it correctly and try again."
+msgstr ""
+
+#: ./Idno/Pages/Session/Logout.php:24
+msgid "You've signed out. See you soon!"
+msgstr ""
+
+#: ./Idno/Pages/User/Edit.php:30
+msgid "Edit profile: %s"
+msgstr ""
+
+#: ./Idno/Pages/Webmentions/Endpoint.php:19
+msgid "Webmention endpoint"
+msgstr ""
+
+#: ./Idno/Stats/Timer.php:39
+msgid "Timer %s has not been started."
+msgstr ""
+
+#: ./templates/default/account/export.tpl.php:8
+msgid "Export your data"
+msgstr ""
+
+#: ./templates/default/account/export.tpl.php:19
+msgid "You can download an RSS version of everything you've posted on this site. This file is suitable for importing into content management systems like WordPress, or another Known site."
+msgstr ""
+
+#: ./templates/default/account/export.tpl.php:24
+msgid "Include private posts?"
+msgstr ""
+
+#: ./templates/default/account/export.tpl.php:28
+msgid "Yes"
+msgstr ""
+
+#: ./templates/default/account/export.tpl.php:29
+msgid "No"
+msgstr ""
+
+#: ./templates/default/account/export.tpl.php:34
+msgid "Platforms like WordPress may assume that all your posts should be displayed publicly. In order to protect your privacy, you may wish to just download your public posts."
+msgstr ""
+
+#: ./templates/default/account/export.tpl.php:38
+msgid "Download RSS Feed"
+msgstr ""
+
+#: ./templates/default/account/login.tpl.php:4
+msgid "Welcome back!"
+msgstr ""
+
+#: ./templates/default/account/login.tpl.php:14
+msgid "Your email address or username"
+msgstr ""
+
+#: ./templates/default/account/login.tpl.php:17
+msgid "Password"
+msgstr ""
+
+#: ./templates/default/account/login.tpl.php:36
+msgid "New here? Register for an account."
+msgstr ""
+
+#: ./templates/default/account/login.tpl.php:40
+msgid "Forgot your password?"
+msgstr ""
+
+#: ./templates/default/account/menu.tpl.php:3
+msgid "Settings"
+msgstr ""
+
+#: ./templates/default/account/menu.tpl.php:6
+msgid "Email notifications"
+msgstr ""
+
+#: ./templates/default/account/notifications.tpl.php:6
+msgid "The notifications screen shows you who has interacted with your content."
+msgstr ""
+
+#: ./templates/default/account/notifications.tpl.php:25
+msgid "You don't have any notifications yet. But we love you anyway!"
+msgstr ""
+
+#: ./templates/default/account/password/reset.tpl.php:5
+msgid "Reset your password"
+msgstr ""
+
+#: ./templates/default/account/password/reset.tpl.php:7
+msgid "To change your password, enter your new password below:"
+msgstr ""
+
+#: ./templates/default/account/password/reset.tpl.php:16
+msgid "Your email address"
+msgstr ""
+
+#: ./templates/default/account/password/reset.tpl.php:17
+msgid "The address associated with your %s account."
+msgstr ""
+
+#: ./templates/default/account/password/reset.tpl.php:23
+msgid "New password (7 characters or more)"
+msgstr ""
+
+#: ./templates/default/account/password/reset.tpl.php:29
+msgid "Retype password"
+msgstr ""
+
+#: ./templates/default/account/password/reset.tpl.php:30
+msgid "We ask you to enter the password twice to protect against typos."
+msgstr ""
+
+#: ./templates/default/account/password/sent.tpl.php:5
+msgid "Your password reset email has been sent"
+msgstr ""
+
+#: ./templates/default/account/password/sent.tpl.php:15
+msgid "Check your inbox! You'll find an email containing a special link that will help you reset your password."
+msgstr ""
+
+#: ./templates/default/account/password/sent.tpl.php:18
+msgid "Did you remember your password? That's okay too. You can <a href=\"%s\">click here to sign in.</a>"
+msgstr ""
+
+#: ./templates/default/account/password.tpl.php:9
+msgid "Forgot your password? Don't worry! It happens to the best of us."
+msgstr ""
+
+#: ./templates/default/account/password.tpl.php:10
+msgid "Just enter the email address associated with your %s account below, and we'll send you a top secret link to your email account so that you can create a new password."
+msgstr ""
+
+#: ./templates/default/account/password.tpl.php:27
+msgid "Send password reset email"
+msgstr ""
+
+#: ./templates/default/account/register.tpl.php:5
+msgid "Hello there!"
+msgstr ""
+
+#: ./templates/default/account/register.tpl.php:7
+msgid "Create a new account to get started."
+msgstr ""
+
+#: ./templates/default/account/register.tpl.php:14
+msgid "Your name"
+msgstr ""
+
+#: ./templates/default/account/register.tpl.php:20
+msgid "Choose a handle"
+msgstr ""
+
+#: ./templates/default/account/register.tpl.php:21
+msgid "Handles identify you throughout the site. Something simple is best: for example, <em>janedoe</em>."
+msgstr ""
+
+#: ./templates/default/account/register.tpl.php:23
+msgid "username"
+msgstr ""
+
+#: ./templates/default/account/register.tpl.php:33
+msgid "Create a password"
+msgstr ""
+
+#: ./templates/default/account/register.tpl.php:34
+msgid "At least 7 characters please."
+msgstr ""
+
+#: ./templates/default/account/register.tpl.php:37
+msgid "secret-password"
+msgstr ""
+
+#: ./templates/default/account/register.tpl.php:42
+msgid "Your password again"
+msgstr ""
+
+#: ./templates/default/account/register.tpl.php:49
+msgid "Create Account"
+msgstr ""
+
+#: ./templates/default/account/settings/feedback/confirm.tpl.php:5
+msgid "Message received!"
+msgstr ""
+
+#: ./templates/default/account/settings/feedback/confirm.tpl.php:9
+msgid "Thanks for sending along your thoughts. We'll read them right away."
+msgstr ""
+
+#: ./templates/default/account/settings/feedback/confirm.tpl.php:22
+msgid "Feedback is a gift.  For more information about Known, <a href=\"https://withknown.com/\">please visit our homepage</a>"
+msgstr ""
+
+#: ./templates/default/account/settings/feedback.tpl.php:5
+msgid "Share your feedback"
+msgstr ""
+
+#: ./templates/default/account/settings/feedback.tpl.php:9
+msgid "Want to share something with the Known team? We'd love to read your thoughts, suggestions, or ideas. We will personally read all of your feedback."
+msgstr ""
+
+#: ./templates/default/account/settings/feedback.tpl.php:21
+msgid "From"
+msgstr ""
+
+#: ./templates/default/account/settings/feedback.tpl.php:29
+msgid "Feedback for the Known team"
+msgstr ""
+
+#: ./templates/default/account/settings/feedback.tpl.php:32
+msgid "Let us know what you think."
+msgstr ""
+
+#: ./templates/default/account/settings/following/bookmarklet.tpl.php:3
+msgid "Add as friend..."
+msgstr ""
+
+#: ./templates/default/account/settings/following/mf2user.tpl.php:55
+msgid "Name"
+msgstr ""
+
+#: ./templates/default/account/settings/following/mf2user.tpl.php:64
+msgid "Nickname"
+msgstr ""
+
+#: ./templates/default/account/settings/following/mf2user.tpl.php:67
+msgid "Handle (for your reference)"
+msgstr ""
+
+#: ./templates/default/account/settings/following/mf2user.tpl.php:82
+msgid "Profile URL"
+msgstr ""
+
+#: ./templates/default/account/settings/following.tpl.php:5
+msgid "Following..."
+msgstr ""
+
+#: ./templates/default/account/settings/following.tpl.php:11
+msgid "Manage your subscriptions here. These users can also be given access to private content you produce on your site."
+msgstr ""
+
+#: ./templates/default/account/settings/following.tpl.php:16
+msgid "Use this bookmarklet to make is easy to add new friends."
+msgstr ""
+
+#: ./templates/default/account/settings/notifications.tpl.php:17
+msgid "Set how you'd like to be notified when someone stars or comments on your content."
+msgstr ""
+
+#: ./templates/default/account/settings/notifications.tpl.php:26
+msgid "Send email notifications"
+msgstr ""
+
+#: ./templates/default/account/settings/notifications.tpl.php:34
+msgid "Whenever someone interacts with my content"
+msgstr ""
+
+#: ./templates/default/account/settings/notifications.tpl.php:44
+msgid "Only when someone comments on my content"
+msgstr ""
+
+#: ./templates/default/account/settings/notifications.tpl.php:54
+msgid "Never"
+msgstr ""
+
+#: ./templates/default/account/settings/notifications.tpl.php:63
+msgid "Ignored Domains"
+msgstr ""
+
+#: ./templates/default/account/settings/notifications.tpl.php:64
+msgid "Do not send notifications for interactions originating from these domains (one domain per line)"
+msgstr ""
+
+#: ./templates/default/account/settings/notifications.tpl.php:75
+msgid "Save settings"
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:13
+msgid "Bookmarklet"
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:22
+msgid "The Known bookmarklet is the best way to save links, reply to posts, and share articles."
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:23
+msgid "Just drag the bookmarklet button below into your browser's Bookmark Bar."
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:42
+msgid "Don't see a bookmarks bar?"
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:45
+msgid "Sometimes web browsers have their bookmarked links bar hidden by default. Here's how to reveal it:"
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:47
+msgid "Chrome"
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:47
+msgid "Select <em>Always Show Bookmarks Bar</em> from the <em>View</em> menu."
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:48
+msgid "Firefox"
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:48
+msgid "Select <em>View</em>, then <em>Toolbars</em>, and make sure"
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:49
+msgid "Bookmarks Toolbar"
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:49
+msgid "is checked."
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:50
+msgid "Internet Explorer"
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:50
+msgid "Select <em>Tools</em>, then make sure <em>Favorites Bar</em> is checked."
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:65
+msgid "Your API key"
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:76
+msgid "Revoke"
+msgstr ""
+
+#: ./templates/default/account/settings/tools.tpl.php:76
+msgid "Revoking this key will mean you must update any applications that use this key!"
+msgstr ""
+
+#: ./templates/default/account/settings.tpl.php:9
+msgid "Account Settings"
+msgstr ""
+
+#: ./templates/default/account/settings.tpl.php:14
+msgid "Change your user account settings here. You may also want to <a href=\"%s\">edit your profile</a>."
+msgstr ""
+
+#: ./templates/default/account/settings.tpl.php:45
+msgid "Site notifications will be sent here."
+msgstr ""
+
+#: ./templates/default/account/settings.tpl.php:51
+msgid "Your password"
+msgstr ""
+
+#: ./templates/default/account/settings.tpl.php:58
+msgid "Leave this blank if you don't want to change it."
+msgstr ""
+
+#: ./templates/default/account/settings.tpl.php:64
+msgid "Your timezone"
+msgstr ""
+
+#: ./templates/default/account/settings.tpl.php:73
+msgid "Timezone"
+msgstr ""
+
+#: ./templates/default/account/settings.tpl.php:78
+msgid "Specify your timezone."
+msgstr ""
+
+#: ./templates/default/account/settings.tpl.php:83
+msgid "Save updates"
+msgstr ""
+
+#: ./templates/default/admin/about.tpl.php:15
+msgid "Known"
+msgstr ""
+
+#: ./templates/default/admin/about.tpl.php:15
+msgid "is a social publishing platform for groups and individuals."
+msgstr ""
+
+#: ./templates/default/admin/about.tpl.php:17
+msgid "Open source project details"
+msgstr ""
+
+#: ./templates/default/admin/about.tpl.php:20
+msgid "Version: %s+%s"
+msgstr ""
+
+#: ./templates/default/admin/dependencies/build.tpl.php:2
+msgid "%s installed"
+msgstr ""
+
+#: ./templates/default/admin/dependencies/plugin.tpl.php:30
+msgid "(v%s required)"
+msgstr ""
+
+#: ./templates/default/admin/dependencies.tpl.php:8
+msgid "The following are system components that are required for Known to fully run. It's worth checking to make sure that they're all installed. If you need help installing any required packages, ask your web host or system administrator."
+msgstr ""
+
+#: ./templates/default/admin/dependencies.tpl.php:17
+msgid "PHP"
+msgstr ""
+
+#: ./templates/default/admin/dependencies.tpl.php:19
+msgid "Version %s or greater"
+msgstr ""
+
+#: ./templates/default/admin/dependencies.tpl.php:27
+msgid "PHP extensions required"
+msgstr ""
+
+#: ./templates/default/admin/dependencies.tpl.php:28
+msgid "These extend the way PHP works, and are required for functionality like database storage, webmentions, etc. Click an extension name to learn more about it, including installation instructions."
+msgstr ""
+
+#: ./templates/default/admin/diagnostics.tpl.php:9
+msgid "This page provides you with information that may help you or others diagnose any problems you may be experiencing with your Known install."
+msgstr ""
+
+#: ./templates/default/admin/diagnostics.tpl.php:45
+msgid "Basic checks on installation discovered no problems."
+msgstr ""
+
+#: ./templates/default/admin/diagnostics.tpl.php:57
+msgid "Generate detailed report"
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:5
+msgid "Email settings"
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:9
+msgid "Known tries to send email using your server's default email settings. If you'd like it to do something else - for example, if you'd like to send email using an external provider - enter the new SMTP settings below. You can also <a href=\"%s\">change your notification settings</a>."
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:20
+msgid "Fill in the site email address if you would like your site to send email."
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:26
+msgid "Site email address"
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:33
+msgid "This is the address that every notification will be sent from."
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:40
+msgid "You can often leave the following settings blank. However, you may wish to set them if you're using a third-party service to send email."
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:48
+msgid "SMTP host"
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:55
+msgid "This is the address of the server that will send email for you."
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:62
+msgid "SMTP username"
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:69
+msgid "If your mail server needs a username, enter it here."
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:76
+msgid "SMTP password"
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:84
+msgid "If your mail server needs a password, enter it here."
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:91
+msgid "SMTP port"
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:107
+msgid "This is normally 25 or 587."
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:114
+msgid "Secure connection"
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:135
+msgid "Select yes if you use secure logins to your mail server."
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:157
+msgid "Send a test message to"
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:160
+msgid "To address"
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:164
+msgid "Check your email settings by sending a test email."
+msgstr ""
+
+#: ./templates/default/admin/email.tpl.php:170
+msgid "Test settings"
+msgstr ""
+
+#: ./templates/default/admin/export/download.tpl.php:2
+msgid "Download your data"
+msgstr ""
+
+#: ./templates/default/admin/export/download.tpl.php:3
+msgid "Generated"
+msgstr ""
+
+#: ./templates/default/admin/export/download.tpl.php:7
+msgid "You can also regenerate a new copy of your data archive."
+msgstr ""
+
+#: ./templates/default/admin/export/download.tpl.php:11
+msgid "Re-archive your data"
+msgstr ""
+
+#: ./templates/default/admin/export/generate.tpl.php:5
+msgid "Create archive"
+msgstr ""
+
+#: ./templates/default/admin/export/generate.tpl.php:18
+msgid "It may take a while to generate your archive. You can leave this page while it's working. Once the export file is complete, this page will update, and you'll be able to download the archive right here."
+msgstr ""
+
+#: ./templates/default/admin/export.tpl.php:9
+msgid "Export content"
+msgstr ""
+
+#: ./templates/default/admin/export.tpl.php:17
+msgid "Export your published Known content as an RSS file. You can import this file into Known or WordPress."
+msgstr ""
+
+#: ./templates/default/admin/export.tpl.php:20
+msgid "Generate RSS file"
+msgstr ""
+
+#: ./templates/default/admin/export.tpl.php:35
+msgid "Some platforms may assume that your content should be displayed publicly. To protect your privacy, you may wish to only download your public content."
+msgstr ""
+
+#: ./templates/default/admin/export.tpl.php:39
+msgid "Download file"
+msgstr ""
+
+#: ./templates/default/admin/export/wait.tpl.php:4
+msgid "An archive of your data is being created. Please check again in a few minutes."
+msgstr ""
+
+#: ./templates/default/admin/home/description.tpl.php:2
+msgid "Site configuration"
+msgstr ""
+
+#: ./templates/default/admin/home/description.tpl.php:6
+msgid "On this page you can change the basic settings for your site, like the site name and the number of posts visible on each page."
+msgstr ""
+
+#: ./templates/default/admin/homepage.tpl.php:6
+msgid "Homepage content"
+msgstr ""
+
+#: ./templates/default/admin/homepage.tpl.php:11
+msgid "Here you can choose what content visitors see on your site homepage. By default, all published content appears on the main page. If you want to hide some content types from the main page, you can turn them off below."
+msgstr ""
+
+#: ./templates/default/admin/homepage.tpl.php:16
+msgid "Turn off content types to hide them from the homepage of your site."
+msgstr ""
+
+#: ./templates/default/admin/homepage.tpl.php:45
+msgid "On"
+msgstr ""
+
+#: ./templates/default/admin/homepage.tpl.php:46
+msgid "Off"
+msgstr ""
+
+#: ./templates/default/admin/homepage.tpl.php:109
+msgid "Save"
 msgstr ""
 
 #: ./templates/default/admin/home.tpl.php:15
@@ -734,124 +1250,84 @@ msgstr ""
 msgid "This is the number of content posts displayed on each page."
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:88
+#: ./templates/default/admin/home.tpl.php:79
+msgid "Single user"
+msgstr ""
+
+#: ./templates/default/admin/home.tpl.php:90
 msgid "Is this a single-user site? If so, your profile information will be shown at the top of the homepage."
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:116
+#: ./templates/default/admin/home.tpl.php:101
+msgid "Permalink Structure"
+msgstr ""
+
+#: ./templates/default/admin/home.tpl.php:118
 msgid "How permalinks for individual posts are constructed."
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:128
+#: ./templates/default/admin/home.tpl.php:130
 msgid "Registration and privacy"
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:136
+#: ./templates/default/admin/home.tpl.php:138
 msgid "Allow registration"
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:144
+#: ./templates/default/admin/home.tpl.php:148
 msgid "Allow registration if you want others to sign up for your site."
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:157
+#: ./templates/default/admin/home.tpl.php:161
 msgid "Make site private"
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:164
+#: ./templates/default/admin/home.tpl.php:170
 msgid "Content on a private site is only visible if you're logged in."
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:182
+#: ./templates/default/admin/home.tpl.php:188
 msgid "Per-post privacy"
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:191
+#: ./templates/default/admin/home.tpl.php:199
 msgid "Show per-post privacy settings."
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:207
+#: ./templates/default/admin/home.tpl.php:215
 msgid "Technical Settings"
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:215
+#: ./templates/default/admin/home.tpl.php:223
 msgid "PubSubHubbub hub"
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:218
+#: ./templates/default/admin/home.tpl.php:226
 msgid "PubSubHubbub hub address"
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:222
+#: ./templates/default/admin/home.tpl.php:230
 msgid "You can probably leave this as is."
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:223
+#: ./templates/default/admin/home.tpl.php:231
 msgid "Learn more about PuSH"
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:233
+#: ./templates/default/admin/home.tpl.php:241
 msgid "Avatar as icon"
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:242
+#: ./templates/default/admin/home.tpl.php:252
 msgid "This uses members' avatar images as the site favicon."
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:250
+#: ./templates/default/admin/home.tpl.php:260
 msgid "Include permalinks"
 msgstr ""
 
-#: ./templates/default/admin/home.tpl.php:257
-msgid "Always add a link back to your site when you syndicate to external networks."
-msgstr ""
-
 #: ./templates/default/admin/home.tpl.php:269
-msgid "Save updates"
-msgstr ""
-
-#: ./templates/default/admin/export/wait.tpl.php:4
-msgid "An archive of your data is being created. Please check again in a few minutes."
-msgstr ""
-
-#: ./templates/default/admin/export/generate.tpl.php:5
-msgid "Create archive"
-msgstr ""
-
-#: ./templates/default/admin/export/generate.tpl.php:18
-msgid "It may take a while to generate your archive. You can leave this page while it's working. Once the export file is complete, this page will update, and you'll be able to download the archive right here."
-msgstr ""
-
-#: ./templates/default/admin/export/download.tpl.php:2
-msgid "Download your data"
-msgstr ""
-
-#: ./templates/default/admin/export/download.tpl.php:3
-msgid "Generated"
-msgstr ""
-
-#: ./templates/default/admin/export/download.tpl.php:7
-msgid "You can also regenerate a new copy of your data archive."
-msgstr ""
-
-#: ./templates/default/admin/export/download.tpl.php:11
-msgid "Re-archive your data"
-msgstr ""
-
-#: ./templates/default/admin/dependencies/build.tpl.php:2
-msgid "%s installed"
-msgstr ""
-
-#: ./templates/default/admin/dependencies/plugin.tpl.php:30
-msgid "(v%s required)"
-msgstr ""
-
-#: ./templates/default/admin/plugins.tpl.php:5
-msgid "Plugins"
-msgstr ""
-
-#: ./templates/default/admin/plugins.tpl.php:9
-msgid "Plugins allow you to add features to your site. These include new kinds of content, options to syndicate content to different sites, and features to change the way Known behaves. To enable or disable a plugin, just click its enable or disable button."
+msgid "Always add a link back to your site when you syndicate to external networks."
 msgstr ""
 
 #: ./templates/default/admin/import.tpl.php:9
@@ -860,10 +1336,6 @@ msgstr ""
 
 #: ./templates/default/admin/import.tpl.php:12
 msgid "Import your content from other sites into Known. All imported content will be treated as a post, with a title and body content."
-msgstr ""
-
-#: ./templates/default/admin/import.tpl.php:24
-msgid "Known"
 msgstr ""
 
 #: ./templates/default/admin/import.tpl.php:27
@@ -978,36 +1450,12 @@ msgstr ""
 msgid "Click on Export Blog"
 msgstr ""
 
-#: ./templates/default/admin/about.tpl.php:5
-msgid "About Known"
+#: ./templates/default/admin/logs.tpl.php:9
+msgid "This page provides you with captured PHP logs. These contain sensitive information, so be very careful how you disclose the information and to whom."
 msgstr ""
 
-#: ./templates/default/admin/about.tpl.php:15
-msgid "is a social publishing platform for groups and individuals."
-msgstr ""
-
-#: ./templates/default/admin/about.tpl.php:17
-msgid "Open source project details"
-msgstr ""
-
-#: ./templates/default/admin/about.tpl.php:20
-msgid "Version: %s+%s"
-msgstr ""
-
-#: ./templates/default/admin/menu.tpl.php:2
-msgid "Site configuration"
-msgstr ""
-
-#: ./templates/default/admin/menu.tpl.php:4
-msgid "Themes"
-msgstr ""
-
-#: ./templates/default/admin/menu.tpl.php:6
-msgid "Homepage"
-msgstr ""
-
-#: ./templates/default/admin/menu.tpl.php:7
-msgid "Email"
+#: ./templates/default/admin/logs.tpl.php:19
+msgid "Refresh..."
 msgstr ""
 
 #: ./templates/default/admin/menu.tpl.php:8
@@ -1022,10 +1470,6 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: ./templates/default/admin/menu.tpl.php:11
-msgid "Diagnostics"
-msgstr ""
-
 #: ./templates/default/admin/menu.tpl.php:13
 msgid "Captured Logs"
 msgstr ""
@@ -1034,28 +1478,52 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: ./templates/default/admin/dependencies.tpl.php:4
-msgid "Dependencies"
+#: ./templates/default/admin/plugins/plugin.tpl.php:35
+msgid "Enabled"
 msgstr ""
 
-#: ./templates/default/admin/dependencies.tpl.php:8
-msgid "The following are system components that are required for Known to fully run. It's worth checking to make sure that they're all installed. If you need help installing any required packages, ask your web host or system administrator."
+#: ./templates/default/admin/plugins/plugin.tpl.php:37
+msgid "Disabled"
 msgstr ""
 
-#: ./templates/default/admin/dependencies.tpl.php:17
-msgid "PHP"
+#: ./templates/default/admin/plugins/plugin.tpl.php:56
+msgid "Known Version"
 msgstr ""
 
-#: ./templates/default/admin/dependencies.tpl.php:19
-msgid "Version %s or greater"
+#: ./templates/default/admin/plugins/plugin.tpl.php:67
+msgid "Known Build"
 msgstr ""
 
-#: ./templates/default/admin/dependencies.tpl.php:27
-msgid "PHP extensions required"
+#: ./templates/default/admin/plugins/plugin.tpl.php:78
+msgid "PHP Version"
 msgstr ""
 
-#: ./templates/default/admin/dependencies.tpl.php:28
-msgid "These extend the way PHP works, and are required for functionality like database storage, webmentions, etc. Click an extension name to learn more about it, including installation instructions."
+#: ./templates/default/admin/plugins/plugin.tpl.php:91
+msgid "Extensions"
+msgstr ""
+
+#: ./templates/default/admin/plugins/plugin.tpl.php:134
+msgid "Disable"
+msgstr ""
+
+#: ./templates/default/admin/plugins/plugin.tpl.php:147
+msgid "Enable"
+msgstr ""
+
+#: ./templates/default/admin/plugins.tpl.php:9
+msgid "Plugins allow you to add features to your site. These include new kinds of content, options to syndicate content to different sites, and features to change the way Known behaves. To enable or disable a plugin, just click its enable or disable button."
+msgstr ""
+
+#: ./templates/default/admin/statistics.tpl.php:9
+msgid "This page provides you with information and statistics about your Known site."
+msgstr ""
+
+#: ./templates/default/admin/themes/theme.tpl.php:41
+msgid "(Selected)"
+msgstr ""
+
+#: ./templates/default/admin/themes/theme.tpl.php:48
+msgid "by"
 msgstr ""
 
 #: ./templates/default/admin/themes.tpl.php:7
@@ -1107,228 +1575,115 @@ msgid "Block email addresses"
 msgstr ""
 
 #: ./templates/default/admin/users.tpl.php:174
-msgid "By blocking email addresses, you prevent people using those email addresses from registering on
-                        your site. Enter the email addresses you want to block below."
+msgid "By blocking email addresses, you prevent people using those email addresses from registering on your site. Enter the email addresses you want to block below."
 msgstr ""
 
-#: ./templates/default/admin/users.tpl.php:197
+#: ./templates/default/admin/users.tpl.php:196
 msgid "Blocked email addresses"
 msgstr ""
 
-#: ./templates/default/admin/export.tpl.php:9
-msgid "Export content"
+#: ./templates/default/content/access.tpl.php:34
+msgid "Public"
 msgstr ""
 
-#: ./templates/default/admin/export.tpl.php:17
-msgid "Export your published Known content as an RSS file. You can import this file into Known or WordPress."
+#: ./templates/default/content/access.tpl.php:36
+msgid "Members only"
 msgstr ""
 
-#: ./templates/default/admin/export.tpl.php:20
-msgid "Generate RSS file"
+#: ./templates/default/content/access.tpl.php:38
+msgid "Private"
 msgstr ""
 
-#: ./templates/default/admin/export.tpl.php:25
-msgid "Include private posts?"
+#: ./templates/default/content/annotation/edit.tpl.php:5
+msgid "Delete"
 msgstr ""
 
-#: ./templates/default/admin/export.tpl.php:33
-msgid "Some platforms may assume that your content should be displayed publicly. To protect your privacy, you may wish to only download your public content."
+#: ./templates/default/content/edit.tpl.php:8
+msgid "Edit"
 msgstr ""
 
-#: ./templates/default/admin/export.tpl.php:37
-msgid "Download file"
+#: ./templates/default/content/edit.tpl.php:9
+msgid "Are you sure you want to permanently delete this entry?"
 msgstr ""
 
-#: ./templates/default/admin/home/description.tpl.php:6
-msgid "On this page you can change the basic settings for your site, like the site name and the number of posts visible on each page."
+#: ./templates/default/content/end.tpl.php:26
+msgid "published this"
 msgstr ""
 
-#: ./templates/default/admin/themes/theme.tpl.php:41
-msgid "(Selected)"
+#: ./templates/default/content/end.tpl.php:55
+msgid "Star this!"
 msgstr ""
 
-#: ./templates/default/admin/themes/theme.tpl.php:43
-msgid "Enable"
+#: ./templates/default/content/end.tpl.php:61
+msgid "star"
 msgstr ""
 
-#: ./templates/default/admin/themes/theme.tpl.php:48
-msgid "by"
+#: ./templates/default/content/end.tpl.php:64
+msgid "stars"
 msgstr ""
 
-#: ./templates/default/admin/diagnostics.tpl.php:9
-msgid "This page provides you with information that may help you or others diagnose any problems you may be experiencing with your Known install."
+#: ./templates/default/content/end.tpl.php:95
+msgid "comment"
 msgstr ""
 
-#: ./templates/default/admin/diagnostics.tpl.php:45
-msgid "Basic checks on installation discovered no problems."
+#: ./templates/default/content/end.tpl.php:97
+msgid "comments"
 msgstr ""
 
-#: ./templates/default/admin/diagnostics.tpl.php:57
-msgid "Generate detailed report"
+#: ./templates/default/content/feed/end.tpl.php:106
+msgid "Also on"
 msgstr ""
 
-#: ./templates/default/admin/email.tpl.php:5
-msgid "Email settings"
+#: ./templates/default/content/unfurl.tpl.php:11
+msgid "Refresh preview"
 msgstr ""
 
-#: ./templates/default/admin/email.tpl.php:9
-msgid "Known tries to send email using your server's default email settings. If you'd like it to do something else - for example, if you'd like to send email using an external provider - enter the new SMTP settings below. You can also <a href=\\"%s\\">change your notification settings</a>."
+#: ./templates/default/content/unfurl.tpl.php:12
+msgid "Remove preview"
 msgstr ""
 
-#: ./templates/default/admin/email.tpl.php:20
-msgid "Fill in the site email address if you would like your site to send email."
+#: ./templates/default/entity/annotations/comment/main.tpl.php:16
+msgid "Add a comment ..."
 msgstr ""
 
-#: ./templates/default/admin/email.tpl.php:26
-msgid "Site email address"
+#: ./templates/default/entity/annotations/comment/main.tpl.php:21
+msgid "Leave Comment"
 msgstr ""
 
-#: ./templates/default/admin/email.tpl.php:33
-msgid "This is the address that every notification will be sent from."
+#: ./templates/default/entity/annotations/likes.tpl.php:24
+msgid "liked this post"
 msgstr ""
 
-#: ./templates/default/admin/email.tpl.php:40
-msgid "You can often leave the following settings blank. However, you may wish to set them if you're using a third-party service to send email."
+#: ./templates/default/entity/annotations/mentions.tpl.php:18
+msgid "Mentioned in"
 msgstr ""
 
-#: ./templates/default/admin/email.tpl.php:48
-msgid "SMTP host"
+#: ./templates/default/entity/annotations/rsvps.tpl.php:38
+msgid "Attending"
 msgstr ""
 
-#: ./templates/default/admin/email.tpl.php:55
-msgid "This is the address of the server that will send email for you."
+#: ./templates/default/entity/annotations/rsvps.tpl.php:41
+msgid "Maybe attending"
 msgstr ""
 
-#: ./templates/default/admin/email.tpl.php:62
-msgid "SMTP username"
+#: ./templates/default/entity/annotations/rsvps.tpl.php:44
+msgid "Not attending"
 msgstr ""
 
-#: ./templates/default/admin/email.tpl.php:69
-msgid "If your mail server needs a username, enter it here."
+#: ./templates/default/entity/annotations/rsvps.tpl.php:47
+msgid "Other responses"
 msgstr ""
 
-#: ./templates/default/admin/email.tpl.php:76
-msgid "SMTP password"
-msgstr ""
-
-#: ./templates/default/admin/email.tpl.php:84
-msgid "If your mail server needs a password, enter it here."
-msgstr ""
-
-#: ./templates/default/admin/email.tpl.php:91
-msgid "SMTP port"
-msgstr ""
-
-#: ./templates/default/admin/email.tpl.php:107
-msgid "This is normally 25 or 587."
-msgstr ""
-
-#: ./templates/default/admin/email.tpl.php:114
-msgid "Secure connection"
-msgstr ""
-
-#: ./templates/default/admin/email.tpl.php:135
-msgid "Select yes if you use secure logins to your mail server."
-msgstr ""
-
-#: ./templates/default/admin/email.tpl.php:142
-msgid "Save settings"
-msgstr ""
-
-#: ./templates/default/admin/email.tpl.php:157
-msgid "Send a test message to"
-msgstr ""
-
-#: ./templates/default/admin/email.tpl.php:160
-msgid "To address"
-msgstr ""
-
-#: ./templates/default/admin/email.tpl.php:164
-msgid "Check your email settings by sending a test email."
-msgstr ""
-
-#: ./templates/default/admin/email.tpl.php:170
-msgid "Test settings"
-msgstr ""
-
-#: ./templates/default/admin/statistics.tpl.php:4
-msgid "Statistics"
-msgstr ""
-
-#: ./templates/default/admin/statistics.tpl.php:9
-msgid "This page provides you with information and statistics about your Known site."
-msgstr ""
-
-#: ./templates/default/admin/homepage.tpl.php:6
-msgid "Homepage content"
-msgstr ""
-
-#: ./templates/default/admin/homepage.tpl.php:11
-msgid "Here you can choose what content visitors see on your site homepage. By default, all published content appears on the main page. If you want to hide some content types from the main page, you can turn them off below."
-msgstr ""
-
-#: ./templates/default/admin/homepage.tpl.php:16
-msgid "Turn off content types to hide them from the homepage of your site."
-msgstr ""
-
-#: ./templates/default/admin/homepage.tpl.php:106
-msgid "Save"
-msgstr ""
-
-#: ./templates/default/admin/logs.tpl.php:4
-msgid "Log capture"
-msgstr ""
-
-#: ./templates/default/admin/logs.tpl.php:9
-msgid "This page provides you with captured PHP logs. These contain sensitive information, so be very careful how you disclose the information and to whom."
-msgstr ""
-
-#: ./templates/default/admin/logs.tpl.php:19
-msgid "Refresh..."
-msgstr ""
-
-#: ./templates/default/admin/plugins/plugin.tpl.php:35
-msgid "Enabled"
-msgstr ""
-
-#: ./templates/default/admin/plugins/plugin.tpl.php:37
-msgid "Disabled"
-msgstr ""
-
-#: ./templates/default/admin/plugins/plugin.tpl.php:56
-msgid "Known Version"
-msgstr ""
-
-#: ./templates/default/admin/plugins/plugin.tpl.php:67
-msgid "Known Build"
-msgstr ""
-
-#: ./templates/default/admin/plugins/plugin.tpl.php:78
-msgid "PHP Version"
-msgstr ""
-
-#: ./templates/default/admin/plugins/plugin.tpl.php:91
-msgid "Extensions"
-msgstr ""
-
-#: ./templates/default/admin/plugins/plugin.tpl.php:134
-msgid "Disable"
-msgstr ""
-
-#: ./templates/default/entity/share.tpl.php:9
-msgid "This content can't be shared right now."
+#: ./templates/default/entity/annotations/shares.tpl.php:21
+msgid "reshared this post"
 msgstr ""
 
 #: ./templates/default/entity/search.tpl.php:18
 msgid "Nothing found."
 msgstr ""
 
-#: ./templates/default/entity/User.tpl.php:61
-msgid "A profile helps you describe yourself to other people on the site and on the web. You haven't described yourself yet."
-msgstr ""
-
-#: ./templates/default/entity/User.tpl.php:62
-msgid "Click here to fill in your profile information."
+#: ./templates/default/entity/share.tpl.php:9
+msgid "This content can't be shared right now."
 msgstr ""
 
 #: ./templates/default/entity/User/edit.tpl.php:3
@@ -1341,10 +1696,6 @@ msgstr ""
 
 #: ./templates/default/entity/User/edit.tpl.php:23
 msgid "Select a user picture"
-msgstr ""
-
-#: ./templates/default/entity/User/edit.tpl.php:37
-msgid "Your name"
 msgstr ""
 
 #: ./templates/default/entity/User/edit.tpl.php:49
@@ -1375,108 +1726,12 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: ./templates/default/entity/annotations/mentions.tpl.php:18
-msgid "Mentioned in"
+#: ./templates/default/entity/User.tpl.php:61
+msgid "A profile helps you describe yourself to other people on the site and on the web. You haven't described yourself yet."
 msgstr ""
 
-#: ./templates/default/entity/annotations/likes.tpl.php:24
-msgid "liked this post"
-msgstr ""
-
-#: ./templates/default/entity/annotations/rsvps.tpl.php:38
-msgid "Attending"
-msgstr ""
-
-#: ./templates/default/entity/annotations/rsvps.tpl.php:41
-msgid "Maybe attending"
-msgstr ""
-
-#: ./templates/default/entity/annotations/rsvps.tpl.php:44
-msgid "Not attending"
-msgstr ""
-
-#: ./templates/default/entity/annotations/rsvps.tpl.php:47
-msgid "Other responses"
-msgstr ""
-
-#: ./templates/default/entity/annotations/shares.tpl.php:21
-msgid "reshared this post"
-msgstr ""
-
-#: ./templates/default/entity/annotations/comment/main.tpl.php:16
-msgid "Add a comment ..."
-msgstr ""
-
-#: ./templates/default/entity/annotations/comment/main.tpl.php:21
-msgid "Leave Comment"
-msgstr ""
-
-#: ./templates/default/settings-shell/toolbar/logged-in.tpl.php:4
-msgid "Notifications"
-msgstr ""
-
-#: ./templates/default/settings-shell/toolbar/logged-in.tpl.php:13
-msgid "Account Settings"
-msgstr ""
-
-#: ./templates/default/settings-shell/toolbar/logged-in.tpl.php:18
-msgid "Site Configuration"
-msgstr ""
-
-#: ./templates/default/settings-shell/nav.tpl.php:6
-msgid "Toggle navigation"
-msgstr ""
-
-#: ./templates/default/shell/pagination.tpl.php:28
-msgid "Newer"
-msgstr ""
-
-#: ./templates/default/shell/pagination.tpl.php:29
-msgid "Older"
-msgstr ""
-
-#: ./templates/default/shell/toolbar/content/all.tpl.php:4
-msgid "All content"
-msgstr ""
-
-#: ./templates/default/shell/toolbar/content/default.tpl.php:4
-msgid "Default content"
-msgstr ""
-
-#: ./templates/default/shell/toolbar/login.tpl.php:3
-msgid "Sign in"
-msgstr ""
-
-#: ./templates/default/shell/toolbar/content.tpl.php:26
-msgid "Filter content"
-msgstr ""
-
-#: ./templates/default/shell/toolbar/logout.tpl.php:1
-msgid "Sign out"
-msgstr ""
-
-#: ./templates/default/shell/toolbar/logged-in.tpl.php:16
-msgid "Profile"
-msgstr ""
-
-#: ./templates/default/shell/toolbar/logged-in.tpl.php:49
-msgid "Leave feedback"
-msgstr ""
-
-#: ./templates/default/shell/toolbar/logged-in.tpl.php:49
-msgid "Feedback"
-msgstr ""
-
-#: ./templates/default/shell/toolbar/register.tpl.php:1
-msgid "Register"
-msgstr ""
-
-#: ./templates/default/shell/toolbar/search.tpl.php:17
-msgid "Search"
-msgstr ""
-
-#: ./templates/default/shell/toolbar/main.tpl.php:1
-msgid "Skip to main content"
+#: ./templates/default/entity/User.tpl.php:62
+msgid "Click here to fill in your profile information."
 msgstr ""
 
 #: ./templates/default/file/picker/image.tpl.php:19
@@ -1491,128 +1746,24 @@ msgstr ""
 msgid "Choose a different image"
 msgstr ""
 
-#: ./templates/default/robot/post.tpl.php:19
-msgid "Power down robots. I can take it from here."
+#: ./templates/default/following/add.tpl.php:3
+msgid "Add the address of a site to follow"
 msgstr ""
 
-#: ./templates/default/robot/wizard.tpl.php:7
-msgid "Check out my new @withknown site!"
+#: ./templates/default/following/confirm.tpl.php:7
+msgid "Follow"
 msgstr ""
 
-#: ./templates/default/robot/wizard.tpl.php:13
-msgid "Welcome to your new Known site! I'm Aleph, your very own welcome robot. Let's get started by <a href=\\"#\\" onclick=\\"event.preventDefault(); contentCreateForm('status', '{{baseurl}}status/edit/'); return false;\">adding your first status update</a>!"
+#: ./templates/default/following/confirm.tpl.php:12
+msgid "Here's the latest content."
 msgstr ""
 
-#: ./templates/default/robot/wizard.tpl.php:26
-msgid "Beep! That was a great update. Why not <a href=\\"{{facebookurl}}\\" target=\\"blank\\" onclick=\\"window.open('{{facebookurl}}', 'newwindow', 'width=600, height=350'); return false;\">share your new website on Facebook</a> and <a href=\"{{twitterurl}}\">Twitter</a> so your friends know about it?\n\nI bet you've got some great photos. <a href=\"#\" onclick=\"event.preventDefault(); contentCreateForm('photo', '{{baseurl}}photo/edit/'); return false;\">Try posting one</a>!"
+#: ./templates/default/following/home.tpl.php:13
+msgid "Follow another site"
 msgstr ""
 
-#: ./templates/default/robot/wizard.tpl.php:39
-msgid "Zeep! That was a great update. Why not <a href=\\"{{facebookurl}}\\" target=\\"blank\\" onclick=\\"window.open('{{facebookurl}}', 'newwindow', 'width=600, height=350'); return false;\">share your new website on Facebook</a> and <a href=\"{{twitterurl}}\">Twitter</a> so your friends know about it?\n\nI bet you've got some great photos. <a href=\"#\" onclick=\"event.preventDefault(); contentCreateForm('photo', '{{baseurl}}photo/edit/'); return false;\">Try posting one</a>!"
-msgstr ""
-
-#: ./templates/default/robot/wizard.tpl.php:52
-msgid "Beep boop! That was a great update. Why not <a href=\\"{{facebookurl}}\\" target=\\"blank\\" onclick=\\"window.open('{{facebookurl}}', 'newwindow', 'width=600, height=350'); return false;\">share your new website on Facebook</a> and <a href=\"{{twitterurl}}\">Twitter</a> so your friends know about it?\n\nI bet you've got some great photos. <a href=\"#\" onclick=\"event.preventDefault(); contentCreateForm('photo', '{{baseurl}}photo/edit/'); return false;\">Try posting one</a>!"
-msgstr ""
-
-#: ./templates/default/robot/wizard.tpl.php:57
-msgid "Beepity boop! That was a great picture. Did you see that you can also <a href=\\"{{userurl}}/edit\\">update your profile</a>?"
-msgstr ""
-
-#: ./templates/default/robot/wizard.tpl.php:62
-msgid "Boopity beep! Did you see that you can also <a href=\\"{{userurl}}/edit\\">update your profile</a>?"
-msgstr ""
-
-#: ./templates/default/robot/wizard.tpl.php:75
-msgid "01011001 01101111 00100000 01111001 01101111 00100000 01111001 01101111 \n\nThat's how you say hello where I come from. I wanted to remind you that you can also <a href=\\"{{baseurl}}admin/themes/\\">change the theme of your site</a>. If you ever have feedback, you can <a href=\\"{{baseurl}}account/settings/feedback/\\">send a message to my human creators</a>."
-msgstr ""
-
-#: ./templates/default/pages/500.tpl.php:6
-msgid "Something went wrong."
-msgstr ""
-
-#: ./templates/default/pages/500.tpl.php:15
-msgid "<a href=\"#\" onclick=\"window.history.back();\">Click here to try again</a> or <a href=\"%s\">click here to go back to the homepage</a>."
-msgstr ""
-
-#: ./templates/default/pages/500.tpl.php:19
-msgid "Click here to see the technical details."
-msgstr ""
-
-#: ./templates/default/pages/500.tpl.php:32
-msgid "Oh no! Something went wrong."
-msgstr ""
-
-#: ./templates/default/pages/404.tpl.php:5
-msgid "Oops! We couldn't find it."
-msgstr ""
-
-#: ./templates/default/pages/404.tpl.php:7
-msgid "Whatever you were looking for, it's not here. It might have been moved, deleted, or it doesn't exist. Or the robots ate it. That's always a possibility too."
-msgstr ""
-
-#: ./templates/default/pages/404.tpl.php:8
-msgid "Maybe you'll find something interesting if you head back to the <a href=\\"%s\\">%s homepage</a>."
-msgstr ""
-
-#: ./templates/default/pages/403.tpl.php:7
-msgid "Click here to log in."
-msgstr ""
-
-#: ./templates/default/pages/403.tpl.php:18
-msgid "Hold on. You don't have access to this content."
-msgstr ""
-
-#: ./templates/default/pages/403.tpl.php:20
-msgid "It's nothing personal. You just don't have the right permissions to see what's here."
-msgstr ""
-
-#: ./templates/default/pages/403.tpl.php:22
-msgid "Find something else to view on the <a href=\"%s\">%s homepage</a>."
-msgstr ""
-
-#: ./templates/default/pages/home/nocontent.tpl.php:10
-msgid "We couldn't find anything that matches your search."
-msgstr ""
-
-#: ./templates/default/pages/410.tpl.php:6
-msgid "Sorry, this content isn't here anymore."
-msgstr ""
-
-#: ./templates/default/pages/410.tpl.php:8
-msgid "You may be wondering where it went, but we can't tell you. It's a secret."
-msgstr ""
-
-#: ./templates/default/pages/410.tpl.php:10
-msgid "Maybe you'd like to head back to the <a href=\\"%s\\">%s homepage</a> instead."
-msgstr ""
-
-#: ./templates/default/forms/usersearch.tpl.php:24
-msgid "Search by name, email address, or username"
-msgstr ""
-
-#: ./templates/default/forms/usersearch.tpl.php:79
-msgid "By creation date"
-msgstr ""
-
-#: ./templates/default/forms/usersearch.tpl.php:80
-msgid "By name"
-msgstr ""
-
-#: ./templates/default/forms/usersearch.tpl.php:89
-msgid "Ascending"
-msgstr ""
-
-#: ./templates/default/forms/usersearch.tpl.php:90
-msgid "Descending"
-msgstr ""
-
-#: ./templates/default/forms/usersearch.tpl.php:102
-msgid "Prev"
-msgstr ""
-
-#: ./templates/default/forms/usersearch.tpl.php:103
-msgid "Next"
+#: ./templates/default/following/home.tpl.php:31
+msgid "You're not following anyone yet."
 msgstr ""
 
 #: ./templates/default/forms/components/usersearch/user.tpl.php:27
@@ -1621,10 +1772,6 @@ msgstr ""
 
 #: ./templates/default/forms/components/usersearch/user.tpl.php:35
 msgid "Last update posted"
-msgstr ""
-
-#: ./templates/default/forms/components/usersearch/user.tpl.php:45
-msgid "Never"
 msgstr ""
 
 #: ./templates/default/forms/components/usersearch/user.tpl.php:57
@@ -1637,10 +1784,6 @@ msgstr ""
 
 #: ./templates/default/forms/components/usersearch/user.tpl.php:65
 msgid "Remove rights"
-msgstr ""
-
-#: ./templates/default/forms/components/usersearch/user.tpl.php:67
-msgid "Yes"
 msgstr ""
 
 #: ./templates/default/forms/components/usersearch/user.tpl.php:71
@@ -1671,14 +1814,6 @@ msgstr ""
 msgid "Are you sure? This will delete this user and all their content."
 msgstr ""
 
-#: ./templates/default/forms/input/richtext.tpl.php:21
-msgid "Share something brilliant..."
-msgstr ""
-
-#: ./templates/default/forms/input/richtext.tpl.php:49
-msgid "Please complete this field."
-msgstr ""
-
 #: ./templates/default/forms/input/image-file.tpl.php:58
 msgid "Are you sure you want to permanently delete this?"
 msgstr ""
@@ -1695,360 +1830,40 @@ msgstr ""
 msgid "Add photo"
 msgstr ""
 
-#: ./templates/default/account/login.tpl.php:4
-msgid "Welcome back!"
+#: ./templates/default/forms/input/longtext.tpl.php:21
+msgid "Share something brilliant..."
 msgstr ""
 
-#: ./templates/default/account/login.tpl.php:14
-msgid "Your email address or username"
+#: ./templates/default/forms/input/richtext.tpl.php:49
+msgid "Please complete this field."
 msgstr ""
 
-#: ./templates/default/account/login.tpl.php:17
-msgid "Password"
+#: ./templates/default/forms/usersearch.tpl.php:24
+msgid "Search by name, email address, or username"
 msgstr ""
 
-#: ./templates/default/account/login.tpl.php:36
-msgid "New here? Register for an account."
+#: ./templates/default/forms/usersearch.tpl.php:79
+msgid "By creation date"
 msgstr ""
 
-#: ./templates/default/account/login.tpl.php:40
-msgid "Forgot your password?"
+#: ./templates/default/forms/usersearch.tpl.php:80
+msgid "By name"
 msgstr ""
 
-#: ./templates/default/account/settings.tpl.php:14
-msgid "Change your user account settings here. You may also want to <a href=\"%s\">edit your profile</a>."
+#: ./templates/default/forms/usersearch.tpl.php:89
+msgid "Ascending"
 msgstr ""
 
-#: ./templates/default/account/settings.tpl.php:39
-msgid "Your email address"
+#: ./templates/default/forms/usersearch.tpl.php:90
+msgid "Descending"
 msgstr ""
 
-#: ./templates/default/account/settings.tpl.php:45
-msgid "Site notifications will be sent here."
+#: ./templates/default/forms/usersearch.tpl.php:102
+msgid "Prev"
 msgstr ""
 
-#: ./templates/default/account/settings.tpl.php:51
-msgid "Your password"
-msgstr ""
-
-#: ./templates/default/account/settings.tpl.php:58
-msgid "Leave this blank if you don't want to change it."
-msgstr ""
-
-#: ./templates/default/account/settings.tpl.php:64
-msgid "Your timezone"
-msgstr ""
-
-#: ./templates/default/account/settings.tpl.php:73
-msgid "Timezone"
-msgstr ""
-
-#: ./templates/default/account/settings.tpl.php:78
-msgid "Specify your timezone."
-msgstr ""
-
-#: ./templates/default/account/menu.tpl.php:3
-msgid "Settings"
-msgstr ""
-
-#: ./templates/default/account/menu.tpl.php:6
-msgid "Email notifications"
-msgstr ""
-
-#: ./templates/default/account/menu.tpl.php:8
-msgid "Tools and Apps"
-msgstr ""
-
-#: ./templates/default/account/menu.tpl.php:11
-msgid "Export Data"
-msgstr ""
-
-#: ./templates/default/account/notifications.tpl.php:6
-msgid "The notifications screen shows you who has interacted with your content."
-msgstr ""
-
-#: ./templates/default/account/notifications.tpl.php:25
-msgid "You don't have any notifications yet. But we love you anyway!"
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:13
-msgid "Bookmarklet"
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:22
-msgid "The Known bookmarklet is the best way to save links, reply to posts, and share articles."
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:23
-msgid "Just drag the bookmarklet button below into your browser's Bookmark Bar."
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:42
-msgid "Don't see a bookmarks bar?"
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:45
-msgid "Sometimes web browsers have their bookmarked links bar hidden by default. Here's how to reveal it:"
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:47
-msgid "Chrome"
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:47
-msgid "Select <em>Always Show Bookmarks Bar</em> from the <em>View</em> menu."
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:48
-msgid "Firefox"
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:48
-msgid "Select <em>View</em>, then <em>Toolbars</em>, and make sure"
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:49
-msgid "Bookmarks Toolbar"
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:49
-msgid "is checked."
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:50
-msgid "Internet Explorer"
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:50
-msgid "Select <em>Tools</em>, then make sure <em>Favorites Bar</em> is checked."
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:65
-msgid "Your API key"
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:76
-msgid "Revoke"
-msgstr ""
-
-#: ./templates/default/account/settings/tools.tpl.php:76
-msgid "Revoking this key will mean you must update any applications that use this key!"
-msgstr ""
-
-#: ./templates/default/account/settings/notifications.tpl.php:17
-msgid "Set how you'd like to be notified when someone stars or comments on your content."
-msgstr ""
-
-#: ./templates/default/account/settings/notifications.tpl.php:26
-msgid "Send email notifications"
-msgstr ""
-
-#: ./templates/default/account/settings/notifications.tpl.php:34
-msgid "Whenever someone interacts with my content"
-msgstr ""
-
-#: ./templates/default/account/settings/notifications.tpl.php:44
-msgid "Only when someone comments on my content"
-msgstr ""
-
-#: ./templates/default/account/settings/notifications.tpl.php:63
-msgid "Ignored Domains"
-msgstr ""
-
-#: ./templates/default/account/settings/notifications.tpl.php:64
-msgid "Do not send notifications for interactions originating from these domains (one domain per line)"
-msgstr ""
-
-#: ./templates/default/account/settings/feedback.tpl.php:5
-msgid "Share your feedback"
-msgstr ""
-
-#: ./templates/default/account/settings/feedback.tpl.php:9
-msgid "Want to share something with the Known team? We'd love to read your thoughts, suggestions, or ideas. We will personally read all of your feedback."
-msgstr ""
-
-#: ./templates/default/account/settings/feedback.tpl.php:21
-msgid "From"
-msgstr ""
-
-#: ./templates/default/account/settings/feedback.tpl.php:29
-msgid "Feedback for the Known team"
-msgstr ""
-
-#: ./templates/default/account/settings/feedback.tpl.php:32
-msgid "Let us know what you think."
-msgstr ""
-
-#: ./templates/default/account/settings/feedback.tpl.php:37
-msgid "Send feedback"
-msgstr ""
-
-#: ./templates/default/account/settings/following.tpl.php:5
-msgid "Following..."
-msgstr ""
-
-#: ./templates/default/account/settings/following.tpl.php:11
-msgid "Manage your subscriptions here. These users can also be given access to private content you produce on your site."
-msgstr ""
-
-#: ./templates/default/account/settings/following.tpl.php:16
-msgid "Use this bookmarklet to make is easy to add new friends."
-msgstr ""
-
-#: ./templates/default/account/settings/feedback/confirm.tpl.php:5
-msgid "Message received!"
-msgstr ""
-
-#: ./templates/default/account/settings/feedback/confirm.tpl.php:9
-msgid "Thanks for sending along your thoughts. We'll read them right away."
-msgstr ""
-
-#: ./templates/default/account/settings/feedback/confirm.tpl.php:22
-msgid "Feedback is a gift.  For more information about Known, <a href=\"https://withknown.com/\">please visit our homepage</a>"
-msgstr ""
-
-#: ./templates/default/account/settings/following/bookmarklet.tpl.php:3
-msgid "Add as friend..."
-msgstr ""
-
-#: ./templates/default/account/settings/following/mf2user.tpl.php:55
-msgid "Name"
-msgstr ""
-
-#: ./templates/default/account/settings/following/mf2user.tpl.php:64
-msgid "Nickname"
-msgstr ""
-
-#: ./templates/default/account/settings/following/mf2user.tpl.php:67
-msgid "Handle (for your reference)"
-msgstr ""
-
-#: ./templates/default/account/settings/following/mf2user.tpl.php:82
-msgid "Profile URL"
-msgstr ""
-
-#: ./templates/default/account/password/reset.tpl.php:5
-msgid "Reset your password"
-msgstr ""
-
-#: ./templates/default/account/password/reset.tpl.php:7
-msgid "To change your password, enter your new password below:"
-msgstr ""
-
-#: ./templates/default/account/password/reset.tpl.php:17
-msgid "The address associated with your %s account."
-msgstr ""
-
-#: ./templates/default/account/password/reset.tpl.php:23
-msgid "New password (7 characters or more)"
-msgstr ""
-
-#: ./templates/default/account/password/reset.tpl.php:29
-msgid "Retype password"
-msgstr ""
-
-#: ./templates/default/account/password/reset.tpl.php:30
-msgid "We ask you to enter the password twice to protect against typos."
-msgstr ""
-
-#: ./templates/default/account/password/reset.tpl.php:37
-msgid "Reset password"
-msgstr ""
-
-#: ./templates/default/account/password/sent.tpl.php:5
-msgid "Your password reset email has been sent"
-msgstr ""
-
-#: ./templates/default/account/password/sent.tpl.php:15
-msgid "Check your inbox! You'll find an email containing a special link that will help you reset your password."
-msgstr ""
-
-#: ./templates/default/account/password/sent.tpl.php:18
-msgid "Did you remember your password? That's okay too. You can <a href=\\"%s\\">click here to sign in.</a>"
-msgstr ""
-
-#: ./templates/default/account/password.tpl.php:9
-msgid "Forgot your password? Don't worry! It happens to the best of us."
-msgstr ""
-
-#: ./templates/default/account/password.tpl.php:10
-msgid "Just enter the email address associated with your %s account below, and we'll send you a top secret link to your email account so that you can create a new password."
-msgstr ""
-
-#: ./templates/default/account/password.tpl.php:27
-msgid "Send password reset email"
-msgstr ""
-
-#: ./templates/default/account/export.tpl.php:8
-msgid "Export your data"
-msgstr ""
-
-#: ./templates/default/account/export.tpl.php:19
-msgid "You can download an RSS version of everything you've posted on this site. This file is suitable for importing into content management systems like WordPress, or another Known site."
-msgstr ""
-
-#: ./templates/default/account/export.tpl.php:32
-msgid "Platforms like WordPress may assume that all your posts should be displayed publicly. In order to protect your privacy, you may wish to just download your public posts."
-msgstr ""
-
-#: ./templates/default/account/export.tpl.php:36
-msgid "Download RSS Feed"
-msgstr ""
-
-#: ./templates/default/account/register.tpl.php:5
-msgid "Hello there!"
-msgstr ""
-
-#: ./templates/default/account/register.tpl.php:7
-msgid "Create a new account to get started."
-msgstr ""
-
-#: ./templates/default/account/register.tpl.php:20
-msgid "Choose a handle"
-msgstr ""
-
-#: ./templates/default/account/register.tpl.php:21
-msgid "Handles identify you throughout the site. Something simple is best: for example, <em>janedoe</em>."
-msgstr ""
-
-#: ./templates/default/account/register.tpl.php:23
-msgid "username"
-msgstr ""
-
-#: ./templates/default/account/register.tpl.php:33
-msgid "Create a password"
-msgstr ""
-
-#: ./templates/default/account/register.tpl.php:34
-msgid "At least 7 characters please."
-msgstr ""
-
-#: ./templates/default/account/register.tpl.php:37
-msgid "secret-password"
-msgstr ""
-
-#: ./templates/default/account/register.tpl.php:42
-msgid "Your password again"
-msgstr ""
-
-#: ./templates/default/account/register.tpl.php:49
-msgid "Create Account"
-msgstr ""
-
-#: ./templates/default/onboarding/connect.tpl.php:3
-msgid "Share to social"
-msgstr ""
-
-#: ./templates/default/onboarding/connect.tpl.php:6
-msgid "Connect your accounts to easily share content with people across the web."
-msgstr ""
-
-#: ./templates/default/onboarding/connect.tpl.php:14
-msgid "Continue"
-msgstr ""
-
-#: ./templates/default/onboarding/connect.tpl.php:19
-msgid "Don't worry, you can always connect these later."
+#: ./templates/default/forms/usersearch.tpl.php:103
+msgid "Next"
 msgstr ""
 
 #: ./templates/default/onboarding/begin.tpl.php:8
@@ -2075,16 +1890,20 @@ msgstr ""
 msgid "Already have an account? Sign in."
 msgstr ""
 
-#: ./templates/default/onboarding/register.tpl.php:13
-msgid "Choose a username"
+#: ./templates/default/onboarding/connect.tpl.php:3
+msgid "Share to social"
 msgstr ""
 
-#: ./templates/default/onboarding/register.tpl.php:26
-msgid "(at least 7 characters please)"
+#: ./templates/default/onboarding/connect.tpl.php:6
+msgid "Connect your accounts to easily share content with people across the web."
 msgstr ""
 
-#: ./templates/default/onboarding/profile.tpl.php:3
-msgid "Create your profile"
+#: ./templates/default/onboarding/connect.tpl.php:14
+msgid "Continue"
+msgstr ""
+
+#: ./templates/default/onboarding/connect.tpl.php:19
+msgid "Don't worry, you can always connect these later."
 msgstr ""
 
 #: ./templates/default/onboarding/profile.tpl.php:16
@@ -2115,28 +1934,164 @@ msgstr ""
 msgid "Add another website"
 msgstr ""
 
-#: ./templates/default/following/home.tpl.php:3
-msgid "Following"
+#: ./templates/default/onboarding/register.tpl.php:13
+msgid "Choose a username"
 msgstr ""
 
-#: ./templates/default/following/home.tpl.php:13
-msgid "Follow another site"
+#: ./templates/default/onboarding/register.tpl.php:26
+msgid "(at least 7 characters please)"
 msgstr ""
 
-#: ./templates/default/following/home.tpl.php:31
-msgid "You're not following anyone yet."
+#: ./templates/default/pages/403.tpl.php:7
+msgid "Click here to log in."
 msgstr ""
 
-#: ./templates/default/following/confirm.tpl.php:7
-msgid "Follow"
+#: ./templates/default/pages/403.tpl.php:18
+msgid "Hold on. You don't have access to this content."
 msgstr ""
 
-#: ./templates/default/following/confirm.tpl.php:12
-msgid "Here's the latest content."
+#: ./templates/default/pages/403.tpl.php:20
+msgid "It's nothing personal. You just don't have the right permissions to see what's here."
 msgstr ""
 
-#: ./templates/default/following/add.tpl.php:3
-msgid "Add the address of a site to follow"
+#: ./templates/default/pages/403.tpl.php:22
+msgid "Find something else to view on the <a href=\"%s\">%s homepage</a>."
+msgstr ""
+
+#: ./templates/default/pages/404.tpl.php:5
+msgid "Oops! We couldn't find it."
+msgstr ""
+
+#: ./templates/default/pages/404.tpl.php:7
+msgid "Whatever you were looking for, it's not here. It might have been moved, deleted, or it doesn't exist. Or the robots ate it. That's always a possibility too."
+msgstr ""
+
+#: ./templates/default/pages/404.tpl.php:8
+msgid "Maybe you'll find something interesting if you head back to the <a href=\"%s\">%s homepage</a>."
+msgstr ""
+
+#: ./templates/default/pages/410.tpl.php:6
+msgid "Sorry, this content isn't here anymore."
+msgstr ""
+
+#: ./templates/default/pages/410.tpl.php:8
+msgid "You may be wondering where it went, but we can't tell you. It's a secret."
+msgstr ""
+
+#: ./templates/default/pages/410.tpl.php:10
+msgid "Maybe you'd like to head back to the <a href=\"%s\">%s homepage</a> instead."
+msgstr ""
+
+#: ./templates/default/pages/500.tpl.php:15
+msgid "<a href=\"#\" onclick=\"window.history.back();\">Click here to try again</a> or <a href=\"%s\">click here to go back to the homepage</a>."
+msgstr ""
+
+#: ./templates/default/pages/500.tpl.php:19
+msgid "Click here to see the technical details."
+msgstr ""
+
+#: ./templates/default/pages/500.tpl.php:32
+msgid "Oh no! Something went wrong."
+msgstr ""
+
+#: ./templates/default/pages/home/nocontent.tpl.php:10
+msgid "We couldn't find anything that matches your search."
+msgstr ""
+
+#: ./templates/default/robot/post.tpl.php:19
+msgid "Power down robots. I can take it from here."
+msgstr ""
+
+#: ./templates/default/robot/wizard.tpl.php:7
+msgid "Check out my new @withknown site!"
+msgstr ""
+
+#: ./templates/default/robot/wizard.tpl.php:9
+msgid " That was a great update. Why not <%s>share your new website on Facebook</a> and <a href=\"%s\">Twitter</a> so your friends know about it?\n\nI bet you've got some great photos. <%s>Try posting one</a>!"
+msgstr ""
+
+#: ./templates/default/robot/wizard.tpl.php:20
+msgid "Welcome to your new Known site! I'm Aleph, your very own welcome robot. Let's get started by <%s>adding your first status update</a>!"
+msgstr ""
+
+#: ./templates/default/robot/wizard.tpl.php:28
+msgid "Beep!"
+msgstr ""
+
+#: ./templates/default/robot/wizard.tpl.php:34
+msgid "Zeep!"
+msgstr ""
+
+#: ./templates/default/robot/wizard.tpl.php:40
+msgid "Beep boop!"
+msgstr ""
+
+#: ./templates/default/robot/wizard.tpl.php:47
+msgid "Beepity boop! That was a great picture. Did you see that you can also <a href=\"{{userurl}}/edit\">update your profile</a>?"
+msgstr ""
+
+#: ./templates/default/robot/wizard.tpl.php:52
+msgid "Boopity beep! Did you see that you can also <a href=\"{{userurl}}/edit\">update your profile</a>?"
+msgstr ""
+
+#: ./templates/default/robot/wizard.tpl.php:65
+msgid "01011001 01101111 00100000 01111001 01101111 00100000 01111001 01101111 \n\nThat's how you say hello where I come from. I wanted to remind you that you can also <a href=\"{{baseurl}}admin/themes/\">change the theme of your site</a>. If you ever have feedback, you can <a href=\"{{baseurl}}account/settings/feedback/\">send a message to my human creators</a>."
+msgstr ""
+
+#: ./templates/default/settings-shell/nav.tpl.php:6
+msgid "Toggle navigation"
+msgstr ""
+
+#: ./templates/default/settings-shell/toolbar/logged-in.tpl.php:18
+msgid "Site Configuration"
+msgstr ""
+
+#: ./templates/default/shell/pagination.tpl.php:28
+msgid "Newer"
+msgstr ""
+
+#: ./templates/default/shell/pagination.tpl.php:29
+msgid "Older"
+msgstr ""
+
+#: ./templates/default/shell/toolbar/content/all.tpl.php:4
+msgid "All content"
+msgstr ""
+
+#: ./templates/default/shell/toolbar/content/default.tpl.php:4
+msgid "Default content"
+msgstr ""
+
+#: ./templates/default/shell/toolbar/content.tpl.php:26
+msgid "Filter content"
+msgstr ""
+
+#: ./templates/default/shell/toolbar/logged-in.tpl.php:16
+msgid "Profile"
+msgstr ""
+
+#: ./templates/default/shell/toolbar/logged-in.tpl.php:49
+msgid "Leave feedback"
+msgstr ""
+
+#: ./templates/default/shell/toolbar/logged-in.tpl.php:49
+msgid "Feedback"
+msgstr ""
+
+#: ./templates/default/shell/toolbar/logout.tpl.php:1
+msgid "Sign out"
+msgstr ""
+
+#: ./templates/default/shell/toolbar/main.tpl.php:1
+msgid "Skip to main content"
+msgstr ""
+
+#: ./templates/default/shell/toolbar/register.tpl.php:1
+msgid "Register"
+msgstr ""
+
+#: ./templates/default/shell/toolbar/search.tpl.php:17
+msgid "Search"
 msgstr ""
 
 #: ./known.php:110

--- a/templates/default/account/export.tpl.php
+++ b/templates/default/account/export.tpl.php
@@ -24,7 +24,9 @@
                     <p><label class="control-label" for="allposts"><strong><?php echo \Idno\Core\Idno::site()->language()->_('Include private posts?'); ?></strong></label></p>
                 </div>
                 <div class="config-toggle col-md-2">
-                    <input type="checkbox" data-toggle="toggle" data-onstyle="info" data-on="Yes" data-off="No"
+                    <input type="checkbox" data-toggle="toggle" data-onstyle="info"
+                           data-on="<?php echo \Idno\Core\Idno::site()->language()->_('Yes'); ?>"
+                           data-off="<?php echo \Idno\Core\Idno::site()->language()->_('No'); ?>"
                            name="allposts" id="allposts"
                            value="0">
                 </div>

--- a/templates/default/admin/export.tpl.php
+++ b/templates/default/admin/export.tpl.php
@@ -18,14 +18,16 @@
         </p>
         <h3>
             <?php echo \Idno\Core\Idno::site()->language()->_('Generate RSS file'); ?>
-        </h3>        
+        </h3>
         <form action="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>admin/export/rss" method="post">
             <div class="row">
                 <div class="col-md-3">
                     <p><label class="control-label" for="allposts"><strong><?php echo \Idno\Core\Idno::site()->language()->_('Include private posts?'); ?></strong></label></p>
                 </div>
                 <div class="config-toggle col-md-3">
-                    <input type="checkbox" data-toggle="toggle" data-onstyle="info" data-on="Yes" data-off="No"
+                    <input type="checkbox" data-toggle="toggle" data-onstyle="info"
+                           data-on="<?php echo \Idno\Core\Idno::site()->language()->_('Yes'); ?>"
+                           data-off="<?php echo \Idno\Core\Idno::site()->language()->_('No'); ?>"
                            name="allposts" id="allposts"
                            value="1">
                 </div>

--- a/templates/default/admin/home.tpl.php
+++ b/templates/default/admin/home.tpl.php
@@ -76,11 +76,13 @@
 
             <div class="row">
                 <div class="col-md-2">
-                    <p><label class="control-label" for="single_user"><strong>Single user</strong></label>
+                    <p><label class="control-label" for="single_user"><strong><?php echo \Idno\Core\Idno::site()->language()->_('Single user'); ?></strong></label>
                     </p>
                 </div>
                 <div class="config-toggle col-md-4">
-                    <input type="checkbox" data-toggle="toggle" data-onstyle="info" data-on="Yes" data-off="No"
+                    <input type="checkbox" data-toggle="toggle" data-onstyle="info"
+                           data-on="<?php echo \Idno\Core\Idno::site()->language()->_('Yes'); ?>"
+                           data-off="<?php echo \Idno\Core\Idno::site()->language()->_('No'); ?>"
                            value="true" id="single_user"
                            name="single_user" <?php if (\Idno\Core\Idno::site()->config()->single_user) echo 'checked'; ?>>
                 </div>
@@ -96,7 +98,7 @@
 
             <div class="row">
                 <div class="col-md-2">
-                    <p><label class="control-label" for="permalink_structure"><strong>Permalink Structure</strong></label></p>
+                    <p><label class="control-label" for="permalink_structure"><strong><?php echo \Idno\Core\Idno::site()->language()->_('Permalink Structure'); ?></strong></label></p>
                 </div>
                 <div class="col-md-4">
                     <?php foreach (array(
@@ -136,7 +138,9 @@
                     <p><label class="control-label" for="open_registration"><strong><?php echo \Idno\Core\Idno::site()->language()->_('Allow registration'); ?></strong></label></p>
                 </div>
                 <div class="config-toggle col-md-4">
-                    <input type="checkbox" data-toggle="toggle" data-onstyle="info" data-on="Yes" data-off="No"
+                    <input type="checkbox" data-toggle="toggle" data-onstyle="info"
+                           data-on="<?php echo \Idno\Core\Idno::site()->language()->_('Yes'); ?>"
+                           data-off="<?php echo \Idno\Core\Idno::site()->language()->_('No'); ?>"
                            name="open_registration"
                            value="true" <?php if (\Idno\Core\Idno::site()->config()->open_registration == true) echo 'checked'; ?>>
                 </div>
@@ -157,7 +161,9 @@
                             <p><label class="control-label" for="walled_garden"><strong><?php echo \Idno\Core\Idno::site()->language()->_('Make site private'); ?></strong></label></p>
                         </div>
                         <div class="config-toggle col-md-4">
-                            <input type="checkbox" data-toggle="toggle" data-onstyle="info" data-on="Yes" data-off="No"
+                            <input type="checkbox" data-toggle="toggle" data-onstyle="info"
+                           data-on="<?php echo \Idno\Core\Idno::site()->language()->_('Yes'); ?>"
+                           data-off="<?php echo \Idno\Core\Idno::site()->language()->_('No'); ?>"
                                    name="walled_garden" id="walled_garden"
                                    value="true" <?php if (\Idno\Core\Idno::site()->config()->walled_garden == true) echo 'checked'; ?>>
                         </div>
@@ -183,7 +189,9 @@
                             </p>
                         </div>
                         <div class="config-toggle col-md-4">
-                            <input type="checkbox" data-toggle="toggle" data-onstyle="info" data-on="Yes" data-off="No"
+                            <input type="checkbox" data-toggle="toggle" data-onstyle="info"
+                           data-on="<?php echo \Idno\Core\Idno::site()->language()->_('Yes'); ?>"
+                           data-off="<?php echo \Idno\Core\Idno::site()->language()->_('No'); ?>"
                                    name="show_privacy" id="show_privacy"
                                    value="true" <?php if (\Idno\Core\Idno::site()->config()->show_privacy == true) echo 'checked'; ?>>
                         </div>
@@ -234,7 +242,9 @@
                     </p>
                 </div>
                 <div class="config-toggle col-md-4">
-                    <input type="checkbox" data-toggle="toggle" data-onstyle="info" data-on="Yes" data-off="No"
+                    <input type="checkbox" data-toggle="toggle" data-onstyle="info"
+                           data-on="<?php echo \Idno\Core\Idno::site()->language()->_('Yes'); ?>"
+                           data-off="<?php echo \Idno\Core\Idno::site()->language()->_('No'); ?>"
                            value="true" id="user_avatar_favicons"
                            name="user_avatar_favicons" <?php if (\Idno\Core\Idno::site()->config()->user_avatar_favicons == true) echo 'checked'; ?>>
                 </div>
@@ -250,7 +260,9 @@
                     <p><label class="control-label" for="include_permalinks"><strong><?php echo \Idno\Core\Idno::site()->language()->_('Include permalinks'); ?></strong></label></p>
                 </div>
                 <div class="config-toggle col-md-4">
-                    <input type="checkbox" data-toggle="toggle" data-onstyle="info" data-on="Yes" data-off="No"
+                    <input type="checkbox" data-toggle="toggle" data-onstyle="info"
+                           data-on="<?php echo \Idno\Core\Idno::site()->language()->_('Yes'); ?>"
+                           data-off="<?php echo \Idno\Core\Idno::site()->language()->_('No'); ?>"
                            name="indieweb_reference" id="include_permalinks"
                            value="true" <?php if (\Idno\Core\Idno::site()->config()->indieweb_reference == true) echo 'checked'; ?>>
                 </div>

--- a/templates/default/admin/homepage.tpl.php
+++ b/templates/default/admin/homepage.tpl.php
@@ -41,7 +41,10 @@
                                     <div class="config-toggle col-md-4">
                                         
                                         <input type="checkbox" data-toggle="toggle" data-onstyle="info" name="default_feed_content[]"
-                                               
+
+                           data-on="<?php echo \Idno\Core\Idno::site()->language()->_('On'); ?>"
+                           data-off="<?php echo \Idno\Core\Idno::site()->language()->_('Off'); ?>"
+
                                                value="<?php echo $content_type->getCategoryTitleSlug() ?>" <?php
 
                                                 if (in_array($content_type->getEntityClass(), $vars['default_content_types'])) {


### PR DESCRIPTION
## Here's what I fixed or added:

* Fixed missing, and localisation tool-"breaking" localised strings

* Added localisation hooks for yes/no, on/off

These checkins localise bootstrap toggle controls (plus some other localisable strings (in admin/home.tpl.php), fix one prone to creating a truncated entry in the gettext template
(Pages/Account/Register.php & Pages/Admin/Users.php))

## Here's why I did it:

Fixed it before but hadn't fixed localisation tool at the time

## Checklist:

- [?] This pull request addresses a single issue
- [?] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [/] I've tested my code in-browser
