### PR TITLE
Improve phpunit assertion usage

### DIFF
--- a/Tests/Core/GatekeeperTest.php
+++ b/Tests/Core/GatekeeperTest.php
@@ -17,7 +17,7 @@ namespace Tests\Core {
             $this->assertEquals($response, 403,  'The response should have returned a 403 HTTP response.');
 
             $user = \Tests\KnownTestCase::user();
-            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)));
+            $this->assertIsObject(\Idno\Core\Idno::site()->session()->logUserOn($user));
 
             $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'account/settings/', [], [
                 'X-KNOWN-USERNAME: ' . $user->handle,
@@ -41,7 +41,7 @@ namespace Tests\Core {
             $this->assertEquals($response, 403,  'The response should have returned a 403 HTTP response.');
 
             $user = \Tests\KnownTestCase::user();
-            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)));
+            $this->assertIsObject(\Idno\Core\Idno::site()->session()->logUserOn($user));
 
             // Try normal user
             \Idno\Core\Idno::site()->session()->logUserOff();
@@ -57,7 +57,7 @@ namespace Tests\Core {
 
             // Try admin
             $user = \Tests\KnownTestCase::admin();
-            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)));
+            $this->assertIsObject(\Idno\Core\Idno::site()->session()->logUserOn($user));
 
             $result = \Idno\Core\Webservice::get(\Idno\Core\Idno::site()->config()->url . 'admin/', [], [
                 'X-KNOWN-USERNAME: ' . $user->handle,

--- a/Tests/Core/InputTest.php
+++ b/Tests/Core/InputTest.php
@@ -12,13 +12,13 @@ namespace Tests\Core {
         public function testInputDefaults()
         {
 
-            $this->assertTrue(null === \Idno\Core\Input::getInput('nulltest', null), 'getInput should return null when this is specified as the default value and no input with the specified name is found.');
+            $this->assertNull(\Idno\Core\Input::getInput('nulltest', null), 'getInput should return null when this is specified as the default value and no input with the specified name is found.');
             $this->assertTrue(false === \Idno\Core\Input::getInput('falsetest', false), 'getInput should return false when this is specified as the default value and no input with the specified name is found.');
             $this->assertTrue(true === \Idno\Core\Input::getInput('truetest', true), 'getInput should return true when this is specified as the default value and no input with the specified name is found.');
 
             $page = new DummyPage();
 
-            $this->assertTrue(null === $page->getInput('nulltest', null), 'getInput should return null when this is specified as the default value and no input with the specified name is found.');
+            $this->assertNull($page->getInput('nulltest', null), 'getInput should return null when this is specified as the default value and no input with the specified name is found.');
             $this->assertTrue(false === $page->getInput('falsetest', false), 'getInput should return false when this is specified as the default value and no input with the specified name is found.');
             $this->assertTrue(true === $page->getInput('truetest', true), 'getInput should return true when this is specified as the default value and no input with the specified name is found.');
         }

--- a/Tests/Core/LanguageTest.php
+++ b/Tests/Core/LanguageTest.php
@@ -45,9 +45,9 @@ namespace Tests\Core {
             echo "\nFrench: " . $french->_('Hello!');
 
             $txt = $english->_('Hello!');
-            $this->assertFalse(empty($txt), 'A translation for "Hello!" should have been found in the English language.');
+            $this->assertNotEmpty($txt, 'A translation for "Hello!" should have been found in the English language.');
             $txt2 = $french->_('Hello!');
-            $this->assertFalse(empty($txt2), 'A translation for "Hello!" should have been found in the French language.');
+            $this->assertNotEmpty($txt2, 'A translation for "Hello!" should have been found in the French language.');
             $this->assertFalse($french->_('Hello!') == $english->_('Hello!'), 'The English translation should not have been the same as the French translation of "Hello!".');
         }
 

--- a/Tests/Core/SessionTest.php
+++ b/Tests/Core/SessionTest.php
@@ -18,20 +18,20 @@ namespace Tests\Core {
             $user = $this->user();
 
             // Have we created a user?
-            $this->assertTrue(is_object($user));
+            $this->assertIsObject($user);
 
             // Has logon reported ok?
-            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->logUserOn($user)), 'The user should have been logged on.');
+            $this->assertIsObject(\Idno\Core\Idno::site()->session()->logUserOn($user), 'The user should have been logged on.');
 
             // Verify logon
             $this->assertEquals($_SESSION['user_uuid'], $user->getUUID(), 'The user we logged in should be the currently logged-in user.');
-            $this->assertTrue(is_object(\Idno\Core\Idno::site()->session()->currentUser()), 'After logging on, should have a complete user object.');
+            $this->assertIsObject(\Idno\Core\Idno::site()->session()->currentUser(), 'After logging on, should have a complete user object.');
 
             //Verify logoff
             \Idno\Core\Idno::site()->session()->logUserOff();
 
             $this->assertArrayNotHasKey('user_uuid', $_SESSION, 'Once we log off, the user UUID should be missing from the session.');
-            $this->assertFalse(is_object(\Idno\Core\Idno::site()->session()->currentUser()), 'After logging off, site()->session()->currentuser() should not return an object.');
+            $this->assertIsNotObject(\Idno\Core\Idno::site()->session()->currentUser(), 'After logging off, site()->session()->currentuser() should not return an object.');
         }
 
         public static function tearDownAfterClass():void

--- a/Tests/CryptoTest.php
+++ b/Tests/CryptoTest.php
@@ -31,7 +31,7 @@ namespace Tests {
          */
         public function testRandomEntropy()
         {
-            $this->assertTrue(getrandmax() > 32767, 'We need to be able to generate more than a 32-bit random number.');
+            $this->assertGreaterThan(32767, getrandmax(), 'We need to be able to generate more than a 32-bit random number.');
         }
 
         /**
@@ -48,7 +48,7 @@ namespace Tests {
         public function testAssertSha256()
         {
 
-            $this->assertTrue(in_array('sha256', hash_algos()), 'We need sha256 to be supported.');
+            $this->assertContains('sha256', hash_algos(), 'We need sha256 to be supported.');
         }
 
         /**

--- a/Tests/Data/AccessGroupTest.php
+++ b/Tests/Data/AccessGroupTest.php
@@ -74,7 +74,7 @@ namespace Tests\Data {
             $this->swapUser($admin);
 
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
-            $this->assertFalse(empty($tmp), 'Admins should always be able to read data.');
+            $this->assertNotEmpty($tmp, 'Admins should always be able to read data.');
 
             // Test objects in this UUID
             $objs = \Idno\Entities\AccessGroup::getByAccessGroup(self::$acl->getUUID());
@@ -114,7 +114,7 @@ namespace Tests\Data {
             $this->swapUser($admin);
 
             $tmp = \Idno\Entities\GenericDataItem::getByUUID($obj->getUUID());
-            $this->assertFalse(empty($tmp), 'Admins should always be able to see objects.');
+            $this->assertNotEmpty($tmp, 'Admins should always be able to see objects.');
 
             $obj->delete();
 

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -44,7 +44,7 @@ namespace Tests\Data {
             if (is_callable([\Idno\Core\Idno::site()->db(), 'getVersions'])) {
                 $versions = \Idno\Core\Idno::site()->db()->getVersions();
 
-                $this->assertTrue(is_array($versions), 'When versions are callable, getVersions should return all version data.');
+                $this->assertIsArray($versions, 'When versions are callable, getVersions should return all version data.');
             }
         }
 
@@ -54,9 +54,9 @@ namespace Tests\Data {
         public function testCreateObject()
         {
             // Verify
-            $this->assertFalse(empty(self::$id));
-            $this->assertTrue(is_string(self::$uuid));
-            $this->assertTrue(is_string(self::$url));
+            $this->assertNotEmpty(self::$id);
+            $this->assertIsString(self::$uuid);
+            $this->assertIsString(self::$url);
 
             $this->validateObject(self::$object);
         }
@@ -92,10 +92,10 @@ namespace Tests\Data {
         {
             $arr = \Idno\Core\Idno::site()->db()->getAnyRecord();
 
-            $this->assertFalse(empty($arr));
-            $this->assertTrue(is_array($arr));
+            $this->assertNotEmpty($arr);
+            $this->assertIsArray($arr);
             $obj = \Idno\Core\Idno::site()->db()->rowToEntity($arr);
-            $this->assertTrue(is_object($obj));
+            $this->assertIsObject($obj);
         }
 
         /**
@@ -132,7 +132,7 @@ namespace Tests\Data {
             $this->assertEmpty($null,);
 
             $objs = \Idno\Entities\GenericDataItem::get(['variable1' => 'test']);
-            $this->assertTrue(is_array($objs), 'Should have returned an array of objects.');
+            $this->assertIsArray($objs, 'Should have returned an array of objects.');
             $this->validateObject($objs[0]);
         }
 
@@ -143,7 +143,7 @@ namespace Tests\Data {
             $this->assertEmpty($null, 'We should not have retrieved any entities.');
 
             $objs = \Idno\Entities\GenericDataItem::get(['variable1' => 'test', 'variable2' => 'test again']);
-            $this->assertTrue(is_array($objs), 'We should have retrieved entities.');
+            $this->assertIsArray($objs, 'We should have retrieved entities.');
             $this->validateObject($objs[0]);
         }
 
@@ -156,7 +156,7 @@ namespace Tests\Data {
             $search['rangeVariable']['$gt'] = 'a';
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_int($count), 'A count of entities should be an integer.');
+            $this->assertIsInt($count, 'A count of entities should be an integer.');
             $this->assertEquals($count, 1,  '1 entity should match our query.');
         }
 
@@ -168,7 +168,7 @@ namespace Tests\Data {
             $search['rangeVariable']['$gt'] = 'c';
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_int($count), 'A count of entities should be an integer.');
+            $this->assertIsInt($count, 'A count of entities should be an integer.');
             $this->assertEquals($count, 0,  'No entities should match our query.');
         }
 
@@ -179,12 +179,12 @@ namespace Tests\Data {
             $search = \Idno\Core\Idno::site()->db()->createSearchArray("sear");
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_int($count));
-            $this->assertTrue($count > 0);
+            $this->assertIsInt($count);
+            $this->assertGreaterThan(0, $count);
 
             $feed = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_array($feed), 'A feed should be an array.');
-            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem), 'Items in the feed should be of type GenericDataItem.');
+            $this->assertIsArray($feed, 'A feed should be an array.');
+            $this->assertInstanceOf('\Idno\Entities\GenericDataItem', $feed[0], 'Items in the feed should be of type GenericDataItem.');
         }
 
         public function testSearchLong()
@@ -212,12 +212,12 @@ namespace Tests\Data {
             $search = \Idno\Core\Idno::site()->db()->createSearchArray("language");
 
             $count = \Idno\Entities\GenericDataItem::countFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_int($count), 'A count of entities should be an integer.');
-            $this->assertTrue($count > 0, 'We should have matched a non-zero number of entities.');
+            $this->assertIsInt($count, 'A count of entities should be an integer.');
+            $this->assertGreaterThan(0, $count, 'We should have matched a non-zero number of entities.');
 
             $feed = \Idno\Entities\GenericDataItem::getFromX('Idno\Entities\GenericDataItem', $search);
-            $this->assertTrue(is_array($feed), 'A feed should be an array.');
-            $this->assertTrue(($feed[0] instanceof \Idno\Entities\GenericDataItem), 'The first item in the feed should be a GenericDataItem.');
+            $this->assertIsArray($feed, 'A feed should be an array.');
+            $this->assertInstanceOf('\Idno\Entities\GenericDataItem', $feed[0], 'The first item in the feed should be a GenericDataItem.');
 
             // Clean up
             if (static::$fts_objects) {
@@ -231,8 +231,8 @@ namespace Tests\Data {
         {
             $cnt = \Idno\Entities\GenericDataItem::count(['variable1' => 'test']);
 
-            $this->assertTrue(is_int($cnt), 'A count of entities should be an array.');
-            $this->assertTrue($cnt > 0, 'We should have matched a non-zero number of entities.');
+            $this->assertIsInt($cnt, 'A count of entities should be an array.');
+            $this->assertGreaterThan(0, $cnt, 'We should have matched a non-zero number of entities.');
         }
 
         /**
@@ -243,7 +243,7 @@ namespace Tests\Data {
 
             var_export($obj);
             var_export(self::$uuid);
-            $this->assertTrue($obj instanceof \Idno\Entities\GenericDataItem);
+            $this->assertInstanceOf('\Idno\Entities\GenericDataItem', $obj);
 
             $this->assertEquals("" . self::$object->getID(), "" . $obj->getID(), 'The object should have a matching ID.');
             $this->assertEquals("" . self::$id, "" . $obj->getID(), 'The object should have a matching ID.');

--- a/Tests/Data/MutateTest.php
+++ b/Tests/Data/MutateTest.php
@@ -20,7 +20,7 @@ class MutateTest extends \Tests\KnownTestCase
         $this->assertNotEmpty(\Idno\Entities\RemoteUser::getByID($id));
         $user = \Idno\Entities\User::getByID($id);
 
-        $this->assertTrue($user instanceof \Idno\Entities\User, 'The retrieved user should be a User entity.');
+        $this->assertInstanceOf('\Idno\Entities\User', $user, 'The retrieved user should be a User entity.');
         $this->assertNotEmpty($user, 'The user entity should be populated.');
 
         foreach ([


### PR DESCRIPTION
- Generates much better error messages with expected vs actual.
- Refer to https://phpunit.readthedocs.io/en/9.5/assertions.html

## Here's why I did it:

Finishing up what Ben started.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [x] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.