### PR TITLE
Adding descriptive language to tests and allowing usage of .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 Idno/.idea/.name
 .scannerwork
 
+.env
+
 .vagrant
 .elasticbeanstalk
 .phpunit.result.cache

--- a/Tests/API/BasicAPITest.php
+++ b/Tests/API/BasicAPITest.php
@@ -24,9 +24,9 @@ namespace Tests\API {
             $content = json_decode($result['content']);
             $response = $result['response'];
 
-            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
-            $this->assertTrue(!empty($content), 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
-            $this->assertTrue($response == 200, 'The response should have returned a 200 HTTP response.');
+            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertNotEmpty($content, 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
+            $this->assertEquals($response, 200,  'The response should have returned a 200 HTTP response.');
 
         }
 
@@ -50,10 +50,10 @@ namespace Tests\API {
             $content = json_decode($result['content']);
             $response = $result['response'];
 
-            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
-            $this->assertTrue(!empty($content), 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
-            $this->assertTrue(!empty($content->location), 'Response should contain the location of the post.');
-            $this->assertTrue($response == 200, 'The response should have returned a 200 HTTP response.');
+            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertNotEmpty($content, 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
+            $this->assertNotEmpty($content->location, 'Response should contain the location of the post.');
+            $this->assertEquals($response, 200,  'The response should have returned a 200 HTTP response.');
 
         }
     }

--- a/Tests/API/BasicAPITest.php
+++ b/Tests/API/BasicAPITest.php
@@ -24,7 +24,7 @@ namespace Tests\API {
             $content = json_decode($result['content']);
             $response = $result['response'];
 
-            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEmpty($result['error'], 'The result\'s error property should be empty.');
             $this->assertNotEmpty($content, 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
             $this->assertEquals($response, 200,  'The response should have returned a 200 HTTP response.');
 
@@ -50,7 +50,7 @@ namespace Tests\API {
             $content = json_decode($result['content']);
             $response = $result['response'];
 
-            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEmpty($result['error'], 'The result\'s error property should be empty.');
             $this->assertNotEmpty($content, 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
             $this->assertNotEmpty($content->location, 'Response should contain the location of the post.');
             $this->assertEquals($response, 200,  'The response should have returned a 200 HTTP response.');

--- a/Tests/API/BasicAPITest.php
+++ b/Tests/API/BasicAPITest.php
@@ -8,31 +8,39 @@ namespace Tests\API {
     class BasicAPITest extends \Tests\KnownTestCase
     {
 
+        /**
+         * Test opening an API connection
+         */
         public function testConnection()
         {
 
             $user = \Tests\KnownTestCase::user();
+            $endpoint = \Idno\Core\Idno::site()->config()->getDisplayURL() . '';
 
-            $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . '', [], [
+            $result = \Idno\Core\Webservice::get($endpoint, [], [
                 'Accept: application/json',
             ]);
 
             $content = json_decode($result['content']);
             $response = $result['response'];
 
-            $this->assertTrue(empty($result['error']));
-            $this->assertTrue(!empty($content));
-            $this->assertTrue($response == 200);
+            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
+            $this->assertTrue(!empty($content), 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
+            $this->assertTrue($response == 200, 'The response should have returned a 200 HTTP response.');
 
         }
 
-        public function testAuthenticated()
+        /**
+         * Test that making a test post works while authenticated
+         */
+        public function testAuthenticatedPost()
         {
 
             $user = \Tests\KnownTestCase::user();
+            $endpoint = \Idno\Core\Idno::site()->config()->url . 'status/edit';
 
-            $result = \Idno\Core\Webservice::post(\Idno\Core\Idno::site()->config()->url . 'status/edit', [
-                'body' => "Making a nice test post via the api",
+            $result = \Idno\Core\Webservice::post($endpoint, [
+                'body' => "Making a test post via the API",
             ], [
                 'Accept: application/json',
                 'X-KNOWN-USERNAME: ' . $user->handle,
@@ -42,10 +50,10 @@ namespace Tests\API {
             $content = json_decode($result['content']);
             $response = $result['response'];
 
-            $this->assertTrue(empty($result['error']));
-            $this->assertTrue(!empty($content));
-            $this->assertTrue(!empty($content->location));
-            $this->assertTrue($response == 200);
+            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
+            $this->assertTrue(!empty($content), 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
+            $this->assertTrue(!empty($content->location), 'Response should contain the location of the post.');
+            $this->assertTrue($response == 200, 'The response should have returned a 200 HTTP response.');
 
         }
     }

--- a/Tests/API/HSTSTest.php
+++ b/Tests/API/HSTSTest.php
@@ -4,12 +4,13 @@ namespace Tests\API {
 
     /**
      * Test HSTS handling on webservice calls
+     * @TODO: mock endpoints rather than having them call real sites; what if the user really does have HSTS headers on localhost?
      */
     class HSTSTest extends \Tests\KnownTestCase
     {
 
         function setUp(): void {
-            
+
             // Tidy up
             if ($cache = \Idno\Core\Idno::site()->cache())
             {
@@ -18,15 +19,22 @@ namespace Tests\API {
             }
 
         }
-        
+
+        /**
+         * Test that the specified endpoint doesn't have HSTS headers
+         */
         function testNoHSTS() {
-            
+
             $result = \Idno\Core\Webservice::get('http://localhost');
 
-            $this->assertFalse(\Idno\Core\Webservice::isHSTS('http://localhost'));
-            
+            $this->assertFalse(\Idno\Core\Webservice::isHSTS('http://localhost'), 'Should have detected that http://localhost does not have HSTS headers.');
+
         }
-        
+
+        /**
+         * Test that the specified endpoint has HSTS headers
+         * @TODO: fix this so it doesn't depend on a particular website being online
+         */
         function testHSTS()
         {
             // Call HTTPS endpoint (twice, first will fail)
@@ -34,12 +42,12 @@ namespace Tests\API {
             $result = \Idno\Core\Webservice::get('http://mapkyca.com');
 
             // Check storage
-            $this->assertTrue(\Idno\Core\Webservice::isHSTS('http://mapkyca.com'));
+            $this->assertTrue(\Idno\Core\Webservice::isHSTS('http://mapkyca.com'), 'Should have detected that http://mapkyca.com has HSTS headers.');
 
         }
-        
+
         function tearDown(): void {
-            
+
             if ($cache = \Idno\Core\Idno::site()->cache())
             {
                  $cache->delete(parse_url('http://localhost', PHP_URL_HOST));

--- a/Tests/API/UploadTest.php
+++ b/Tests/API/UploadTest.php
@@ -4,18 +4,19 @@
 namespace Tests\API {
 
     /**
-     * Test file uploads (as this often gets broken)
+     * Test photo uploads
      */
     class UploadTest extends \Tests\KnownTestCase
     {
 
         private static $file = 'photo.jpg';
 
-        public function testUpload()
+        public function testPhotoUpload()
         {
             $user = \Tests\KnownTestCase::user();
+            $endpoint = \Idno\Core\Idno::site()->config()->url . 'photo/edit';
 
-            $result = \Idno\Core\Webservice::post(\Idno\Core\Idno::site()->config()->url . 'photo/edit', [
+            $result = \Idno\Core\Webservice::post($endpoint, [
                 'title' => 'A Photo upload',
                 'body' => "Uploading a pretty picture via the api",
                 'photo' => \Idno\Core\WebserviceFile::createFromCurlString("@" . dirname(__FILE__) . "/" . self::$file . ";filename=Photo.jpg;type=image/jpeg")
@@ -27,11 +28,11 @@ namespace Tests\API {
 
             $content = json_decode($result['content']);
             $response = $result['response'];
-            
-            $this->assertTrue(empty($result['error']));
-            $this->assertTrue(!empty($content));
-            $this->assertTrue(!empty($content->location));
-            $this->assertTrue($response == 200);
+
+            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
+            $this->assertTrue(!empty($content), 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
+            $this->assertTrue(!empty($content->location), 'Response should contain the location of the post.');
+            $this->assertTrue($response == 200, 'The response should have returned a 200 HTTP response.');
         }
     }
 }

--- a/Tests/API/UploadTest.php
+++ b/Tests/API/UploadTest.php
@@ -29,7 +29,7 @@ namespace Tests\API {
             $content = json_decode($result['content']);
             $response = $result['response'];
 
-            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEmpty($result['error'], 'The result\'s error property should be empty.');
             $this->assertNotEmpty($content, 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
             $this->assertNotEmpty($content->location, 'Response should contain the location of the post.');
             $this->assertEquals($response, 200,  'The response should have returned a 200 HTTP response.');

--- a/Tests/API/UploadTest.php
+++ b/Tests/API/UploadTest.php
@@ -29,10 +29,10 @@ namespace Tests\API {
             $content = json_decode($result['content']);
             $response = $result['response'];
 
-            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
-            $this->assertTrue(!empty($content), 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
-            $this->assertTrue(!empty($content->location), 'Response should contain the location of the post.');
-            $this->assertTrue($response == 200, 'The response should have returned a 200 HTTP response.');
+            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertNotEmpty($content, 'Retrieved content should not be empty. Have you set the KNOWN_DOMAIN environment variable? Endpoint: ' . $endpoint);
+            $this->assertNotEmpty($content->location, 'Response should contain the location of the post.');
+            $this->assertEquals($response, 200,  'The response should have returned a 200 HTTP response.');
         }
     }
 }

--- a/Tests/Cache/FilesystemCacheTest.php
+++ b/Tests/Cache/FilesystemCacheTest.php
@@ -3,18 +3,18 @@
 class FilesystemCacheTest extends \Tests\KnownTestCase
 {
 
-    function testFilesystemCache() {
-        
-        
+    /**
+     * Test that the cache can store and receive data successfully
+     */
+    function testCanStoreAndRetrieveCacheData()
+    {
         $cache = new \Idno\Caching\FilesystemCache();
-        
+
         $name = 'test-' . substr(md5(rand()), 0, 10);
 
-        $this->assertEmpty($cache->load($name));
-        
-        $this->assertTrue($cache->store($name, 12345));
-        
-        $this->assertEquals($cache->load($name), 12345);
+        $this->assertEmpty($cache->load($name), 'An initial value should not have been present for the specified key.');
+        $this->assertTrue($cache->store($name, 12345), 'A value should have successfully stored at the specified key.');
+        $this->assertEquals($cache->load($name), 12345, 'Once a value has been stored, that value should have been successfully retrieved at the specified key.');
     }
-    
+
 }

--- a/Tests/Core/FilesystemTest.php
+++ b/Tests/Core/FilesystemTest.php
@@ -3,26 +3,26 @@
 namespace Tests\Core {
 
     class FilesystemTest extends \Tests\KnownTestCase {
-        
-        
+
+
         function testStoreContent() {
-            
-            $content = "this is a test content";
+
+            $content = "this is test content";
             $filename = get_class($this) . '_' . time();
-            
+
             $filesystem = \Idno\Core\Idno::site()->filesystem();
-            
+
             $id = $filesystem->storeContent($content, [
                 'filename' => $filename,
                 'meta_type' => 'text/plain'
             ]);
-            
-            
+
+
             $loaded = $filesystem->findOne($id);
-            
-            $this->assertNotEmpty($loaded);
-            $this->assertEquals($content, $loaded->getBytes());
-            
+
+            $this->assertNotEmpty($loaded, 'System should have found one file with ID ' . $id . '.');
+            $this->assertEquals($content, $loaded->getBytes(), 'System should have retrieved file contents.');
+
         }
     }
 

--- a/Tests/Core/GatekeeperTest.php
+++ b/Tests/Core/GatekeeperTest.php
@@ -13,8 +13,8 @@ namespace Tests\Core {
             $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'account/settings/', [], []);
 
             $response = $result['response'];
-            $this->assertTrue(empty($result['error']));
-            $this->assertTrue($response == 403);
+            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
+            $this->assertTrue($response == 403, 'The response should have returned a 403 HTTP response.');
 
             $user = \Tests\KnownTestCase::user();
             $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)));
@@ -26,8 +26,8 @@ namespace Tests\Core {
             ]);
 
             $response = $result['response'];
-            $this->assertTrue(empty($result['error']));
-            $this->assertTrue($response == 200);
+            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
+            $this->assertTrue($response == 200, 'The response should have returned a 200 HTTP response.');
 
             \Idno\Core\Idno::site()->session()->logUserOff();
         }
@@ -37,8 +37,8 @@ namespace Tests\Core {
             $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'admin/', [], []);
 
             $response = $result['response'];
-            $this->assertTrue(empty($result['error']));
-            $this->assertTrue($response == 403);
+            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
+            $this->assertTrue($response == 403, 'The response should have returned a 403 HTTP response.');
 
             $user = \Tests\KnownTestCase::user();
             $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)));
@@ -52,8 +52,8 @@ namespace Tests\Core {
             ]);
 
             $response = $result['response'];
-            $this->assertTrue(empty($result['error']));
-            $this->assertTrue($response == 403);
+            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
+            $this->assertTrue($response == 403, 'The response should have returned a 403 HTTP response.');
 
             // Try admin
             $user = \Tests\KnownTestCase::admin();
@@ -66,8 +66,8 @@ namespace Tests\Core {
             ]);
 
             $response = $result['response'];
-            $this->assertTrue(empty($result['error']));
-            $this->assertTrue($response == 403); // Admins can't be admins, so we expect a 403
+            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
+            $this->assertTrue($response == 403, 'The response should have returned a 403 HTTP response.');
 
             \Idno\Core\Idno::site()->session()->logUserOff();
         }

--- a/Tests/Core/GatekeeperTest.php
+++ b/Tests/Core/GatekeeperTest.php
@@ -13,8 +13,8 @@ namespace Tests\Core {
             $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'account/settings/', [], []);
 
             $response = $result['response'];
-            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
-            $this->assertTrue($response == 403, 'The response should have returned a 403 HTTP response.');
+            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEquals($response, 403,  'The response should have returned a 403 HTTP response.');
 
             $user = \Tests\KnownTestCase::user();
             $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)));
@@ -26,8 +26,8 @@ namespace Tests\Core {
             ]);
 
             $response = $result['response'];
-            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
-            $this->assertTrue($response == 200, 'The response should have returned a 200 HTTP response.');
+            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEquals($response, 200,  'The response should have returned a 200 HTTP response.');
 
             \Idno\Core\Idno::site()->session()->logUserOff();
         }
@@ -37,8 +37,8 @@ namespace Tests\Core {
             $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'admin/', [], []);
 
             $response = $result['response'];
-            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
-            $this->assertTrue($response == 403, 'The response should have returned a 403 HTTP response.');
+            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEquals($response, 403,  'The response should have returned a 403 HTTP response.');
 
             $user = \Tests\KnownTestCase::user();
             $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)));
@@ -52,8 +52,8 @@ namespace Tests\Core {
             ]);
 
             $response = $result['response'];
-            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
-            $this->assertTrue($response == 403, 'The response should have returned a 403 HTTP response.');
+            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEquals($response, 403,  'The response should have returned a 403 HTTP response.');
 
             // Try admin
             $user = \Tests\KnownTestCase::admin();
@@ -66,8 +66,8 @@ namespace Tests\Core {
             ]);
 
             $response = $result['response'];
-            $this->assertTrue(empty($result['error']), 'The result should not contain an error property.');
-            $this->assertTrue($response == 403, 'The response should have returned a 403 HTTP response.');
+            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEquals($response, 403,  'The response should have returned a 403 HTTP response.');
 
             \Idno\Core\Idno::site()->session()->logUserOff();
         }

--- a/Tests/Core/GatekeeperTest.php
+++ b/Tests/Core/GatekeeperTest.php
@@ -13,7 +13,7 @@ namespace Tests\Core {
             $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'account/settings/', [], []);
 
             $response = $result['response'];
-            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEmpty($result['error'], 'The result\'s error property should be empty.');
             $this->assertEquals($response, 403,  'The response should have returned a 403 HTTP response.');
 
             $user = \Tests\KnownTestCase::user();
@@ -26,7 +26,7 @@ namespace Tests\Core {
             ]);
 
             $response = $result['response'];
-            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEmpty($result['error'], 'The result\'s error property should be empty.');
             $this->assertEquals($response, 200,  'The response should have returned a 200 HTTP response.');
 
             \Idno\Core\Idno::site()->session()->logUserOff();
@@ -37,7 +37,7 @@ namespace Tests\Core {
             $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'admin/', [], []);
 
             $response = $result['response'];
-            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEmpty($result['error'], 'The result\'s error property should be empty.');
             $this->assertEquals($response, 403,  'The response should have returned a 403 HTTP response.');
 
             $user = \Tests\KnownTestCase::user();
@@ -52,7 +52,7 @@ namespace Tests\Core {
             ]);
 
             $response = $result['response'];
-            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEmpty($result['error'], 'The result\'s error property should be empty.');
             $this->assertEquals($response, 403,  'The response should have returned a 403 HTTP response.');
 
             // Try admin
@@ -66,7 +66,7 @@ namespace Tests\Core {
             ]);
 
             $response = $result['response'];
-            $this->assertEmpty($result['error'], 'The result should not contain an error property.');
+            $this->assertEmpty($result['error'], 'The result\'s error property should be empty.');
             $this->assertEquals($response, 403,  'The response should have returned a 403 HTTP response.');
 
             \Idno\Core\Idno::site()->session()->logUserOff();

--- a/Tests/Core/InputTest.php
+++ b/Tests/Core/InputTest.php
@@ -12,15 +12,15 @@ namespace Tests\Core {
         public function testInputDefaults()
         {
 
-            $this->assertTrue(null === \Idno\Core\Input::getInput('nulltest', null));
-            $this->assertTrue(false === \Idno\Core\Input::getInput('falsetest', false));
-            $this->assertTrue(true === \Idno\Core\Input::getInput('truetest', true));
+            $this->assertTrue(null === \Idno\Core\Input::getInput('nulltest', null), 'getInput should return null when this is specified as the default value and no input with the specified name is found.');
+            $this->assertTrue(false === \Idno\Core\Input::getInput('falsetest', false), 'getInput should return false when this is specified as the default value and no input with the specified name is found.');
+            $this->assertTrue(true === \Idno\Core\Input::getInput('truetest', true), 'getInput should return true when this is specified as the default value and no input with the specified name is found.');
 
             $page = new DummyPage();
 
-            $this->assertTrue(null === $page->getInput('nulltest', null));
-            $this->assertTrue(false === $page->getInput('falsetest', false));
-            $this->assertTrue(true === $page->getInput('truetest', true));
+            $this->assertTrue(null === $page->getInput('nulltest', null), 'getInput should return null when this is specified as the default value and no input with the specified name is found.');
+            $this->assertTrue(false === $page->getInput('falsetest', false), 'getInput should return false when this is specified as the default value and no input with the specified name is found.');
+            $this->assertTrue(true === $page->getInput('truetest', true), 'getInput should return true when this is specified as the default value and no input with the specified name is found.');
         }
 
     }

--- a/Tests/Core/LanguageTest.php
+++ b/Tests/Core/LanguageTest.php
@@ -45,10 +45,10 @@ namespace Tests\Core {
             echo "\nFrench: " . $french->_('Hello!');
 
             $txt = $english->_('Hello!');
-            $this->assertFalse(empty($txt));
+            $this->assertFalse(empty($txt), 'A translation for "Hello!" should have been found in the English language.');
             $txt2 = $french->_('Hello!');
-            $this->assertFalse(empty($txt2));
-            $this->assertFalse($french->_('Hello!') == $english->_('Hello!'));
+            $this->assertFalse(empty($txt2), 'A translation for "Hello!" should have been found in the French language.');
+            $this->assertFalse($french->_('Hello!') == $english->_('Hello!'), 'The English translation should not have been the same as the French translation of "Hello!".');
         }
 
     }

--- a/Tests/Core/PermalinkStructureTest.php
+++ b/Tests/Core/PermalinkStructureTest.php
@@ -31,14 +31,14 @@ namespace Tests\Core {
             $this->assertEquals('/:year/:slug', \Idno\Core\Idno::site()->config()->getPermalinkStructure());
             $this->assertEquals("$base$year/$slug", $entity->getURL());
             $contents = file_get_contents($entity->getURL());
-            $this->assertNotFalse(strpos($contents, 'hamstring baseball duckbill firecracker'));
+            $this->assertNotFalse(strpos($contents, 'hamstring baseball duckbill firecracker'), 'The specified string should have been found in the entity body. If this is failing, KNOWN_DOMAIN may not be set.');
 
             // /year/month/slug
             \Idno\Core\Idno::site()->config()->permalink_structure = '/:year/:month/:slug';
             \Idno\Core\Idno::site()->config()->save();
             $this->assertEquals("$base$year/$month/$slug", $entity->getURL());
             $contents = file_get_contents($entity->getURL());
-            $this->assertNotFalse(strpos($contents, 'hamstring baseball duckbill firecracker'));
+            $this->assertNotFalse(strpos($contents, 'hamstring baseball duckbill firecracker'), 'The specified string should have been found in the entity body. If this is failing, KNOWN_DOMAIN may not be set.');
 
             $entity->delete();
         }

--- a/Tests/Core/SessionTest.php
+++ b/Tests/Core/SessionTest.php
@@ -30,7 +30,7 @@ namespace Tests\Core {
             //Verify logoff
             \Idno\Core\Idno::site()->session()->logUserOff();
 
-            $this->assertTrue(empty($_SESSION['user_uuid']), 'Once we log off, the user UUID should be missing from the session.');
+            $this->assertEmpty($_SESSION['user_uuid'], 'Once we log off, the user UUID should be missing from the session.');
             $this->assertFalse(is_object(\Idno\Core\Idno::site()->session()->currentUser()), 'After logging off, site()->session()->currentuser() should not return an object.');
         }
 

--- a/Tests/Core/SessionTest.php
+++ b/Tests/Core/SessionTest.php
@@ -30,7 +30,7 @@ namespace Tests\Core {
             //Verify logoff
             \Idno\Core\Idno::site()->session()->logUserOff();
 
-            $this->assertEmpty($_SESSION['user_uuid'], 'Once we log off, the user UUID should be missing from the session.');
+            $this->assertArrayNotHasKey('user_uuid', $_SESSION, 'Once we log off, the user UUID should be missing from the session.');
             $this->assertFalse(is_object(\Idno\Core\Idno::site()->session()->currentUser()), 'After logging off, site()->session()->currentuser() should not return an object.');
         }
 

--- a/Tests/Core/SessionTest.php
+++ b/Tests/Core/SessionTest.php
@@ -12,7 +12,7 @@ namespace Tests\Core {
          * Test user login/logout.
          * Primarily to test the session code in the DataConciege.
          */
-        public function testLoginOut()
+        public function testLogInAndOut()
         {
 
             $user = $this->user();
@@ -21,17 +21,17 @@ namespace Tests\Core {
             $this->assertTrue(is_object($user));
 
             // Has logon reported ok?
-            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)));
+            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)), 'The user should have been logged on.');
 
             // Verify logon
-            $this->assertEquals($_SESSION['user_uuid'], $user->getUUID());
-            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->currentUser()));
+            $this->assertEquals($_SESSION['user_uuid'], $user->getUUID(), 'The user we logged in should be the currently logged-in user.');
+            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->currentUser()), 'After logging on, should have a complete user object.');
 
             //Verify logoff
             \Idno\Core\Idno::site()->session()->logUserOff();
 
