### PR TITLE
Moving rewrite canary over to javascript, making it a non-blocker.

### DIFF
--- a/warmup/WebInstaller.php
+++ b/warmup/WebInstaller.php
@@ -20,6 +20,10 @@ class WebInstaller extends \Idno\Core\Installer
         parent::__construct();
     }
 
+    /**
+     * @deprecated This needs to be moved into the front end js to handle proxies etc
+     * @return boolean
+     */
     public function rewriteWorking()
     {
         if (!empty($_SERVER['PHP_SELF'])) {
@@ -78,13 +82,14 @@ class WebInstaller extends \Idno\Core\Installer
         $mysql_name  = \Idno\Core\Input::getInput('mysql_name');
         $upload_path = \Idno\Core\Input::getInput('upload_path', dirname(dirname(__FILE__)) . '/Uploads/');
 
-        if (!WebInstaller::installer()->rewriteWorking()) {
-            $messages .= '<p>Rewriting appears to be disabled. Usually this means "AllowOverride None" is set in apache2.conf ';
-            $messages .= 'which prevents Known\'s .htaccess from doing its thing. We tried to fetch a URL that should redirect ';
-            $messages .= 'to known.min.js</p>';
-            $messages .= '<p>You can usually fix this by setting <code>AllowOverride All</code> in your Apache configuration.</p>';
-            $ok = false;
-        }
+//        if (!WebInstaller::installer()->rewriteWorking()) {
+//            $messages .= '<p>Rewriting appears to be disabled. Usually this means "AllowOverride None" is set in apache2.conf ';
+//            $messages .= 'which prevents Known\'s .htaccess from doing its thing. We tried to fetch a URL that should redirect ';
+//            $messages .= 'to known.min.js</p>';
+//            $messages .= '<p>You can usually fix this by setting <code>AllowOverride All</code> in your Apache configuration.</p>';
+//            $messages .= '<p>If you think this is an error, you can continue, but you might have problems later on.</p>';
+//            $ok = false;
+//        }
 
         if (!empty($mysql_name) && !empty($mysql_host)) {
             try {

--- a/warmup/templates/default/pages/elements/messages.tpl.php
+++ b/warmup/templates/default/pages/elements/messages.tpl.php
@@ -3,11 +3,11 @@
 if (!empty($vars['messages'])) {
 
     ?>
-    <div class="alerts">
+    <div <?php if (!empty($vars['style'])) { echo 'style="' . $vars['style'] . '"'; } ?> <?php if (!empty($vars['id'])) { echo 'id="' . $vars['id'] . '"'; } ?> class="alerts">
         <div class="alert">
             <?=$messages?>
         </div>
-        </div>
+    </div>
     <?php
 
 }

--- a/warmup/templates/default/pages/settings.tpl.php
+++ b/warmup/templates/default/pages/settings.tpl.php
@@ -26,16 +26,31 @@
         echo $this->__([
             'messages' => $messages
         ])->draw('pages/elements/messages');
+        
     } else {
 
+        $canary = '<p>Rewriting appears to be disabled. Usually this means "AllowOverride None" is set in apache2.conf ';
+        $canary .= 'which prevents Known\'s .htaccess from doing its thing. We tried to fetch a URL that should redirect ';
+        $canary .= 'to known.min.js</p>';
+        $canary .= '<p>You can usually fix this by setting <code>AllowOverride All</code> in your Apache configuration.</p>';
+        $canary .= '<p>If you think this is an error, you can continue, but you might have problems later on.</p>';
+        
+        echo $this->__([
+            'id' => 'canary',
+            'messages' => $canary,
+            'style' => 'display: none;'
+        ])->draw('pages/elements/messages');
+        
         ?>
-        <p>
-            Great! You have everything you need to get started.
-        </p>
-        <p>
-            On this screen, we'll ask you how we should connect to your database, and where we should save
-            uploaded files like user photos, pictures and audio.
-        </p>
+        <div id="success-block" class="alerts success message-success-block" style="display:none;">
+            <p>
+                Great! You have everything you need to get started.
+            </p>
+            <p>
+                On this screen, we'll ask you how we should connect to your database, and where we should save
+                uploaded files like user photos, pictures and audio.
+            </p>
+        </div>
         <?php
 
     }
@@ -125,5 +140,20 @@
             <input type="submit" class="btn btn-primary btn-lg btn-responsive" value="Onwards!">
         </div>
     </form>
+    <script>
+        var request = new XMLHttpRequest();  
+        request.open('GET', '../js/canary.js', true);
+        request.onreadystatechange = function(){
+            if (request.readyState !== 2){
+                if (request.status !== 200) {  
+                    document.getElementById('canary').style.display = 'block';
+                    document.getElementById('success-block').style.display = 'none';
+                }  
+            } else {
+                document.getElementById('success-block').style.display = 'block';
+            }
+        };
+        request.send();
+    </script>
 
 </div>


### PR DESCRIPTION
## Here's what I fixed or added:

Moved the rewrite canary over to front side javascript.

## Here's why I did it:

People kept on having installer problems, which makes sense. Doing the rewrite canary on the back end is going to cause problems in situations where you're behind a proxy, using a container, or running on another port.

It should also really be on the front end anyway. Moving it there.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
