### PR TITLE
Check for edit permissions before save

### DIFF
--- a/Idno/Entities/RemoteUser.php
+++ b/Idno/Entities/RemoteUser.php
@@ -14,13 +14,13 @@ namespace Idno\Entities {
 
         use Mutate;
 
-        public function save($add_to_feed = false, $feed_verb = 'post')
+        public function save()
         {
             // TODO: use a remote API to save to external sources if we have permission to
             // return false;
 
             // BUT for now, we still need to save some stub information in case we've just followed them
-            return parent::save($add_to_feed, $feed_verb);
+            return parent::save(true);
         }
 
         public function checkPassword($password)

--- a/Idno/Entities/RemoteUser.php
+++ b/Idno/Entities/RemoteUser.php
@@ -14,13 +14,13 @@ namespace Idno\Entities {
 
         use Mutate;
 
-        public function save()
+        public function save($overrideAccess = true)
         {
             // TODO: use a remote API to save to external sources if we have permission to
             // return false;
 
             // BUT for now, we still need to save some stub information in case we've just followed them
-            return parent::save(true);
+            return parent::save($overrideAccess);
         }
 
         public function checkPassword($password)

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -610,7 +610,7 @@ namespace Idno\Entities {
                     }
 
                     $acl->addMember($user->getUUID());
-                    $acl->save();
+                    $acl->save(true);
 
                     \Idno\Core\Idno::site()->events()->triggerEvent('follow', array('user' => $this, 'following' => $user));
 
@@ -673,7 +673,7 @@ namespace Idno\Entities {
 
                 if (!empty($acl)) {
                     $acl->removeMember($user->getUUID());
-                    $acl->save();
+                    $acl->save(true);
                 }
 
                 \Idno\Core\Idno::site()->events()->triggerEvent('unfollow', array('user' => $this, 'following' => $user));
@@ -992,6 +992,15 @@ namespace Idno\Entities {
 
             return $this->save();
 
+        }
+
+        /**
+         * Wrapper for Entity::save()
+         * @return false|\Idno\Core\id
+         */
+        function save($overrideAccess = true)
+        {
+            return parent::save($overrideAccess);
         }
 
         /**

--- a/Idno/Pages/Account/Password/Reset.php
+++ b/Idno/Pages/Account/Password/Reset.php
@@ -54,11 +54,10 @@ namespace Idno\Pages\Account\Password {
                         /* @var \Idno\Entities\User $user */
                         $user->setPassword($password);
                         $user->clearPasswordRecoveryCode();
-                        $user->save();
+                        $user->save(true);
                         \Idno\Core\Idno::site()->session()->addMessage(\Idno\Core\Idno::site()->language()->_("Your password was reset!"));
 
                     }
-
                 }
             } else {
                 \Idno\Core\Idno::site()->session()->addErrorMessage(\Idno\Core\Idno::site()->language()->_('Sorry, your passwords either don\'t match, or are too weak'));

--- a/Idno/Pages/Account/Register.php
+++ b/Idno/Pages/Account/Register.php
@@ -125,7 +125,7 @@ namespace Idno\Pages\Account {
                     } else {
                         \Idno\Core\Idno::site()->events()->triggerEvent('site/newuser', array('user' => $user)); // Event hook for new user
                     }
-                    $user->save();
+                    $user->save(true);
                     // Now we can remove the invitation
                     if (!empty($invitation)) {
                         if ($invitation instanceof Invitation) {

--- a/Idno/Pages/User/View.php
+++ b/Idno/Pages/User/View.php
@@ -183,7 +183,7 @@ namespace Idno\Pages\User {
                 $notif->setVerb('mention');
                 $notif->setObject($mention);
                 $notif->setTarget($user);
-                $notif->save();
+                $notif->save(true);
                 $user->notify($notif);
             } else {
                 \Idno\Core\Idno::site()->logging()->debug("ignoring duplicate notification", ['source' => $source, 'target' => $target, 'user' => $user->getHandle()]);

--- a/Tests/API/BasicAPITest.php
+++ b/Tests/API/BasicAPITest.php
@@ -39,7 +39,7 @@ namespace Tests\API {
         {
 
             $user = \Tests\KnownTestCase::user();
-            $endpoint = \Idno\Core\Idno::site()->config()->url . 'status/edit';
+            $endpoint = \Idno\Core\Idno::site()->config()->getDisplayURL() . 'status/edit';
 
             $result = \Idno\Core\Webservice::post(
                 $endpoint, [

--- a/Tests/Common/EntityTest.php
+++ b/Tests/Common/EntityTest.php
@@ -79,14 +79,14 @@ class EntityTest extends \Tests\KnownTestCase
         $entity->setDatatype('data-slug-test');
         $entity->setSlugResilient($title);
         $this->assertEquals($slug, $entity->getSlug(), 'Slug should have matched '. $slug . '.');
-        $entity->save();
+        $entity->save(true);
         $this->toDelete[] = $entity;
 
         $entity = new GenericDataItem();
         $entity->setDatatype('data-slug-test');
         $entity->setSlugResilient($title);
         $this->assertEquals($slug . '-1', $entity->getSlug(), 'Because there was a slug collision, slug should have matched ' . $slug . '-1.');
-        $entity->save();
+        $entity->save(true);
         $this->toDelete[] = $entity;
     }
 

--- a/Tests/Data/DataConciergeTest.php
+++ b/Tests/Data/DataConciergeTest.php
@@ -26,7 +26,7 @@ namespace Tests\Data {
                 $obj->rangeVariable = 'b';
 
                 //echo "\n\n\nabout to save";
-                $id = $obj->save(); //die($id);
+                $id = $obj->save(true); //die($id);
 
                 // Save for later retrieval
                 self::$id = $id;
@@ -197,14 +197,14 @@ namespace Tests\Data {
             $obj->setTitle("This is a test obj to get around MySQL natural language mode");
             $obj->variable1 = 'test';
             $obj->variable2 = 'test again';
-            $id = $obj->save();
+            $id = $obj->save(true);
 
             $obj2 = new \Idno\Entities\GenericDataItem();
             $obj2->setDatatype('UnitTestObject');
             $obj2->setTitle("This is some other text because mysql is a pain.");
             $obj2->variable1 = 'test';
             $obj2->variable2 = 'test again';
-            $id = $obj2->save();
+            $id = $obj2->save(true);
 
             self::$fts_objects = [$obj, $obj2];
 

--- a/Tests/Data/MutateTest.php
+++ b/Tests/Data/MutateTest.php
@@ -14,7 +14,7 @@ class MutateTest extends \Tests\KnownTestCase
         $remoteuser->setPassword(md5(rand())); // Set password to something random to mitigate security holes if cleanup fails
         $remoteuser->setTitle('Test Mutation');
 
-        $id = $remoteuser->save();
+        $id = $remoteuser->save(true);
 
         $this->assertNotEmpty($remoteuser->mutate(\Idno\Entities\User::class));
 

--- a/Tests/KnownTestCase.php
+++ b/Tests/KnownTestCase.php
@@ -38,7 +38,7 @@ namespace Tests {
             $user->setPassword(md5(rand())); // Set password to something random to mitigate security holes if cleanup fails
             $user->setTitle('Test User');
 
-            $user->save();
+            $user->save(true);
 
             static::$testUser = $user;
 
@@ -73,7 +73,7 @@ namespace Tests {
             $user->setTitle('Test Admin User');
             $user->setAdmin(true);
 
-            $user->save();
+            $user->save(true);
 
             static::$testAdmin = $user;
 


### PR DESCRIPTION
## Here's what I fixed or added:

The `Entity::save()` method now, by default, checks that the current user can edit the entity before saving to the database. 

**Please note:** this will currently fail tests, until OAuth plugin changes are merged.

## Here's why I did it:

This takes responsibility for this kind of check from plugins, which have not always be doing it effectively.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [x] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