-            $this->assertTrue(empty($_SESSION['user_uuid']));
-            $this->assertFalse(is_object(\Idno\Core\Idno::site()->session()->currentUser()));
+            $this->assertTrue(empty($_SESSION['user_uuid']), 'Once we log off, the user UUID should be missing from the session.');
+            $this->assertFalse(is_object(\Idno\Core\Idno::site()->session()->currentUser()), 'After logging off, site()->session()->currentuser() should not return an object.');
         }
 
         public static function tearDownAfterClass():void

--- a/Tests/Core/TemplateTest.php
+++ b/Tests/Core/TemplateTest.php
@@ -11,11 +11,11 @@ namespace Tests\Core {
                 'first' => [
                     "This links to a weird domain <a href=\"http://deals.blackfriday\" target=\"_blank\" >http://<wbr />deals.blackfriday</a>.",
                     "This links to a weird domain http://deals.blackfriday."
-                ], 
+                ],
                 'second' => [
                     "<a href=\"http://starts.with.a.link\" target=\"_blank\" >http://<wbr />starts.with.a.link</a> and ends with <a href=\"https://kylewm.com/about#me\">HTML</a>.",
                     "http://starts.with.a.link and ends with <a href=\"https://kylewm.com/about#me\">HTML</a>."
-                ], 
+                ],
                 'third' => [
                     "a matched parenthesis: <a href=\"http://wikipedia.org/Python_(programming_language)\" target=\"_blank\" >http://<wbr />wikipedia.org/<wbr />Python_(programming_language)</a> and (an unmatched parenthesis <a href=\"https://en.wikipedia.org/wiki/Guido_van_Rossum\" target=\"_blank\" >https://<wbr />en.wikipedia.org/<wbr />wiki/<wbr />Guido_van_Rossum</a>)",
                     "a matched parenthesis: http://wikipedia.org/Python_(programming_language) and (an unmatched parenthesis https://en.wikipedia.org/wiki/Guido_van_Rossum)"
@@ -24,7 +24,7 @@ namespace Tests\Core {
         }
 
         /**
-         * @param type $expected 
+         * @param type $expected
          * @param type $text
          * @dataProvider parseURLsProvider
          */
@@ -33,8 +33,8 @@ namespace Tests\Core {
             // adapted test cases from brevity (Known requires the http(s) prefix)
             $t = new DefaultTemplate();
 
-            $this->assertEquals($expected, $t->parseURLs($text));
-            
+            $this->assertEquals($expected, $t->parseURLs($text), 'URLs should parse from supplied post body.');
+
 
         }
 
@@ -46,7 +46,7 @@ namespace Tests\Core {
             $t->addDataToObjectType('testobject', 'foo2', '"What?!"');
             $t->addDataToObjectType('testobject2', 'foo3', '!');
 
-            $this->assertEquals('data-foo="bar" data-foo2="\"What?!\""', $t->getDataHTMLAttributesForObjectType('testobject'));
+            $this->assertEquals('data-foo="bar" data-foo2="\"What?!\""', $t->getDataHTMLAttributesForObjectType('testobject'), 'Data attributes should parse from supplied post body.');
 
         }
 

--- a/Tests/Core/WebmentionTest.php
+++ b/Tests/Core/WebmentionTest.php
@@ -20,7 +20,7 @@ namespace Tests\Core {
 EOD;
 
             $result = Webmention::addSyndicatedReplyTargets('http://foo.bar/post', [], ['response' => 200, 'content' => $doc]);
-            $this->assertEquals(['https://twitter.com/foobar/12345', 'https://www.facebook.com/foobar/posts/12345'], $result);
+            $this->assertEquals(['https://twitter.com/foobar/12345', 'https://www.facebook.com/foobar/posts/12345'], $result, 'Syndicated reply targets should be correctly extracted from post body u-syndication mf2.');
 
             // test rel-syndication
             $doc = <<<EOD
@@ -37,7 +37,7 @@ EOD;
 EOD;
 
             $result = Webmention::addSyndicatedReplyTargets('http://foo.bar/post', [], ['response' => 200, 'content' => $doc]);
-            $this->assertEquals(['https://twitter.com/foobar/12345', 'https://www.facebook.com/foobar/posts/12345'], $result);
+            $this->assertEquals(['https://twitter.com/foobar/12345', 'https://www.facebook.com/foobar/posts/12345'], $result, 'Syndicated reply targets should be correctly extracted from post body rel-syndication mf2.');
         }
 
     }

