### PR TITLE
Standardizing extracted URLs from webmentions

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1990,10 +1990,11 @@ namespace Idno\Common {
          * Many properties in mf2 can have either a simple string value or a complex
          * object value, "u-in-reply-to h-cite" is a common example. This function
          * takes a possibly mixed array, and returns an array of only strings.
-         *
+         * @param $arr An array of URL strings
+         * @param bool $filter_urls If true (default), will remove URL parameters and anchors
          * @return array
          */
-        static function getStringURLs($arr)
+        static function getStringURLs($arr, $filter_urls = true)
         {
             $result = [];
             foreach ($arr as $value) {
@@ -2001,6 +2002,10 @@ namespace Idno\Common {
                     $result[] = $value;
                 } else if (is_array($value) && !empty($value['properties']) && !empty($value['properties']['url'])) {
                     foreach ($value['properties']['url'] as $url) {
+                        if ($filter_urls) {
+                            $url = explode($url, '?')[0];
+                            $url = explode($url, '#')[0];
+                        }
                         $result[] = $url;
                     }
                 }


### PR DESCRIPTION
## Here's what I fixed or added:

URLs extracted from webmentions for targeting purposes are now stripped of URL parameters and fragment elements.

## Here's why I did it:

URL fragments were breaking type detection for webmentions.

Refs #2878 

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
