### PR TITLE
CORS headers to allow API calls from Javascript / node

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -444,6 +444,25 @@ namespace Idno\Common {
         }
         
         /**
+         * Default handling of OPTIONS (mostly to handle CORS)
+         */
+        function options() {
+            
+            header('Access-Control-Allow-Methods: ' . implode(', ', [
+                'GET',
+                'POST',
+                'HEAD',
+                'OPTIONS',
+                'PUT',
+                'DELETE'
+            ]) );
+            
+            header('Access-Control-Max-Age: 86400');
+            
+            http_response_code(204);
+        }
+        
+        /**
          * Return the referrer, or an empty string
          * @return string
          */

--- a/templates/json/shell.tpl.php
+++ b/templates/json/shell.tpl.php
@@ -2,6 +2,9 @@
 
     header('Content-type: application/json');
     header("Access-Control-Allow-Origin: *");
+    header('Access-Control-Allow-Credentials: true');
+    header("Access-Control-Allow-Headers: Authorization");
+    
     unset($vars['body']);
 
 if (!empty($vars['exception'])) {

--- a/templates/jsonp/shell.tpl.php
+++ b/templates/jsonp/shell.tpl.php
@@ -2,6 +2,8 @@
 
     header('Content-type: application/x-javascript; charset=UTF-8');
     header("Access-Control-Allow-Origin: *");
+    header('Access-Control-Allow-Credentials: true');
+    header("Access-Control-Allow-Headers: Authorization");
 
     unset($vars['body']);
 


### PR DESCRIPTION
## Here's what I fixed or added:

* Added support for browser preflight OPTIONS call
* Added support to pass Authentication BEARER tokens through

## Here's why I did it:

Backporting stuff from the Day Job, to allow react front end applications and GQL parsers to federate bearer tokens and handle browser preflight tests

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