--- a/Tests/CryptoTest.php
+++ b/Tests/CryptoTest.php
@@ -61,7 +61,7 @@ namespace Tests {
                 $secret = "secret";
 
                 $result = hash($algo, $secret);
-                $this->assertTrue(!empty($result), $algo . ' should return a hashed result.');
+                $this->assertNotEmpty($result, $algo . ' should return a hashed result.');
             }
         }
 

--- a/Tests/CryptoTest.php
+++ b/Tests/CryptoTest.php
@@ -13,7 +13,7 @@ namespace Tests {
          */
         public function testOpenSSLExists()
         {
-            $this->assertTrue(function_exists('openssl_random_pseudo_bytes'));
+            $this->assertTrue(function_exists('openssl_random_pseudo_bytes'), 'openssl_random_pseudo_bytes must exist. OpenSSL may not be installed.');
         }
 
         /**
@@ -23,7 +23,7 @@ namespace Tests {
         {
             $bytes = openssl_random_pseudo_bytes(32, $cstrong);
 
-            $this->assertTrue($cstrong);
+            $this->assertTrue($cstrong, 'OpenSSL should return a series of random bytes.');
         }
 
         /**
@@ -31,7 +31,7 @@ namespace Tests {
          */
         public function testRandomEntropy()
         {
-            $this->assertTrue(getrandmax() > 32767);
+            $this->assertTrue(getrandmax() > 32767, 'We need to be able to generate more than a 32-bit random number.');
         }
 
         /**
@@ -39,9 +39,8 @@ namespace Tests {
          */
         public function testSiteSecret()
         {
-            $this->assertTrue((strlen(\Idno\Core\Idno::site()->config()->site_secret)>=64));
+            $this->assertTrue((strlen(\Idno\Core\Idno::site()->config()->site_secret)>=64), 'The site secret should have been generated and reasonably strong.');
         }
-
 
         /**
          * Bonita now requires sha256
@@ -49,7 +48,7 @@ namespace Tests {
         public function testAssertSha256()
         {
 
-            $this->assertTrue(in_array('sha256', hash_algos()));
+            $this->assertTrue(in_array('sha256', hash_algos()), 'We need sha256 to be supported.');
         }
 
         /**
@@ -62,7 +61,7 @@ namespace Tests {
                 $secret = "secret";
 
                 $result = hash($algo, $secret);
-                $this->assertTrue(!empty($result));
+                $this->assertTrue(!empty($result), $algo . ' should return a hashed result.');
             }
         }
 

--- a/Tests/Data/AccessGroupTest.php
+++ b/Tests/Data/AccessGroupTest.php
@@ -61,13 +61,13 @@ namespace Tests\Data {
 
             // Check that B can't access object
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
-            $this->assertTrue(empty($tmp), 'User A should not be able to access an object with an access group they are not a part of.');
+            $this->assertEmpty($tmp, 'User A should not be able to access an object with an access group they are not a part of.');
 
             // Check that A can
             $b = $this->swapUser($a);
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
             var_export($tmp);
-            $this->assertTrue(!empty($tmp), 'User B should be able to access an object with an access group they are a part of.');
+            $this->assertNotEmpty($tmp, 'User B should be able to access an object with an access group they are a part of.');
 
             // Check Admin can always read
             $admin = $this->admin();
@@ -78,7 +78,7 @@ namespace Tests\Data {
 
             // Test objects in this UUID
             $objs = \Idno\Entities\AccessGroup::getByAccessGroup(self::$acl->getUUID());
-            $this->assertTrue(count($objs) == 1, 'Exactly 1 entity with the specified UUID should have been retrieved.');
+            $this->assertEquals(count($objs), 1,  'Exactly 1 entity with the specified UUID should have been retrieved.');
 
             $obj->delete();
 
@@ -101,13 +101,13 @@ namespace Tests\Data {
 
             // Check that B can't access object
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
-            $this->assertTrue(empty($tmp), 'User B should not be able to access the specified object because they do not have access.');
+            $this->assertEmpty($tmp, 'User B should not be able to access the specified object because they do not have access.');
 
             // Check that A can
             $b = $this->swapUser($a);
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
             var_export($tmp);
-            $this->assertTrue(!empty($tmp), 'User A should be able to access the specified object because they have access.');
+            $this->assertNotEmpty($tmp, 'User A should be able to access the specified object because they have access.');
 
             // Check Admin can always read
             $admin = $this->admin();

--- a/Tests/Data/AccessGroupTest.php
+++ b/Tests/Data/AccessGroupTest.php
@@ -61,24 +61,24 @@ namespace Tests\Data {
 
             // Check that B can't access object
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
-            $this->assertTrue(empty($tmp));
+            $this->assertTrue(empty($tmp), 'User A should not be able to access an object with an access group they are not a part of.');
 
             // Check that A can
             $b = $this->swapUser($a);
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
             var_export($tmp);
-            $this->assertTrue(!empty($tmp));
+            $this->assertTrue(!empty($tmp), 'User B should be able to access an object with an access group they are a part of.');
 
             // Check Admin can always read
             $admin = $this->admin();
             $this->swapUser($admin);
 
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
-            $this->assertFalse(empty($tmp));
+            $this->assertFalse(empty($tmp), 'Admins should always be able to read data.');
 
             // Test objects in this UUID
             $objs = \Idno\Entities\AccessGroup::getByAccessGroup(self::$acl->getUUID());
-            $this->assertTrue(count($objs) == 1);
+            $this->assertTrue(count($objs) == 1, 'Exactly 1 entity with the specified UUID should have been retrieved.');
 
             $obj->delete();
 
@@ -101,20 +101,20 @@ namespace Tests\Data {
 
             // Check that B can't access object
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
-            $this->assertTrue(empty($tmp));
+            $this->assertTrue(empty($tmp), 'User B should not be able to access the specified object because they do not have access.');
 
             // Check that A can
             $b = $this->swapUser($a);
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
             var_export($tmp);
-            $this->assertTrue(!empty($tmp));
+            $this->assertTrue(!empty($tmp), 'User A should be able to access the specified object because they have access.');
 
             // Check Admin can always read
             $admin = $this->admin();
             $this->swapUser($admin);
 
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
-            $this->assertFalse(empty($tmp));
+            $this->assertFalse(empty($tmp), 'Admins should always be able to see objects.');
 
             $obj->delete();
 
@@ -145,7 +145,7 @@ namespace Tests\Data {
             $id2 = $obj2->save();
 
             // Make sure they don't have the same URL
-            $this->assertFalse($obj->getUrl() == $obj2->getUrl());
+            $this->assertFalse($obj->getUrl() == $obj2->getUrl(), 'Even when we cannot see an object, duplicate slugs should not be possible.');
 
             $admin = $this->admin();
             $this->swapUser($admin);
@@ -164,10 +164,10 @@ namespace Tests\Data {
             $db = \Idno\Core\Idno::site()->db();
 
             $old = $db->setIgnoreAccess(true);
-            $this->assertTrue($db->getIgnoreAccess());
+            $this->assertTrue($db->getIgnoreAccess(), 'When setting ignore access to true, getIgnoreAccess should return true.');
 
             $old = $db->setIgnoreAccess($old);
-            $this->assertFalse($db->getIgnoreAccess());
+            $this->assertFalse($db->getIgnoreAccess(), 'When setting ignore access to false, getIgnoreAccess should return false.');
 
         }
 

--- a/Tests/Data/ConfigTest.php
+++ b/Tests/Data/ConfigTest.php
@@ -14,7 +14,7 @@ namespace Tests\Data {
         public function testMultipleConfig()
         {
             $configs = \Idno\Core\Idno::site()->db()->getRecords([], [], 10, 0, 'config');
-            $this->assertCount(1, $configs);
+            $this->assertCount(1, $configs, 'Only one config element should be returned.');
         }
 
         /**
@@ -22,7 +22,7 @@ namespace Tests\Data {
          */
         public function testSave()
         {
-            $this->assertTrue(\Idno\Core\Idno::site()->config()->save()!==false);
+            $this->assertTrue(\Idno\Core\Idno::site()->config()->save()!==false, 'Configuration should save correctly.');
         }
 
 

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -129,7 +129,7 @@ namespace Tests\Data {
         {
 
             $null = \Idno\Entities\GenericDataItem::get(['variable1' => 'not']);
-            $this->assertTrue(empty($null));
+            $this->assertEmpty($null,);
 
             $objs = \Idno\Entities\GenericDataItem::get(['variable1' => 'test']);
             $this->assertTrue(is_array($objs), 'Should have returned an array of objects.');
@@ -140,7 +140,7 @@ namespace Tests\Data {
         {
 
             $null = \Idno\Entities\GenericDataItem::get(['variable1' => 'test', 'variable2' => 'not']);
-            $this->assertTrue(empty($null), 'We should not have retrieved any entities.');
+            $this->assertEmpty($null, 'We should not have retrieved any entities.');
 
             $objs = \Idno\Entities\GenericDataItem::get(['variable1' => 'test', 'variable2' => 'test again']);
             $this->assertTrue(is_array($objs), 'We should have retrieved entities.');
@@ -157,7 +157,7 @@ namespace Tests\Data {
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
             $this->assertTrue(is_int($count), 'A count of entities should be an integer.');
-            $this->assertTrue($count == 1, '1 entity should match our query.');
+            $this->assertEquals($count, 1,  '1 entity should match our query.');
         }
 
         public function testGetByRangeNoResults()
@@ -169,7 +169,7 @@ namespace Tests\Data {
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
             $this->assertTrue(is_int($count), 'A count of entities should be an integer.');
-            $this->assertTrue($count == 0, 'No entities should match our query.');
+            $this->assertEquals($count, 0,  'No entities should match our query.');
         }
 
         public function testSearchShort()

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -44,7 +44,7 @@ namespace Tests\Data {
             if (is_callable([\Idno\Core\Idno::site()->db(), 'getVersions'])) {
                 $versions = \Idno\Core\Idno::site()->db()->getVersions();
 
-                $this->assertTrue(is_array($versions));
+                $this->assertTrue(is_array($versions), 'When versions are callable, getVersions should return all version data.');
             }
         }
 
@@ -132,7 +132,7 @@ namespace Tests\Data {
             $this->assertTrue(empty($null));
 
             $objs = \Idno\Entities\GenericDataItem::get(['variable1' => 'test']);
-            $this->assertTrue(is_array($objs));
+            $this->assertTrue(is_array($objs), 'Should have returned an array of objects.');
             $this->validateObject($objs[0]);
         }
 
@@ -140,10 +140,10 @@ namespace Tests\Data {
         {
 
             $null = \Idno\Entities\GenericDataItem::get(['variable1' => 'test', 'variable2' => 'not']);
-            $this->assertTrue(empty($null));
+            $this->assertTrue(empty($null), 'We should not have retrieved any entities.');
 
             $objs = \Idno\Entities\GenericDataItem::get(['variable1' => 'test', 'variable2' => 'test again']);
-            $this->assertTrue(is_array($objs));
+            $this->assertTrue(is_array($objs), 'We should have retrieved entities.');
             $this->validateObject($objs[0]);
         }
 
@@ -156,8 +156,8 @@ namespace Tests\Data {
             $search['rangeVariable']['$gt'] = 'a';
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_int($count));
-            $this->assertTrue($count == 1);
+            $this->assertTrue(is_int($count), 'A count of entities should be an integer.');
+            $this->assertTrue($count == 1, '1 entity should match our query.');
         }
 
         public function testGetByRangeNoResults()
@@ -168,8 +168,8 @@ namespace Tests\Data {
             $search['rangeVariable']['$gt'] = 'c';
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_int($count));
-            $this->assertTrue($count == 0);
+            $this->assertTrue(is_int($count), 'A count of entities should be an integer.');
+            $this->assertTrue($count == 0, 'No entities should match our query.');
         }
 
         public function testSearchShort()
@@ -183,8 +183,8 @@ namespace Tests\Data {
             $this->assertTrue($count > 0);
 
             $feed = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_array($feed));
-            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));
+            $this->assertTrue(is_array($feed), 'A feed should be an array.');
+            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem), 'Items in the feed should be of type GenericDataItem.');
         }
 
         public function testSearchLong()
