### PR TITLE
Update Postgres upgrade script to work

### DIFF
--- a/warmup/schemas/postgres/2020042101.sql
+++ b/warmup/schemas/postgres/2020042101.sql
@@ -10,9 +10,9 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON entities_metadata (value);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON entities_metadata (name);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON entities_metadata (_id);
 
-INSERT INTO entities_metadata SELECT _id, name, value FROM metadata WHERE collection = 'entities';
-
-
+DELETE FROM entities_metadata;
+INSERT INTO entities_metadata SELECT M._id, M.name, M.value FROM metadata M LEFT JOIN config C ON C._id = M._id WHERE M.collection = 'entities' AND C._id IS NOT NULL
+ON CONFLICT DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS config_metadata (
   _id varchar(32) NOT NULL,
@@ -25,9 +25,9 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON config_metadata (value);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON config_metadata (name);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON config_metadata (_id);
 
-INSERT INTO config_metadata SELECT _id, name, value FROM metadata WHERE collection = 'config';
-
-
+DELETE FROM config_metadata;
+INSERT INTO config_metadata SELECT M._id, M.name, M.value FROM metadata M LEFT JOIN config C ON C._id = M._id WHERE M.collection = 'config' AND C._id IS NOT NULL
+ON CONFLICT DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS reader_metadata (
   _id varchar(32) NOT NULL,
@@ -40,10 +40,9 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS m_value ON reader_metadata (value);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m_name ON reader_metadata (name);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS m__id ON reader_metadata (_id);
 
-INSERT INTO reader_metadata SELECT _id, name, value FROM metadata WHERE collection = 'reader';
-
-
-
+DELETE FROM reader_metadata;
+INSERT INTO reader_metadata SELECT M._id, M.name, M.value FROM metadata M LEFT JOIN config C ON C._id = M._id WHERE M.collection = 'reader' AND C._id IS NOT NULL
+ON CONFLICT DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS deprecated_metadata (
   entity varchar(255) NOT NULL,
@@ -56,8 +55,6 @@ CREATE TABLE IF NOT EXISTS deprecated_metadata (
 INSERT INTO deprecated_metadata SELECT entity, _id, collection, name, value FROM metadata;
 
 DROP TABLE metadata;
-
-
 
 DELETE FROM versions WHERE label = 'schema';
 INSERT INTO versions VALUES('schema', '2020042101');


### PR DESCRIPTION
Fixes #2746

Ignores deprecated_metadata

It is unknown / unknowable at this point if the constraint for unique _id, name pairs should be altered into this script, so that if the script errors but allows metadata to drop after transition to deprecated_metadata, if another script could be run without creating duplicates...


## Here's what I fixed or added:

## Here's why I did it:

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
