### PR TITLE
Only include attachments with valid URLs

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1846,11 +1846,13 @@ namespace Idno\Common {
             */
             if ($attachments = $item->getAttachments()) {
                 foreach($attachments as $attachment) {
-                    $enclosureItem = $page->createElement('enclosure');
-                    $enclosureItem->setAttribute('url', $attachment['url']);
-                    $enclosureItem->setAttribute('type', $attachment['mime-type']);
-                    $enclosureItem->setAttribute('length', $attachment['length']);
-                    $rssItem->appendChild($enclosureItem);
+                    if (!empty($attachment['url'])) { // Only include attachments with set URLs
+                        $enclosureItem = $page->createElement('enclosure');
+                        $enclosureItem->setAttribute('url', $attachment['url']);
+                        $enclosureItem->setAttribute('type', $attachment['mime-type']);
+                        $enclosureItem->setAttribute('length', $attachment['length']);
+                        $rssItem->appendChild($enclosureItem);
+                    }
                 }
             }
             if ($tags = $item->getTags()) {


### PR DESCRIPTION
## Here's what I fixed or added:

If `attachment['url']` isn't set, we don't have a real attachment (for some reason) and should not include it in an enclosure.

## Here's why I did it:

Frequent errors.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
