### PR TITLE
Deprecate the EOL PHP 7.2, allow PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
- - 7.2
  - 7.3
  - 7.4
 
@@ -9,9 +8,10 @@ env:
   - DB=mysql
   - DB=mongo
   
-#matrix:
-#   allow_failures:
-#     - php: 7.4
+matrix:
+   allow_failures:
+     - php: 7.2
+     - php: 8.0
   
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
  - 7.3
  - 7.4
+ - 8.0
 
 # Configure different DB environments
 env:
@@ -11,7 +12,6 @@ env:
 matrix:
    allow_failures:
      - php: 7.2
-     - php: 8.0
   
 branches:
   only:

--- a/Idno/Core/Installer.php
+++ b/Idno/Core/Installer.php
@@ -295,9 +295,9 @@ namespace Idno\Core {
          */
         public static function checkPHPVersion()
         {
-            if (version_compare(phpversion(), '7.3') >= 0) {
+            if (version_compare(phpversion(), '7.4') >= 0) {
                 return 'ok';
-            } else if (version_compare(phpversion(), '7.2') >= 0) {
+            } else if (version_compare(phpversion(), '7.3') >= 0) {
                 return 'warn';
             } else {
                 return 'fail';

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ web hosting provider.
 
 ### Installing
 
-Known is under active development and requires PHP 7.2+ with selected extensions, together with a supported database backend. You can find detailed installation instructions here: <http://docs.withknown.com/en/latest/install/index.html>
+Known is under active development and requires PHP 7.3+ with selected extensions, together with a supported database backend. You can find detailed installation instructions here: <http://docs.withknown.com/en/latest/install/index.html>
 
 #### Installing from packages
 

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -4,7 +4,7 @@ Known _requires_ the following server components:
 
 + A Web Server that supports URL rewriting (Apache + mod_rewrite recommended).
 + If you are using Apache, you also need to make sure support for .htaccess is enabled (using [the AllowOverride All directive](https://help.ubuntu.com/community/EnablingUseOfApacheHtaccessFiles)).
-+ PHP 7.2 or above.
++ PHP 7.3 or above.
 + MySQL 5+ / MariaDB or MongoDB. We recommend MySQL.
 
 Known can either be installed at the root of a domain or subdomain, or in a subdirectory.


### PR DESCRIPTION
## Here's what I fixed or added:

* Removed official 7.2 support
* Allowing for testing on PHP 8

## Here's why I did it:

7.2 is EOL & 8 is out

## Checklist: (`[x]` to check/tick the boxes)

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
