### PR TITLE
Minor improvement to test password generation

### DIFF
--- a/Tests/Data/MutateTest.php
+++ b/Tests/Data/MutateTest.php
@@ -11,7 +11,7 @@ class MutateTest extends \Tests\KnownTestCase
         $remoteuser = new \Idno\Entities\RemoteUser();
         $remoteuser->handle = 'Test Mutation User';
         $remoteuser->email = 'hello@withknown.com';
-        $remoteuser->setPassword(md5(rand())); // Set password to something random to mitigate security holes if cleanup fails
+        $remoteuser->setPassword(md5(openssl_random_pseudo_bytes(16))); // Set password to something random to mitigate security holes if cleanup fails
         $remoteuser->setTitle('Test Mutation');
 
         $id = $remoteuser->save(true);


### PR DESCRIPTION
## Here's what I fixed or added:

Removing uses of `rand()` to generate passwords.

## Here's why I did it:

`rand()` is insecure.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
