### PR TITLE
Fix broken URL for idno-file-picker

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -66,7 +66,7 @@ listings here do not imply endorsement by the Known project team in any way.
 
 * [Flickr Import](https://github.com/mapkyca/KnownFlickrDumpImport) – Import content from your Flickr account, 
     by [Marcus Povey][]
-* [File Picker](https://github.com/Decentralized–Sharing–Working–Group/idno–file–picker) – pick files from your
+* [File Picker](https://github.com/Decentralized-Sharing-Working-Group/idno-file-picker) – pick files from your
     Cozy, ownCloud, or remoteStorage server, by [Decentralized Sharing Community Group][decsharing]
 * [Moves Import](https://github.com/danito/KnownImportMoves) – Import your Moves–app.com data, 
     by [Daniel Nix][]


### PR DESCRIPTION
## Here's what I fixed or added:

- fixed the broken URL for the _idno-file-picker_ plugin

## Here's why I did it:

- well, the URL was broken :)

## Checklist: (`[x]` to check/tick the boxes)

- [X] This pull request addresses a single issue
- [X] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [X] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [X] I've tested my code in-browser
- [X] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