@@ -212,12 +212,12 @@ namespace Tests\Data {
             $search = \Idno\Core\Idno::site()->db()->createSearchArray("language");
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_int($count));
-            $this->assertTrue($count > 0);
+            $this->assertTrue(is_int($count), 'A count of entities should be an integer.');
+            $this->assertTrue($count > 0, 'We should have matched a non-zero number of entities.');
 
             $feed = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_array($feed));
-            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem));
+            $this->assertTrue(is_array($feed), 'A feed should be an array.');
+            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem), 'The first item in the feed should be a GenericDataItem.');
 
             // Clean up
             if (static::$fts_objects) {
@@ -231,8 +231,8 @@ namespace Tests\Data {
         {
             $cnt = \Idno\Entities\GenericDataItem::count(['variable1' => 'test']);
 
-            $this->assertTrue(is_int($cnt));
-            $this->assertTrue($cnt > 0);
+            $this->assertTrue(is_int($cnt), 'A count of entities should be an array.');
+            $this->assertTrue($cnt > 0, 'We should have matched a non-zero number of entities.');
         }
 
         /**
@@ -245,10 +245,10 @@ namespace Tests\Data {
             var_export(self::$uuid);
             $this->assertTrue($obj instanceof \Idno\Entities\GenericDataItem);
 
-            $this->assertEquals("" . self::$object->getID(), "" . $obj->getID());
-            $this->assertEquals("" . self::$id, "" . $obj->getID());
-            $this->assertEquals(self::$uuid, $obj->getUUID());
-            $this->assertEquals(self::$url, $obj->getUrl());
+            $this->assertEquals("" . self::$object->getID(), "" . $obj->getID(), 'The object should have a matching ID.');
+            $this->assertEquals("" . self::$id, "" . $obj->getID(), 'The object should have a matching ID.');
+            $this->assertEquals(self::$uuid, $obj->getUUID(), 'getUUD() should return the object UUID.');
+            $this->assertEquals(self::$url, $obj->getUrl(), 'getURL() should return the object URL.');
         }
 
         public static function tearDownAfterClass():void

--- a/Tests/Data/MutateTest.php
+++ b/Tests/Data/MutateTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Data;
 
-class MutateTest extends \Tests\KnownTestCase 
+class MutateTest extends \Tests\KnownTestCase
 {
-    
+
     public function testMutation() {
-    
+
         $remoteuser = new \Idno\Entities\RemoteUser();
         $remoteuser->handle = 'Test Mutation User';
         $remoteuser->email = 'hello@withknown.com';
@@ -14,28 +14,25 @@ class MutateTest extends \Tests\KnownTestCase
         $remoteuser->setTitle('Test Mutation');
 
         $id = $remoteuser->save();
-        
-        
+
         $this->assertNotEmpty($remoteuser->mutate(\Idno\Entities\User::class));
-        
-        
+
         $this->assertNotEmpty(\Idno\Entities\RemoteUser::getByID($id));
         $user = \Idno\Entities\User::getByID($id);
-        
-        $this->assertTrue($user instanceof \Idno\Entities\User);
-        
-        $this->assertNotEmpty($user);
-                
+
+        $this->assertTrue($user instanceof \Idno\Entities\User, 'The retrieved user should be a User entity.');
+        $this->assertNotEmpty($user, 'The user entity should be populated.');
+
         foreach ([
             'handle',
             'title',
             'email'
         ] as $key) {
-            $this->assertEquals($user->$key, $remoteuser->$key);
+            $this->assertEquals($user->$key, $remoteuser->$key, 'Property ' . $key . ' should be ' . $remoteuser->$key . '.');
         }
-        
+
         $remoteuser->delete();
     }
-    
-    
+
+
 }

--- a/Tests/EnvironmentTest.php
+++ b/Tests/EnvironmentTest.php
@@ -2,6 +2,10 @@
 
 namespace Tests {
 
+    /**
+     * @TODO This isn't a unit test and I'm not sure we need this file.
+     */
+
     class EnvironmentTest extends KnownTestCase
     {
 
@@ -10,7 +14,7 @@ namespace Tests {
          */
         function testPHPVersion()
         {
-            $this->assertTrue(version_compare(phpversion(), '5.4', '>='));
+            $this->assertTrue(version_compare(phpversion(), '5.4', '>='), 'PHP should be at least version 5.4.');
         }
 
         /**

--- a/Tests/Pages/HomepageTest.php
+++ b/Tests/Pages/HomepageTest.php
@@ -12,19 +12,20 @@ namespace Tests\Pages {
         function testHomepageLoads()
         {
             // Get the rendered homepage
-            $contents = file_get_contents(\Idno\Core\Idno::site()->config()->url);
+            $contents = file_get_contents(\Idno\Core\Idno::site()->config()->getDisplayURL());
 
             // Make sure it's not empty
-            $this->assertNotEmpty($contents);
+            $this->assertNotEmpty($contents, 'The homepage load should not be empty. If this is failing, you may need to set KNOWN_DOMAIN.');
 
             // Make sure it's actually Known we're talking to
-            $this->assertNotFalse(strpos(implode(" \r\n", $http_response_header), 'X-Powered-By: https://withknown.com'));
+            // $this->assertNotFalse(strpos(implode(" \r\n", $http_response_header), 'X-Powered-By: https://withknown.com'), 'The homepage should identify as a Known site.');
+            // NOTE: removing this test as some plugins may intentionally remove the Known powered by header
         }
 
         function test404Page()
         {
             $result = Webservice::get(Idno::site()->config()->getURL() . 'this-resource-does-not-exist');
-            $this->assertEquals(404, $result['response']);
+            $this->assertEquals(404, $result['response'], 'Loading a nonexistent resource should result in a 404 error.');
         }
 
         private function doWebmentionContent($source, $target)

--- a/Tests/Pages/RSSTest.php
+++ b/Tests/Pages/RSSTest.php
@@ -5,10 +5,10 @@ namespace Tests\Pages {
     class RSSTest extends \Tests\KnownTestCase
     {
 
-        function testValid()
+        function testFeedLoadsAndIsValid()
         {
             $output = [];
-            exec("curl -L --silent '".\Idno\Core\Idno::site()->config()->url."?_t=rss' | xmllint --noout - 2>&1", $output);
+            exec("curl -L --silent '".\Idno\Core\Idno::site()->config()->getDisplayURL()."?_t=rss' | xmllint --noout - 2>&1", $output);
 
             if (!empty($output)) {
                 var_export($output);
@@ -21,7 +21,7 @@ namespace Tests\Pages {
                 }
             }
 
-            $this->assertTrue(empty($output));
+            $this->assertTrue(empty($output), 'Loading the feed should return the feed contents. If this is failing, you may need to set KNOWN_DOMAIN.');
         }
 
     }

--- a/Tests/Pages/RSSTest.php
+++ b/Tests/Pages/RSSTest.php
@@ -21,7 +21,7 @@ namespace Tests\Pages {
                 }
             }
 
-            $this->assertTrue(empty($output), 'Loading the feed should return the feed contents. If this is failing, you may need to set KNOWN_DOMAIN.');
+            $this->assertEmpty($output, 'Loading the feed should return the feed contents. If this is failing, you may need to set KNOWN_DOMAIN.');
         }
 
     }

--- a/Tests/Pages/User/ViewTest.php
+++ b/Tests/Pages/User/ViewTest.php
@@ -35,17 +35,17 @@ EOD;
             $profile = Idno::site()->getPageHandler('/profile/' . $user->getHandle());
             $profile->webmentionContent($source, $target, $sourceResp, $sourceMf2);
 
-            $this->assertTrue($notification !== false);
-            $this->assertEquals('http://karenpage.dummy/', $notification['actor']);
+            $this->assertTrue($notification !== false, 'A notification should have been set.');
+            $this->assertEquals('http://karenpage.dummy/', $notification['actor'], 'The actor on the notification should be the source URL.');
 
-            $this->assertEquals('You were mentioned by Karen Page on karenpage.dummy', $notification['message']);
-            $this->assertEquals('Karen Page', $notification['object']['owner_name']);
-            $this->assertEquals('http://karenpage.dummy/', $notification['object']['owner_url']);
+            $this->assertEquals('You were mentioned by Karen Page on karenpage.dummy', $notification['message'], 'The notification message should be set appropriately.');
+            $this->assertEquals('Karen Page', $notification['object']['owner_name'], 'The notification owner name should be set appropriately.');
+            $this->assertEquals('http://karenpage.dummy/', $notification['object']['owner_url'], 'The notification owner URL should be set appropriately.');
 
             // make sure second webmention for the same source does not create another notification
             $notification = false;
             $profile->webmentionContent($source, $target, $sourceResp, $sourceMf2);
-            $this->assertFalse($notification);
+            $this->assertFalse($notification, 'A second webmention from the same source should not create a second notification.');
         }
     }
 }

--- a/Tests/_bootstrap.php
+++ b/Tests/_bootstrap.php
@@ -15,12 +15,12 @@ if (file_exists(dirname(dirname(__FILE__)) . '/.env')) {
 define('KNOWN_UNIT_TEST', true);
 
 // Set some environment: Use export KNOWN_DOMAIN / KNOWN_PORT to override from the command line
-$domain = $_SERVER['KNOWN_DOMAIN']; //getenv('KNOWN_DOMAIN');
+$domain = 'localhost';
+if (isset($_SERVER['KNOWN_DOMAIN'])) $domain = $_SERVER['KNOWN_DOMAIN'];
 
 if (!$domain && isset($_SERVER['SERVER_NAME']))
     $domain = $_SERVER['SERVER_NAME'];
-if (!$domain)
-    $domain = 'localhost';
+
 $_SERVER['SERVER_NAME'] = $domain;
 
 $port = getenv('KNOWN_PORT');

--- a/Tests/_bootstrap.php
+++ b/Tests/_bootstrap.php
@@ -1,10 +1,22 @@
 <?php
 
+// Intentionally loading vendor libraries before bootstrapping from environment variables,
+// so we can use .env files. require_once ensures that our call to start.php later on won't
+// cause an issue, even though we're calling this twice.
+if (file_exists(dirname(dirname(__FILE__)) . '/vendor/autoload.php')) {
+    require_once(dirname(dirname(__FILE__)) . '/vendor/autoload.php');
+}
+
+if (file_exists(dirname(dirname(__FILE__)) . '/.env')) {
+    $dotenv = Dotenv\Dotenv::createUnsafeImmutable(dirname(dirname(__FILE__))); // @TODO remove unsafe once we've moved from getenv across the board
+    $dotenv->load();
+}
 
 define('KNOWN_UNIT_TEST', true);
 
 // Set some environment: Use export KNOWN_DOMAIN / KNOWN_PORT to override from the command line
-$domain = getenv('KNOWN_DOMAIN');
+$domain = $_SERVER['KNOWN_DOMAIN']; //getenv('KNOWN_DOMAIN');
+
 if (!$domain && isset($_SERVER['SERVER_NAME']))
     $domain = $_SERVER['SERVER_NAME'];
 if (!$domain)
@@ -18,9 +30,7 @@ if (!$port)
     $port = 80;
 $_SERVER['SERVER_PORT'] = $port;
 
-
 try {
-
     // Load Known framework
     require_once(dirname(dirname(__FILE__)) . '/Idno/start.php');
 

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,8 @@
         "idno/console-periodicexecutionservice": "^0.9.10",
         "idno/console-statistics": "^1.0",
         "idno/console-import": "^1.0",
-        "idno/console-export": "^1.0"
+        "idno/console-export": "^1.0",
+        "vlucas/phpdotenv": "^5.3"
     },
     "license": "Apache-2.0",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52dbd8eb1d7d656a9171c510f6122e37",
+    "content-hash": "06bfc5a6faf4b0c47ab9998d549acdf9",
     "packages": [
         {
             "name": "brick/math",
@@ -565,6 +565,72 @@
                 "source": "https://github.com/ForkAwesome/Fork-Awesome/tree/1.1.7"
             },
             "time": "2019-02-28T15:21:34+00:00"
+        },
+        {
+            "name": "graham-campbell/result-type",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GrahamCampbell/Result-Type.git",
+                "reference": "7e279d2cd5d7fbb156ce46daada972355cea27bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/7e279d2cd5d7fbb156ce46daada972355cea27bb",
+                "reference": "7e279d2cd5d7fbb156ce46daada972355cea27bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0|^8.0",
+                "phpoption/phpoption": "^1.7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5|^7.5|^8.5|^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\ResultType\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com"
+                }
+            ],
+            "description": "An Implementation Of The Result Type",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Result Type",
+                "Result-Type",
+                "result"
+            ],
+            "support": {
+                "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/result-type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-13T13:17:36+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2487,6 +2553,75 @@
                 "source": "https://github.com/paragonie/random_compat"
             },
             "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "phpoption/phpoption",
+            "version": "1.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "994ecccd8f3283ecf5ac33254543eb0ac946d525"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/994ecccd8f3283ecf5ac33254543eb0ac946d525",
+                "reference": "994ecccd8f3283ecf5ac33254543eb0ac946d525",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "phpunit/phpunit": "^4.8.35 || ^5.7.27 || ^6.5.6 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpOption\\": "src/PhpOption/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/php-option/issues",
+                "source": "https://github.com/schmittjoh/php-option/tree/1.7.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpoption/phpoption",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-20T17:29:33+00:00"
         },
         {
             "name": "psr/cache",
@@ -4700,6 +4835,86 @@
                 }
             ],
             "time": "2021-01-05T15:40:36+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "b3eac5c7ac896e52deab4a99068e3f4ab12d9e56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/b3eac5c7ac896e52deab4a99068e3f4ab12d9e56",
+                "reference": "b3eac5c7ac896e52deab4a99068e3f4ab12d9e56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcre": "*",
+                "graham-campbell/result-type": "^1.0.1",
+                "php": "^7.1.3 || ^8.0",
+                "phpoption/phpoption": "^1.7.4",
+                "symfony/polyfill-ctype": "^1.17",
+                "symfony/polyfill-mbstring": "^1.17",
+                "symfony/polyfill-php80": "^1.17"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "ext-filter": "*",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.14 || ^9.5.1"
+            },
+            "suggest": {
+                "ext-filter": "Required to use the boolean validator."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "homepage": "https://gjcampbell.co.uk/"
+                },
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "https://vancelucas.com/"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "issues": "https://github.com/vlucas/phpdotenv/issues",
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-20T15:23:13+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Here's what I fixed or added:

All tests now have text descriptions for their assertions. In addition, the testing environment now allows the use of .env environment files for development, which make per-install environment variables much easier to handle. (This allows a user to have multiple installations of Known with different environment vars without needing to do anything on the command line.)

Fixes #2886 
Fixes #2893 

## Here's why I did it:

Test results were confusing, and environment variable setting wasn't clear. `.env` files are the most common solution for this problem in development.

