### PR TITLE
Prettify more Profile URLs to just their identifier where possible

### DIFF
--- a/templates/default/entity/User/profile/fields.tpl.php
+++ b/templates/default/entity/User/profile/fields.tpl.php
@@ -92,6 +92,7 @@ $host_to_icon = [
     "steampowered.com" => "steam",
     "strava.com" => "bicycle", // generic
     "stumbleupon.com" => "stumbleupon",
+    "t.me" => "telegram",tele
     "telegram.me" => "telegram",
     "telegram.org" => "telegram",
     "tripadvisor.com" => "tripadvisor",
@@ -204,20 +205,32 @@ if (!empty($vars['user']->profile['url']) && is_array($vars['user']->profile['ur
             $url_display = rtrim(str_replace('https://', '', str_replace('http://', '', strip_tags($url_display))), '/');
 
             // TODO: find a way to integrate into a config data structure.
-            // Remove hosts where the rest of the URL is a profile identifier
+            // Remove hosts where the rest of the URL after the last slash is:
+            // - a profile identifier.
+            // - and the icon is unique and recognizable.
+            // Keep list alphabetized
             switch ($host) {
+                // keep alphabetical
                 case 'angellist.com':
-                case 'instagram.com':
+                case 'archive.org':
+                case 'bandcamp.com':
                 case 'facebook.com':
                 case 'flickr.com':
-                case 'keybase.io':
                 case 'github.com':
+                case 'instagram.com':
+                case 'keybase.io':
+                case 'last.fm':
                 case 'linkedin.com':
+                case 'matrix.to':
                 case 'medium.com':
                 case 'plus.google.com':
+                case 'reddit.com':
+                case 'slashdot.org':
+                case 'soundcloud.com':
                 case 'strava.com':
                 case 'twitter.com':
                 case 'venmo.com':
+                case 'youtube.com':
                     $url_display = substr(strrchr($url_display, '/'), 1);
                     break;
             }


### PR DESCRIPTION
## Here's what I fixed or added:

Added more logic for profile URL formatting.

## Here's why I did it:

To make my 'wall of links' prettier.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.