### PR TITLE
Added Matomo to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -53,6 +53,8 @@ listings here do not imply endorsement by the Known project team in any way.
     by [Marcus Povey][]
 * [Akismet](https://github.com/mapkyca/KnownAkismet) – Wordpress Akismet spam filtering support for comments and webmentions, 
     by [Marcus Povey][]
+* [Matomo](https://codeberg.org/argovaerts/KnownMatomo) – Add Matomo Analytics to your site,
+    by [Arne Govaerts][]
 
 
 ### Browser Integration and Apps
@@ -111,6 +113,7 @@ listings here do not imply endorsement by the Known project team in any way.
 [Björn Stierand]: https://bjoern.stierand.org/
 [Christian Weiske]: https://cweiske.de/
 [Daniel Goldsmith]: https://ascraeus.org/
+[Arne Govaerts]: https://q4.re
 
 ## Submissions
 


### PR DESCRIPTION
## Here's what I fixed or added:
I added [Matomo](https://codeberg.org/argovaerts/KnownMatomo) to the Community plugins section.

## Here's why I did it:
I made a plugin 🙃

## Checklist: (`[x]` to check/tick the boxes)

- [X] This pull request addresses a single issue
- [X] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [X] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
