### PR TITLE
Schema: Split metadata table out into separate collection based tables

### DIFF
--- a/Idno/Data/Postgres.php
+++ b/Idno/Data/Postgres.php
@@ -75,6 +75,7 @@ namespace Idno\Data {
                             2017032001,
                             2019060501,
                             2019121401,
+                            2020042101,
                         ] as $date) {
                             if ($basedate < $date) {
                                 if ($sql = @file_get_contents($schema_dir . $date . '.sql')) {

--- a/composer.lock
+++ b/composer.lock
@@ -1127,16 +1127,16 @@
         },
         {
             "name": "idno/text",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/idno/text.git",
-                "reference": "3ac2ad13d13240b9001f7d3859cb6b2104f52dde"
+                "reference": "d2dd1cf9a376aa50a0b7b1d0c494cf78e9cb064d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/idno/text/zipball/3ac2ad13d13240b9001f7d3859cb6b2104f52dde",
-                "reference": "3ac2ad13d13240b9001f7d3859cb6b2104f52dde",
+                "url": "https://api.github.com/repos/idno/text/zipball/d2dd1cf9a376aa50a0b7b1d0c494cf78e9cb064d",
+                "reference": "d2dd1cf9a376aa50a0b7b1d0c494cf78e9cb064d",
                 "shasum": ""
             },
             "require": {
@@ -1153,7 +1153,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "A lightweight blogging engine.",
-            "time": "2020-04-19T12:59:49+00:00"
+            "time": "2020-04-21T20:45:09+00:00"
         },
         {
             "name": "idno/theme-black",
@@ -4043,12 +4043,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "09afa996c68c18f49e6487b06adcb2ef27da61fa"
+                "reference": "2bdae3cc8428d637d5c86c8c33d0a3354ce93f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/09afa996c68c18f49e6487b06adcb2ef27da61fa",
-                "reference": "09afa996c68c18f49e6487b06adcb2ef27da61fa",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/2bdae3cc8428d637d5c86c8c33d0a3354ce93f7f",
+                "reference": "2bdae3cc8428d637d5c86c8c33d0a3354ce93f7f",
                 "shasum": ""
             },
             "conflict": {
@@ -4094,6 +4094,8 @@
                 "endroid/qr-code-bundle": "<3.4.2",
                 "enshrined/svg-sanitize": "<0.13.1",
                 "erusev/parsedown": "<1.7.2",
+                "ezsystems/demobundle": ">=5.4,<5.4.6.1",
+                "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1",
                 "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1|>=5.4,<5.4.11.1|>=2017.12,<2017.12.0.1",
                 "ezsystems/ezplatform": ">=1.7,<1.7.9.1|>=1.13,<1.13.5.1|>=2.5,<2.5.4",
                 "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6",
@@ -4299,7 +4301,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2020-04-15T04:56:51+00:00"
+            "time": "2020-04-21T14:24:08+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/warmup/schemas/mysql/2020042101.sql
+++ b/warmup/schemas/mysql/2020042101.sql
@@ -1,0 +1,46 @@
+
+CREATE TABLE IF NOT EXISTS `entities_metadata` (
+  `_id` varchar(32) NOT NULL,
+  `name` varchar(64) NOT NULL,
+  `value` text NOT NULL,
+  KEY `value` (`value`(255)),
+  KEY `name` (`name`),
+  KEY (`_id`),
+  CONSTRAINT `em_id_id` FOREIGN KEY (`_id`) REFERENCES `entities` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `entities_metadata` SELECT `_id`, `name`, `value` FROM metadata WHERE `collection` = 'entities';
+
+CREATE TABLE IF NOT EXISTS `config_metadata` (
+  `_id` varchar(32) NOT NULL,
+  `name` varchar(64) NOT NULL,
+  `value` text NOT NULL,
+  KEY `value` (`value`(255)),
+  KEY `name` (`name`),
+  KEY (`_id`),
+  CONSTRAINT `cm_id_id` FOREIGN KEY (`_id`) REFERENCES `config` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `config_metadata` SELECT `_id`, `name`, `value` FROM metadata WHERE `collection` = 'config';
+
+
+CREATE TABLE IF NOT EXISTS `reader_metadata` (
+  `_id` varchar(32) NOT NULL,
+  `name` varchar(64) NOT NULL,
+  `value` text NOT NULL,
+  KEY `value` (`value`(255)),
+  KEY `name` (`name`),
+  KEY (`_id`),
+  CONSTRAINT `rm_id_id` FOREIGN KEY (`_id`) REFERENCES `reader` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `reader_metadata` SELECT `_id`, `name`, `value` FROM metadata WHERE `collection` = 'reader';
+
+
+
+-- Create a backup so we can clear it up later
+CREATE TABLE deprecated_metadata LIKE metadata;
+DROP TABLE metadata;
+
+
+REPLACE INTO `versions` VALUES('schema', '2020042101');

--- a/warmup/schemas/mysql/mysql.sql
+++ b/warmup/schemas/mysql/mysql.sql
@@ -29,6 +29,16 @@ CREATE TABLE IF NOT EXISTS `config_search` (
   CONSTRAINT `cs_id_id` FOREIGN KEY (`_id`) REFERENCES `config` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+CREATE TABLE IF NOT EXISTS `config_metadata` (
+  `_id` varchar(32) NOT NULL,
+  `name` varchar(64) NOT NULL,
+  `value` text NOT NULL,
+  KEY `value` (`value`(255)),
+  KEY `name` (`name`),
+  KEY (`_id`),
+  CONSTRAINT `cm_id_id` FOREIGN KEY (`_id`) REFERENCES `config` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 -- --------------------------------------------------------
 
 --
@@ -57,6 +67,16 @@ CREATE TABLE IF NOT EXISTS `entities_search` (
   PRIMARY KEY (`_id`),
   FULLTEXT KEY `search` (`search`),
   CONSTRAINT `es_id_id` FOREIGN KEY (`_id`) REFERENCES `entities` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS `entities_metadata` (
+  `_id` varchar(32) NOT NULL,
+  `name` varchar(64) NOT NULL,
+  `value` text NOT NULL,
+  KEY `value` (`value`(255)),
+  KEY `name` (`name`),
+  KEY (`_id`),
+  CONSTRAINT `em_id_id` FOREIGN KEY (`_id`) REFERENCES `entities` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------
@@ -88,23 +108,14 @@ CREATE TABLE IF NOT EXISTS `reader_search` (
   CONSTRAINT `rs_id_id` FOREIGN KEY (`_id`) REFERENCES `reader` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- --------------------------------------------------------
-
---
--- Table structure for table `metadata`
---
-
-CREATE TABLE IF NOT EXISTS `metadata` (
-  `entity` varchar(255) NOT NULL,
+CREATE TABLE IF NOT EXISTS `reader_metadata` (
   `_id` varchar(32) NOT NULL,
-  `collection` varchar(64) NOT NULL,
   `name` varchar(64) NOT NULL,
   `value` text NOT NULL,
-  KEY `entity` (`entity`,`name`),
   KEY `value` (`value`(255)),
   KEY `name` (`name`),
-  KEY `collection` (`collection`),
-  KEY `_id` (`_id`)
+  KEY (`_id`),
+  CONSTRAINT `rm_id_id` FOREIGN KEY (`_id`) REFERENCES `reader` (`_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------
@@ -131,4 +142,4 @@ CREATE TABLE IF NOT EXISTS `session` (
     PRIMARY KEY (`session_id`)
 ) COLLATE utf8_bin, ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-REPLACE INTO `versions` VALUES('schema', '2019121401');
+REPLACE INTO `versions` VALUES('schema', '2020042101');

--- a/warmup/schemas/postgres/2020042101.sql
+++ b/warmup/schemas/postgres/2020042101.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS config_metadata (
   _id varchar(32) NOT NULL,
   name varchar(64) NOT NULL,
   value text NOT NULL,
-  FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE
+  FOREIGN KEY (_id) REFERENCES config (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON config_metadata (value);

--- a/warmup/schemas/postgres/2020042101.sql
+++ b/warmup/schemas/postgres/2020042101.sql
@@ -1,0 +1,60 @@
+
+CREATE TABLE IF NOT EXISTS entities_metadata (
+  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  name varchar(64) NOT NULL,
+  value text NOT NULL
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON entities_metadata (value);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON entities_metadata (name);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON entities_metadata (_id);
+
+INSERT INTO entities_metadata SELECT _id, name, value FROM metadata WHERE collection = 'entities';
+
+
+
+CREATE TABLE IF NOT EXISTS config_metadata (
+  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  name varchar(64) NOT NULL,
+  value text NOT NULL
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON config_metadata (value);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON config_metadata (name);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON config_metadata (_id);
+
+INSERT INTO config_metadata SELECT _id, name, value FROM metadata WHERE collection = 'config';
+
+
+
+CREATE TABLE IF NOT EXISTS reader_metadata (
+  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES reader (_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  name varchar(64) NOT NULL,
+  value text NOT NULL
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON reader_metadata (value);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON reader_metadata (name);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON reader_metadata (_id);
+
+INSERT INTO reader_metadata SELECT _id, name, value FROM metadata WHERE collection = 'reader';
+
+
+
+
+CREATE TABLE IF NOT EXISTS deprecated_metadata (
+  entity varchar(255) NOT NULL,
+  _id varchar(32) NOT NULL,
+  collection varchar(64) NOT NULL,
+  name varchar(64) NOT NULL,
+  value text NOT NULL
+);
+
+INSERT INTO deprecated_metadata SELECT entity, _id, collection, name, value FROM metadata;
+
+DROP TABLE metadata;
+
+
+
+DELETE FROM versions WHERE label = 'schema';
+INSERT INTO versions VALUES('schema', '2020042101');

--- a/warmup/schemas/postgres/2020042101.sql
+++ b/warmup/schemas/postgres/2020042101.sql
@@ -1,8 +1,9 @@
 
 CREATE TABLE IF NOT EXISTS entities_metadata (
-  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  _id varchar(32) NOT NULL,
   name varchar(64) NOT NULL,
-  value text NOT NULL
+  value text NOT NULL,
+  FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON entities_metadata (value);
@@ -14,9 +15,10 @@ INSERT INTO entities_metadata SELECT _id, name, value FROM metadata WHERE collec
 
 
 CREATE TABLE IF NOT EXISTS config_metadata (
-  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  _id varchar(32) NOT NULL,
   name varchar(64) NOT NULL,
-  value text NOT NULL
+  value text NOT NULL,
+  FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON config_metadata (value);
@@ -28,9 +30,10 @@ INSERT INTO config_metadata SELECT _id, name, value FROM metadata WHERE collecti
 
 
 CREATE TABLE IF NOT EXISTS reader_metadata (
-  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES reader (_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  _id varchar(32) NOT NULL,
   name varchar(64) NOT NULL,
-  value text NOT NULL
+  value text NOT NULL,
+  FOREIGN KEY (_id) REFERENCES reader (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON reader_metadata (value);

--- a/warmup/schemas/postgres/postgres.sql
+++ b/warmup/schemas/postgres/postgres.sql
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS config_metadata (
   _id varchar(32) NOT NULL,
   name varchar(64) NOT NULL,
   value text NOT NULL,
-  FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE
+  FOREIGN KEY (_id) REFERENCES config (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON config_metadata (value);

--- a/warmup/schemas/postgres/postgres.sql
+++ b/warmup/schemas/postgres/postgres.sql
@@ -29,9 +29,10 @@ CREATE TABLE IF NOT EXISTS config_search (
 );
 
 CREATE TABLE IF NOT EXISTS config_metadata (
-  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  _id varchar(32) NOT NULL,
   name varchar(64) NOT NULL,
-  value text NOT NULL
+  value text NOT NULL,
+  FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON config_metadata (value);
@@ -68,9 +69,10 @@ CREATE TABLE IF NOT EXISTS entities_search (
 );
 
 CREATE TABLE IF NOT EXISTS entities_metadata (
-  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  _id varchar(32) NOT NULL,
   name varchar(64) NOT NULL,
-  value text NOT NULL
+  value text NOT NULL,
+  FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON entities_metadata (value);
@@ -109,9 +111,10 @@ CREATE TABLE IF NOT EXISTS reader_search (
 );
 
 CREATE TABLE IF NOT EXISTS reader_metadata (
-  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES reader (_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  _id varchar(32) NOT NULL,
   name varchar(64) NOT NULL,
-  value text NOT NULL
+  value text NOT NULL,
+  FOREIGN KEY (_id) REFERENCES reader (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON reader_metadata (value);

--- a/warmup/schemas/postgres/postgres.sql
+++ b/warmup/schemas/postgres/postgres.sql
@@ -57,6 +57,15 @@ CREATE TABLE IF NOT EXISTS entities_search (
   FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS metadata (
+  _id varchar(32) NOT NULL,
+  name varchar(64) NOT NULL,
+  value text NOT NULL
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON metadata (value);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON metadata (name);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON metadata (_id);
 
 
 
@@ -115,19 +124,6 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON metadata (_id);
 -- --------------------------------------------------------
 
 --
--- Table structure for table versions
---
-
-CREATE TABLE IF NOT EXISTS versions (
-  label varchar(32) NOT NULL,
-  value varchar(10) NOT NULL,
-  PRIMARY KEY (label)
-);
-
-DELETE FROM versions WHERE label = 'schema';
-INSERT INTO versions VALUES('schema', '2019121401');
-
---
 -- Session handling table
 --
 
@@ -138,3 +134,17 @@ CREATE TABLE IF NOT EXISTS session (
     session_time integer NOT NULL,
     PRIMARY KEY (session_id)
 );
+
+
+--
+-- Table structure for table versions
+--
+
+CREATE TABLE IF NOT EXISTS versions (
+  label varchar(32) NOT NULL,
+  value varchar(10) NOT NULL,
+  PRIMARY KEY (label)
+);
+
+DELETE FROM versions WHERE label = 'schema';
+INSERT INTO versions VALUES('schema', '2020042101');

--- a/warmup/schemas/postgres/postgres.sql
+++ b/warmup/schemas/postgres/postgres.sql
@@ -28,6 +28,16 @@ CREATE TABLE IF NOT EXISTS config_search (
   FOREIGN KEY (_id) REFERENCES config (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS config_metadata (
+  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  name varchar(64) NOT NULL,
+  value text NOT NULL
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON config_metadata (value);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON config_metadata (name);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON config_metadata (_id);
+
 -- --------------------------------------------------------
 
 --
@@ -57,15 +67,15 @@ CREATE TABLE IF NOT EXISTS entities_search (
   FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS metadata (
-  _id varchar(32) NOT NULL,
+CREATE TABLE IF NOT EXISTS entities_metadata (
+  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES entities (_id) ON DELETE CASCADE ON UPDATE CASCADE,
   name varchar(64) NOT NULL,
   value text NOT NULL
 );
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON metadata (value);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON metadata (name);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON metadata (_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON entities_metadata (value);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON entities_metadata (name);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON entities_metadata (_id);
 
 
 
@@ -98,28 +108,15 @@ CREATE TABLE IF NOT EXISTS reader_search (
   FOREIGN KEY (_id) REFERENCES reader (_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
-
--- --------------------------------------------------------
-
---
--- Table structure for table metadata
---
-
-CREATE TABLE IF NOT EXISTS metadata (
-  entity varchar(255) NOT NULL,
-  _id varchar(32) NOT NULL,
-  collection varchar(64) NOT NULL,
+CREATE TABLE IF NOT EXISTS reader_metadata (
+  _id varchar(32) NOT NULL FOREIGN KEY (_id) REFERENCES reader (_id) ON DELETE CASCADE ON UPDATE CASCADE,
   name varchar(64) NOT NULL,
   value text NOT NULL
 );
 
-
-CREATE INDEX CONCURRENTLY IF NOT EXISTS m_entity ON metadata (entity,name);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON metadata (value);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON metadata (name);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS m_collection ON metadata (collection);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON metadata (_id);
-
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON reader_metadata (value);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON reader_metadata (name);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON reader_metadata (_id);
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
## Here's what I fixed or added:

Splits metadata tables out into their own tables.

## Here's why I did it:

This is the onward goal of improving the database schema bit by bit.

Splitting metadata out into their own tables should make things a bit faster. 

More importantly makes the schema easier to work with, for example, we can offload data integrity (e.g. deleting metadata) off to the database layer to manage. 

It also means we might be able to move over utf8mb4 at some point in the future (#2451), for which the length of indexes proved blockers.


## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
