### PR TITLE
Forwarding to login now operates through a consistent method

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -25,7 +25,7 @@ namespace Idno\Common {
         // Property that defines whether this page may forward to
         // other pages. True by default.
         private $forward = true;
-        
+
         // Where was this page forwarded from
         private $referrer = '';
 
@@ -71,7 +71,7 @@ namespace Idno\Common {
                 }
             }
             \Idno\Core\Idno::site()->setCurrentPage($this);
-            
+
             // Set referrer, and ensure it's not blank
             $this->referrer = $_SERVER['HTTP_REFERER']??'';
             $_SERVER['HTTP_REFERER'] = $_SERVER['HTTP_REFERER']??''; // Ensure that the $_SERVER['HTTP_REFERER'] is never blank
@@ -443,12 +443,12 @@ namespace Idno\Common {
         {
             $this->setResponse(501);
         }
-        
+
         /**
          * Default handling of OPTIONS (mostly to handle CORS)
          */
         function options() {
-            
+
             header('Access-Control-Allow-Methods: ' . implode(', ', [
                 'GET',
                 'POST',
@@ -457,12 +457,12 @@ namespace Idno\Common {
                 'PUT',
                 'DELETE'
             ]) );
-            
+
             header('Access-Control-Max-Age: 86400');
-            
+
             http_response_code(204);
         }
-        
+
         /**
          * Return the referrer, or an empty string
          * @return string
@@ -544,6 +544,15 @@ namespace Idno\Common {
                     exit;
                 }
             }
+        }
+
+        /**
+         * Forwards to login page with optional forward param
+         * @param string $fwd
+         */
+        function forwardToLogin($fwd = '')
+        {
+            $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login/?fwd=' . \Idno\Core\Webservice::encodeValue($fwd));
         }
 
         /**
@@ -1137,27 +1146,27 @@ namespace Idno\Common {
 
             return $headers;
         }
-        
+
         /**
          * Retrieve bearer token passed to this page, if any.
          * @return string|null
          */
         public static function getBearerToken(): ?string {
-            
+
             $headers = null;
             $serverheaders = \Idno\Common\Page::getallheaders();
-            
+
             if (isset($serverheaders['Authorization']))
                 $headers = trim($serverheaders["Authorization"]);
             else if (isset($serverheaders['HTTP_AUTHORIZATION']))
                 $headers = trim($serverheaders["HTTP_AUTHORIZATION"]);
-            
+
             if (!empty($headers)) {
                 if (preg_match('/Bearer\s(\S+)/', $headers, $matches)) {
                     return trim($matches[1], '\'"');
                 }
             }
-                
+
             return null;
         }
 

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -628,7 +628,7 @@ namespace Idno\Core {
 
         /**
          * If the current user isn't logged in and this isn't a public site, and this hasn't been defined as an
-         * always-public page, forward to the login page!
+         * always-public page, forward to the login page.
          */
         function publicGatekeeper()
         {
@@ -636,13 +636,8 @@ namespace Idno\Core {
             if (!\Idno\Core\Idno::site()->config()->isPublicSite()) {
                 if (!\Idno\Core\Idno::site()->session()->isLoggedOn()) {
                     $class = get_class(Idno::site()->currentPage());
-                    if (!\Idno\Core\Idno::site()->isPageHandlerPublic($class)) {
-                        //                            \Idno\Core\Idno::site()->currentPage()->setResponse(403);
-                        //                            if (!\Idno\Core\Idno::site()->session()->isAPIRequest()) {
-                        //                                \Idno\Core\Idno::site()->currentPage()->forward(Idno::site()->config()->getURL() . 'session/login/?fwd=' . urlencode($_SERVER['REQUEST_URI']));
-                        //                            } else {
+                    if (!\Idno\Core\Idno::site()->routes()->isRoutePublic($class)) {
                         \Idno\Core\Idno::site()->currentPage()->deniedContent();
-                        //                            }
                     }
                 }
             }

--- a/Idno/Core/Webservice.php
+++ b/Idno/Core/Webservice.php
@@ -439,6 +439,26 @@ namespace Idno\Core {
         }
 
         /**
+         * Wrapper function to encode a value for use in web services.
+         * This way if we change the algorithm, there's no need to change the whole codebase.
+         * @param $string
+         * @return string
+         */
+        static function encodeValue($string) {
+            return self::base64UrlEncode($string);
+        }
+
+        /**
+         * Wrapper function to decode a value for use in web services.
+         * This way if we change the algorithm, there's no need to change the whole codebase.
+         * @param $string
+         * @return string
+         */
+        static function decodeValue($string) {
+            return self::base64UrlDecode($string);
+        }
+
+        /**
          * Utility method to produce URL safe base64 encoding.
          * @param type $string
          * @return string
@@ -468,7 +488,7 @@ namespace Idno\Core {
 
             // Get the domain
             $domain = parse_url($url, PHP_URL_HOST);
-            
+
             if (empty($domain)) {
                 return false;
             }

--- a/Idno/Pages/Session/Login.php
+++ b/Idno/Pages/Session/Login.php
@@ -17,7 +17,7 @@ namespace Idno\Pages\Session {
 
             // If we're somehow here but logged in, move to the front page if we're viewing with the regular template
             if (\Idno\Core\Idno::site()->session()->isLoggedOn() && \Idno\Core\Idno::site()->template()->getTemplateType() == 'default') {
-                
+
                 $fwd = $this->getInput('fwd'); // Forward to a new page?
                 if (empty($fwd)) {
                     $fwd = \Idno\Core\Idno::site()->config()->getDisplayURL();
@@ -38,13 +38,13 @@ namespace Idno\Pages\Session {
             $vars = [
                 'fwd' => $fwd
             ];
-            
+
             // If user is logged in and we got this far, this is an api login so lets return a user api token (#2240)
             if (\Idno\Core\Idno::site()->session()->isLoggedOn() && \Idno\Core\Idno::site()->template()->getTemplateType() != 'default' && $this->isSSL()) {
                 $user = \Idno\Core\Idno::site()->session()->currentUser();
                 $vars['api-token'] = $user->getAPIkey();
             }
-            
+
             $t->body  = $t->__($vars)->draw('account/login');
             $t->title = \Idno\Core\Idno::site()->language()->_('Sign in');
             $t->drawPage();
@@ -69,15 +69,15 @@ namespace Idno\Pages\Session {
                 if ($user->checkPassword(trim($this->getInput('password')))) {
                     \Idno\Core\Idno::site()->events()->triggerEvent('login/success', array('user' => $user)); // Trigger an event for auditing
                     \Idno\Core\Idno::site()->session()->logUserOn($user);
-                    $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login/?fwd=' . \Idno\Core\Webservice::base64UrlEncode($fwd));
+                    $this->forwardToLogin($fwd);
                 } else {
                     \Idno\Core\Idno::site()->session()->addErrorMessage(\Idno\Core\Idno::site()->language()->_("Oops! It looks like your password isn't correct. Please try again."));
                     \Idno\Core\Idno::site()->events()->triggerEvent('login/failure', array('user' => $user));
-                    $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login/?fwd=' . \Idno\Core\Webservice::base64UrlEncode($fwd));
+                    $this->forwardToLogin($fwd);
                 }
             } else {
                 \Idno\Core\Idno::site()->session()->addErrorMessage(\Idno\Core\Idno::site()->language()->_("Oops! We couldn't find your username or email address. Please check you typed it correctly and try again."));
-                $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login/?fwd=' . \Idno\Core\Webservice::base64UrlEncode($fwd));
+                $this->forwardToLogin($fwd);
             }
         }
 

--- a/templates/default/pages/403.tpl.php
+++ b/templates/default/pages/403.tpl.php
@@ -1,10 +1,13 @@
 <?php
     // Display the login link, if the user is not currently logged in.
     // If they're logged out, this is probably why they're denied.
+
+    $login_url = \Idno\Core\Idno::site()->currentPage()->forwardToLogin($_SERVER['REQUEST_URI']);
+
 if (!\Idno\Core\Idno::site()->session()->isLoggedIn()) {
     ?>
         <a id="soft-forward"
-           href="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() . 'session/login?fwd=' . Idno\Core\Webservice::base64UrlEncode($_SERVER['REQUEST_URI']); ?>"><?php echo \Idno\Core\Idno::site()->language()->_('Click here to log in.'); ?></a>
+           href="<?php echo $login_url; ?>"><?php echo \Idno\Core\Idno::site()->language()->_('Click here to log in.'); ?></a>
         <script>
             $('#soft-forward').hide();  // JS users will be forwarded anyway
         </script>
@@ -20,11 +23,11 @@ if (!\Idno\Core\Idno::site()->session()->isLoggedIn()) {
                     <p><?php echo \Idno\Core\Idno::site()->language()->_("It's nothing personal. You just don't have the right permissions to see what's here."); ?></p>
                     <p>
                     <?php echo \Idno\Core\Idno::site()->language()->_('Find something else to view on the <a href="%s">%s homepage</a>.', [\Idno\Core\Idno::site()->config()->getDisplayURL(), \Idno\Core\Idno::site()->config()->title]); ?>
-                    </p>                    
+                    </p>
                 </div>
                 <div class="col-md-5">
                     <img src="<?php echo \Idno\Core\Idno::site()->config()->getStaticURL()?>gfx/robots/aleph_403.png" alt="Robot with a stop sign">
-                </div>                
+                </div>
             </div>
         </div>
 <?php }


### PR DESCRIPTION
## Here's what I fixed or added:

I added a `$Page->forwardToLogin($fwd);` method.

## Here's why I did it:

We were reproducing this code all over the place. Some plugins were also implementing it, but because the method has changed, none of them forward. Adding a wrapper function will streamline this process, make life easier for developers, and help ensure that plugins don't randomly break when  we change the methodology in  the future.
