### PR TITLE
MySQL warmup schema edits

### DIFF
--- a/warmup/schemas/mysql/2014100801.sql
+++ b/warmup/schemas/mysql/2014100801.sql
@@ -19,8 +19,7 @@ CREATE TABLE IF NOT EXISTS `reader` (
   PRIMARY KEY (`uuid`),
   UNIQUE KEY `_id` (`_id`),
   KEY `owner` (`owner`,`created`),
-  KEY `entity_subtype` (`entity_subtype`),
-  FULLTEXT KEY `search` (`search`)
+  KEY `entity_subtype` (`entity_subtype`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 UPDATE `versions` SET `value` = '2014100801' WHERE `label` = 'schema';

--- a/warmup/schemas/mysql/2019121401.sql
+++ b/warmup/schemas/mysql/2019121401.sql
@@ -2,8 +2,7 @@
 CREATE TABLE IF NOT EXISTS `entities_search` (
   `_id` varchar(32) NOT NULL,
   `search` longtext NOT NULL,
-  PRIMARY KEY (`_id`),
-  FULLTEXT KEY `search` (`search`)
+  PRIMARY KEY (`_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 INSERT INTO `entities_search` SELECT `_id`, `search` FROM `entities`;
@@ -19,8 +18,7 @@ ALTER TABLE `entities_search` ADD CONSTRAINT `es_id_id` FOREIGN KEY (`_id`) REFE
 CREATE TABLE IF NOT EXISTS `reader_search` (
   `_id` varchar(32) NOT NULL,
   `search` longtext NOT NULL,
-  PRIMARY KEY (`_id`),
-  FULLTEXT KEY `search` (`search`)
+  PRIMARY KEY (`_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 INSERT INTO `reader_search` SELECT `_id`, `search` FROM `reader`;
@@ -36,8 +34,7 @@ ALTER TABLE `reader_search` ADD CONSTRAINT `rs_id_id` FOREIGN KEY (`_id`) REFERE
 CREATE TABLE IF NOT EXISTS `config_search` (
   `_id` varchar(32) NOT NULL,
   `search` longtext NOT NULL,
-  PRIMARY KEY (`_id`),
-  FULLTEXT KEY `search` (`search`)
+  PRIMARY KEY (`_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 INSERT INTO `config_search` SELECT `_id`, `search` FROM `config`;

--- a/warmup/schemas/mysql/mysql.sql
+++ b/warmup/schemas/mysql/mysql.sql
@@ -25,7 +25,6 @@ CREATE TABLE IF NOT EXISTS `config_search` (
   `_id` varchar(32) NOT NULL,
   `search` longtext NOT NULL,
   PRIMARY KEY (`_id`),
-  FULLTEXT KEY `search` (`search`),
   CONSTRAINT `cs_id_id` FOREIGN KEY (`_id`) REFERENCES `config` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -55,7 +54,6 @@ CREATE TABLE IF NOT EXISTS `entities_search` (
   `_id` varchar(32) NOT NULL,
   `search` longtext NOT NULL,
   PRIMARY KEY (`_id`),
-  FULLTEXT KEY `search` (`search`),
   CONSTRAINT `es_id_id` FOREIGN KEY (`_id`) REFERENCES `entities` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -84,7 +82,6 @@ CREATE TABLE IF NOT EXISTS `reader_search` (
   `_id` varchar(32) NOT NULL,
   `search` longtext NOT NULL,
   PRIMARY KEY (`_id`),
-  FULLTEXT KEY `search` (`search`),
   CONSTRAINT `rs_id_id` FOREIGN KEY (`_id`) REFERENCES `reader` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
## Here's what I fixed or added:

I altered the MySQL warmup schema to be compatible with a wider number of MySQL server backends

## Here's why I did it:

Heroku MySQL does not support FULLTEXT indexes using clearDB free tier. There seems to be sparse documentation other than the SQL failing on creation of the fulltext index.

I have not worked out how to add back in for users.

## Checklist: (`[x]` to check/tick the boxes)

- [X] This pull request addresses a single issue
- [X] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [X] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [X] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [X] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [X] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
