### PR TITLE
Adding created as a schema field

### DIFF
--- a/Idno/Data/AbstractSQL.php
+++ b/Idno/Data/AbstractSQL.php
@@ -56,7 +56,7 @@ namespace Idno\Data {
          */
         function getSchemaFields()
         {
-            return array('uuid', '_id', 'entity_subtype', 'owner', 'publish_status');
+            return array('uuid', '_id', 'entity_subtype', 'owner', 'publish_status', 'created');
         }
 
         /**


### PR DESCRIPTION
## Here's what I fixed or added:

`created` is now a listed schema field in the `AbstractSQL` library.

## Here's why I did it:

It's a schema field, and we need to be able to search on it.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
