### PR TITLE
Localise password reset

### DIFF
--- a/languages/source/known.pot
+++ b/languages/source/known.pot
@@ -2130,6 +2130,14 @@ msgstr ""
 msgid "If you have any questions at all, please don't hesitate to contact us by sending an email to %s"
 msgstr ""
 
+#: ./templates/email/account/password.tpl.php:6
+msgid "We heard you forgot your password. Don't worry. It happens to the best of us."
+msgstr ""
+
+#: ./templates/email/account/password.tpl.php:8
+msgid "You can reset your password by clicking the link below (or copy and paste it into your browser)."
+msgstr ""
+
 #: ./templates/email/shell.tpl.php:72
 msgid "Powered by"
 msgstr ""

--- a/templates/email-text/account/password.tpl.php
+++ b/templates/email-text/account/password.tpl.php
@@ -1,8 +1,8 @@
-<?php $joinus = \Idno\Core\Idno::site()->language()->_('Forgot your password?');
+<?php $subject = \Idno\Core\Idno::site()->language()->_('Forgot your password?');
 
-    echo $joinus . "\n";
+    echo $subject . "\n";
 
-    $underline = mb_strlen($joinus);
+    $underline = mb_strlen($subject);
 
     for($u = 0; $u < $underline; $u++) {
         echo '=';

--- a/templates/email-text/account/password.tpl.php
+++ b/templates/email-text/account/password.tpl.php
@@ -1,8 +1,20 @@
-Forgot your password?
-=====================
+<?php $joinus = \Idno\Core\Idno::site()->language()->_('Forgot your password?');
 
-We heard you forgot your password. Don't worry. It happens to the best of us.
+    echo $joinus . "\n";
 
-You can reset your password by clicking the link below (or copy and paste it into your browser).
+    $underline = mb_strlen($joinus);
+
+    for($u = 0; $u < $underline; $u++) {
+        echo '=';
+    }
+
+ ?>
+
+
+<?php echo \Idno\Core\Idno::site()->language()->_('We heard you forgot your password. Don\'t worry. It happens to the best of us.') ?>
+
+
+<?php echo \Idno\Core\Idno::site()->language()->_('You can reset your password by clicking the link below (or copy and paste it into your browser).') ?>
+
 
 <?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>account/password/reset/?email=<?php echo urlencode($vars['email']) ?>&code=<?php echo urlencode($vars['code']);

--- a/templates/email/account/password.tpl.php
+++ b/templates/email/account/password.tpl.php
@@ -1,11 +1,11 @@
 <div style="font-weight: bold; font-size: 30px; line-height: 32px; color: #333" align="center">
-    Forgot your password?
+    <?php echo \Idno\Core\Idno::site()->language()->_('Forgot your password?') ?>
 </div><br>
 <hr/>
 <br>
-We heard you forgot your password. Don't worry. It happens to the best of us.
+<?php echo \Idno\Core\Idno::site()->language()->_("We heard you forgot your password. Don't worry. It happens to the best of us.") ?>
 <br><br>
-You can reset your password by clicking the link below (or copy and paste it into your browser).
+<?php echo \Idno\Core\Idno::site()->language()->_('You can reset your password by clicking the link below (or copy and paste it into your browser).') ?>
 <br><br>
 
 <a href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>account/password/reset/?email=<?php echo urlencode($vars['email']) ?>&code=<?php echo urlencode($vars['code']) ?>" style="color: #73b2e3; text-decoration: none;"><?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>account/password/reset/?email=<?php echo urlencode($vars['email']) ?>&code=<?php echo urlencode($vars['code']) ?></a>


### PR DESCRIPTION
## Here's what I fixed or added:

Changed email templates for password reset so that they are in the same localisation as the site when sent

## Here's why I did it:

## Checklist:

- [/] This pull request addresses a single issue
- [/] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [/] I've tested my code in-browser
