### PR TITLE
Don't check non-UUIDs for UUID validity

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -367,7 +367,11 @@ namespace Idno\Common {
          */
         static function isLocalUUID($uuid)
         {
-            // TODO: improve this heuristic
+            // If $uuid is not valid, return false
+            if (empty($uuid) || !is_string($uuid)) {
+                return false;
+            }
+
             // Parse the UUID
             if (($uuid_parse = parse_url($uuid)) && ($url_parse = parse_url(\Idno\Core\Idno::site()->config()->url))) {
                 if (!empty($uuid_parse['host'])) {


### PR DESCRIPTION
## Here's what I fixed or added:

If `Entity::isLocalUUID` is run on a non-UUID, it should return false.

## Here's why I did it:

Instead of returning false, it was crashing the site.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
