### PR TITLE
Fix typo in localisable string on line 16

### DIFF
--- a/templates/default/account/settings/following.tpl.php
+++ b/templates/default/account/settings/following.tpl.php
@@ -13,7 +13,7 @@
         </div>
     
     <div class="well">
-        <p><?php echo \Idno\Core\Idno::site()->language()->_('Use this bookmarklet to make is easy to add new friends.'); ?></p>
+        <p><?php echo \Idno\Core\Idno::site()->language()->_('Use this bookmarklet to make it easy to add new friends.'); ?></p>
     
         <?php echo $this->draw('account/settings/following/bookmarklet'); ?>
     </div>


### PR DESCRIPTION
## Here's what I fixed or added:

Replaced `is` with `it`

## Here's why I did it:

Phrase was incorrectly translating

## Checklist:

- [/] This pull request addresses a single issue
