### PR TITLE
Format timestamps according to db engine

### DIFF
--- a/Idno/Core/DataConcierge.php
+++ b/Idno/Core/DataConcierge.php
@@ -292,6 +292,13 @@ namespace Idno\Core {
          */
         abstract function createSearchArray($query);
 
+        /**
+         * Given a UNIX timestamp, returns a date suitable for use with the current db engine
+         *
+         * @param $timestamp
+         * @return mixed
+         */
+        abstract function formatDate($timestamp);
 
         /**
          * Internal function which ensures collections are sanitised.

--- a/Idno/Data/AbstractSQL.php
+++ b/Idno/Data/AbstractSQL.php
@@ -56,7 +56,7 @@ namespace Idno\Data {
          */
         function getSchemaFields()
         {
-            return array('uuid', '_id', 'entity_subtype', 'owner', 'publish_status');
+            return array('uuid', '_id', 'entity_subtype', 'owner', 'publish_status', 'created');
         }
 
         /**

--- a/Idno/Data/AbstractSQL.php
+++ b/Idno/Data/AbstractSQL.php
@@ -303,6 +303,17 @@ namespace Idno\Data {
         }
 
         /**
+         * Given a UNIX timestamp, returns a date suitable for use with the current db engine
+         *
+         * @param $timestamp
+         * @return mixed
+         */
+        function formatDate($timestamp)
+        {
+            return date( 'Y-m-d H:i:s', $timestamp);
+        }
+
+        /**
          * Given a text query, return an array suitable for adding into getFromX calls
          *
          * @param  $query

--- a/Idno/Data/Mongo.php
+++ b/Idno/Data/Mongo.php
@@ -604,6 +604,17 @@ namespace Idno\Data {
         }
 
         /**
+         * Given a UNIX timestamp, returns a date suitable for use with the current db engine
+         *
+         * @param $timestamp
+         * @return mixed
+         */
+        function formatDate($timestamp)
+        {
+            return $timestamp;
+        }
+
+        /**
          * Given a text query, return an array suitable for adding into getFromX calls
          *
          * @param  $query

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -243,9 +243,9 @@ namespace Idno\Data {
             }
 
             if (empty($array['created'])) {
-                $array['created'] = date("Y-m-d H:i:s", time());
+                $array['created'] = $this->formatDate(time());
             } else {
-                $array['created'] = date("Y-m-d H:i:s", $array['created']);
+                $array['created'] = $this->formatDate($array['created']);
             }
 
             $search = str_replace("\n", " \n ", $search);
@@ -493,11 +493,6 @@ namespace Idno\Data {
                     if (!is_array($value)) {
                         if (in_array($key, $this->getSchemaFields())) {
                             $subwhere[] = "(`{$collection}`.`{$key}` = :nonmdvalue{$non_md_variables})";
-                            if ($key === 'created') {
-                                if (!is_int($value)) {
-                                    $value = strtotime($value);
-                                }
-                            }
                             $variables[":nonmdvalue{$non_md_variables}"] = $value;
                             $non_md_variables++;
                         } else {
@@ -586,11 +581,6 @@ namespace Idno\Data {
                             $val = $value['$lt'];
                             if (in_array($key, $this->getSchemaFields())) {
                                 $subwhere[] = "(`{$collection}`.`{$key}` < :nonmdvalue{$non_md_variables})";
-                                if ($key === 'created') {
-                                    if (!is_int($val)) {
-                                        $val = strtotime($val);
-                                    }
-                                }
                                 $variables[":nonmdvalue{$non_md_variables}"] = $val;
                                 $non_md_variables++;
                             } else {
@@ -604,11 +594,6 @@ namespace Idno\Data {
                             $val = $value['$gt'];
                             if (in_array($key, $this->getSchemaFields())) {
                                 $subwhere[] = "(`{$collection}`.`{$key}` > :nonmdvalue{$non_md_variables})";
-                                if ($key === 'created') {
-                                    if (!is_int($val)) {
-                                        $val = strtotime($val);
-                                    }
-                                }
                                 $variables[":nonmdvalue{$non_md_variables}"] = $val;
                                 $non_md_variables++;
                             } else {


### PR DESCRIPTION
## Here's what I fixed or added:

Timestamps in MySQL are now handled natively vs assuming a UNIX timestamp.

## Here's why I did it:

UNIX timestamp assumptions meant you couldn't filter by timestamp.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
