### PR TITLE
Images now always carry an image mimetype, regardless of upload extension

### DIFF
--- a/Idno/Entities/File.php
+++ b/Idno/Entities/File.php
@@ -1,11 +1,11 @@
 <?php
 
-    /**
-     * User-created file representation
-     *
-     * @package    idno
-     * @subpackage core
-     */
+/**
+ * User-created file representation
+ *
+ * @package    idno
+ * @subpackage core
+ */
 
 namespace Idno\Entities {
 
@@ -34,10 +34,10 @@ namespace Idno\Entities {
         /**
          * Given a path to an image on disk, generates and saves a thumbnail with maximum dimension $max_dimension.
          *
-         * @param  string $file_path     Path to the file.
-         * @param  string $filename      Filename that the file should have on download.
-         * @param  int    $max_dimension The maximum number of pixels the thumbnail image should be along its longest side.
-         * @param  bool   $square        If this is set to true, the thumbnail will be made square.
+         * @param string $file_path Path to the file.
+         * @param string $filename Filename that the file should have on download.
+         * @param int $max_dimension The maximum number of pixels the thumbnail image should be along its longest side.
+         * @param bool $square If this is set to true, the thumbnail will be made square.
          * @return bool|id
          */
         public static function createThumbnailFromFile($file_path, $filename, $max_dimension = 800, $square = false)
@@ -49,7 +49,8 @@ namespace Idno\Entities {
             if (is_callable('exif_read_data')) {
                 try {
                     if ($exif = exif_read_data($file_path)) {
-                        if (!empty($exif['Orientation'])) { $orientation = $exif['Orientation'];
+                        if (!empty($exif['Orientation'])) {
+                            $orientation = $exif['Orientation'];
                         }
                     }
                 } catch (\Exception $e) {
@@ -63,14 +64,16 @@ namespace Idno\Entities {
                             $image = imagecreatefromjpeg($file_path);
                             break;
                         case 'image/png':
-                            $image      = imagecreatefrompng($file_path);
-                            $background = imagecolorallocatealpha($image, 0, 0, 0, 127);
-                            imagecolortransparent($image, $background);
+                            if ($image = imagecreatefrompng($file_path)) {
+                                $background = imagecolorallocatealpha($image, 0, 0, 0, 127);
+                                imagecolortransparent($image, $background);
+                            }
                             break;
                         case 'image/gif':
-                            $image      = imagecreatefromgif($file_path);
-                            $background = imagecolorallocatealpha($image, 0, 0, 0, 127);
-                            imagecolortransparent($image, $background);
+                            if ($image = imagecreatefromgif($file_path)) {
+                                $background = imagecolorallocatealpha($image, 0, 0, 0, 127);
+                                imagecolortransparent($image, $background);
+                            }
                             break;
                     }
                     if (!empty($image)) {
@@ -90,35 +93,35 @@ namespace Idno\Entities {
                         $existing_width = imagesx($image);
                         $existing_height = imagesy($image);
                         if ($existing_width > $existing_height) {
-                            $width  = $max_dimension;
+                            $width = $max_dimension;
                             $height = round($existing_height * ($max_dimension / $existing_width));
                         } else {
                             $height = $max_dimension;
-                            $width  = round($existing_width * ($max_dimension / $existing_height));
+                            $width = round($existing_width * ($max_dimension / $existing_height));
                         }
                         if ($square) {
                             if ($width > $height) {
-                                $new_height      = $max_dimension;
-                                $new_width       = $max_dimension;
+                                $new_height = $max_dimension;
+                                $new_width = $max_dimension;
                                 $original_height = $existing_height;
-                                $original_width  = $existing_height;
-                                $offset_x        = round(($existing_width - $existing_height) / 2);
-                                $offset_y        = 0;
+                                $original_width = $existing_height;
+                                $offset_x = round(($existing_width - $existing_height) / 2);
+                                $offset_y = 0;
                             } else {
-                                $new_height      = $max_dimension;
-                                $new_width       = $max_dimension;
+                                $new_height = $max_dimension;
+                                $new_width = $max_dimension;
                                 $original_height = $existing_width;
-                                $original_width  = $existing_width;
-                                $offset_x        = 0;
-                                $offset_y        = round(($existing_height - $existing_width) / 2);
+                                $original_width = $existing_width;
+                                $offset_x = 0;
+                                $offset_y = round(($existing_height - $existing_width) / 2);
                             }
                         } else {
-                            $new_height      = $height;
-                            $new_width       = $width;
+                            $new_height = $height;
+                            $new_width = $width;
                             $original_height = $existing_height;//$photo_information[1];
-                            $original_width  = $existing_width; //$photo_information[0];
-                            $offset_x        = 0;
-                            $offset_y        = 0;
+                            $original_width = $existing_width; //$photo_information[0];
+                            $offset_x = 0;
+                            $offset_y = 0;
                         }
                         $image_copy = imagecreatetruecolor($new_width, $new_height);
                         imagealphablending($image_copy, false);
@@ -158,70 +161,99 @@ namespace Idno\Entities {
         /**
          * Save a file to the filesystem and return the ID
          *
-         * @param  string $file_path     Full local path to the file
-         * @param  string $filename      Filename to store
-         * @param  string $mime_type     MIME type associated with the file
-         * @param  bool   $return_object Return the file object? If set to false (as is default), will return the ID
-         * @param  bool   $destroy_exif  When true, if an image is uploaded the exif data will be destroyed.
+         * @param string $file_path Full local path to the file
+         * @param string $filename Filename to store
+         * @param string $mime_type MIME type associated with the file
+         * @param bool $return_object Return the file object? If set to false (as is default), will return the ID
+         * @param bool $destroy_exif When true, if an image is uploaded the exif data will be destroyed.
          * @return bool|\id Depending on success
          */
         public static function createFromFile($file_path, $filename, $mime_type = 'application/octet-stream', $return_object = false, $destroy_exif = false)
         {
             if (file_exists($file_path) && !empty($filename)) {
                 if ($fs = \Idno\Core\Idno::site()->filesystem()) {
-                    $file     = new File();
-                    $metadata = array(
-                        'filename'  => $filename,
-                        'mime_type' => $mime_type
-                    );
+                    $file = new File();
 
                     // Get image filesize
                     if (self::isImage($file_path)) {
                         $photo_information = getimagesize($file_path);
                         if (!empty($photo_information[0]) && !empty($photo_information[1])) {
-                            $metadata['width']  = $photo_information[0];
+                            $metadata['width'] = $photo_information[0];
                             $metadata['height'] = $photo_information[1];
                         }
                     }
 
-                    // Do we want to remove EXIF data?
-                    if (!empty($photo_information) && $destroy_exif) {
-                        $tmpfname = $file_path;
+                    // Is this an image?
+                    if (!empty($photo_information)) {
+
+                        $extension = strtolower(substr($filename, strrpos($filename, '.') + 1));
                         switch ($photo_information['mime']) {
                             case 'image/jpeg':
-                                $image = imagecreatefromjpeg($tmpfname);
-
-                                // Since we're stripping Exif, we need to manually adjust orientation of main image
-                                try {
-                                    if (function_exists('exif_read_data')) {
-
-                                        $exif = exif_read_data($tmpfname);
-                                        if (!empty($exif['Orientation'])) {
-                                            switch ($exif['Orientation']) {
-                                                case 8:
-                                                    $image = imagerotate($image, 90, 0);
-                                                    break;
-                                                case 3:
-                                                    $image = imagerotate($image, 180, 0);
-                                                    break;
-                                                case 6:
-                                                    $image = imagerotate($image, -90, 0);
-                                                    break;
-                                            }
-                                        }
-
-                                        $metadata['width']= imagesx($image);
-                                        $metadata['height'] = imagesy($image);
-                                    }
-
-                                    imagejpeg($image, $tmpfname);
-                                } catch (\Exception $e) {
-                                    \Idno\Core\Idno::site()->logging()->error($e->getMessage());
-                                }
+                                $mime_type = 'image/jpeg'; // Hardcode file metadata
+                                if (!in_array($extension, ['jpg','jpeg'])) $filename .= '.jpg';
+                                break;
+                            case 'image/gif':
+                                $mime_type = 'image/gif'; // Hardcode file metadata
+                                if ($extension != 'gif') $filename .= '.gif';
+                                break;
+                            case 'image/png':
+                                $mime_type = 'image/png'; // Hardcode file metadata
+                                if ($extension != 'png') $filename .= '.png';
+                                break;
+                            case 'image/svg+xml':
+                                $mime_type = 'image/svg+xml'; // Hardcode file metadata
+                                if ($extension != 'svg') $filename .= '.svg';
+                                break;
+                            case 'image/webp':
+                                $mime_type = 'image/webp'; // Hardcode file metadata
+                                if ($extension != 'webp') $filename .= '.webp';
                                 break;
                         }
 
+                        // Do we want to remove EXIF data?
+                        if ($destroy_exif) {
+                            $tmpfname = $file_path;
+                            switch ($photo_information['mime']) {
+                                case 'image/jpeg':
+                                    $image = imagecreatefromjpeg($tmpfname);
+
+                                    // Since we're stripping Exif, we need to manually adjust orientation of main image
+                                    try {
+                                        if (function_exists('exif_read_data')) {
+
+                                            $exif = exif_read_data($tmpfname);
+                                            if (!empty($exif['Orientation'])) {
+                                                switch ($exif['Orientation']) {
+                                                    case 8:
+                                                        $image = imagerotate($image, 90, 0);
+                                                        break;
+                                                    case 3:
+                                                        $image = imagerotate($image, 180, 0);
+                                                        break;
+                                                    case 6:
+                                                        $image = imagerotate($image, -90, 0);
+                                                        break;
+                                                }
+                                            }
+
+                                            $metadata['width'] = imagesx($image);
+                                            $metadata['height'] = imagesy($image);
+                                        }
+
+                                        imagejpeg($image, $tmpfname);
+                                    } catch (\Exception $e) {
+                                        \Idno\Core\Idno::site()->logging()->error($e->getMessage());
+                                    }
+                                    break;
+                            }
+
+                        }
                     }
+
+                    $metadata = array(
+                        'filename' => $filename,
+                        'mime_type' => $mime_type
+                    );
 
                     if ($id = $fs->storeFile($file_path, $metadata, $metadata)) {
                         if (!$return_object) {
@@ -239,7 +271,7 @@ namespace Idno\Entities {
         /**
          * Determines whether a file is an image or not.
          *
-         * @param  string $file_path The path to a file
+         * @param string $file_path The path to a file
          * @return bool
          */
         public static function isImage($file_path)
@@ -256,7 +288,7 @@ namespace Idno\Entities {
         /**
          * Retrieve a file by ID
          *
-         * @param  string $id
+         * @param string $id
          * @return \Idno\Common\Entity|\MongoGridFSFile|null
          */
         static function getByID($id)
@@ -290,7 +322,7 @@ namespace Idno\Entities {
         /**
          * Retrieve a file by UUID
          *
-         * @param  string $uuid
+         * @param string $uuid
          * @return bool|\Idno\Common\Entity
          */
         static function getByUUID($uuid)
@@ -313,7 +345,7 @@ namespace Idno\Entities {
         {
             if (substr_count($url, \Idno\Core\Idno::site()->config()->getDisplayURL() . 'file/')) {
 
-                if (preg_match('#'.\Idno\Core\Idno::site()->config()->getDisplayURL() ."file\/([a-zA-Z0-9]+)+#", $url, $matches)) {
+                if (preg_match('#' . \Idno\Core\Idno::site()->config()->getDisplayURL() . "file\/([a-zA-Z0-9]+)+#", $url, $matches)) {
                     $url = $matches[1];
                 }
 
@@ -370,7 +402,7 @@ namespace Idno\Entities {
         /**
          * Retrieve file data by ID
          *
-         * @param  string $id
+         * @param string $id
          * @return mixed
          */
         static function getFileDataByID($id)

--- a/Idno/Pages/File/View.php
+++ b/Idno/Pages/File/View.php
@@ -43,9 +43,7 @@ namespace Idno\Pages\File {
             header("Cache-Control: public");
             header('Expires: ' . date(\DateTime::RFC1123, time() + (86400 * 30))); // Cache files for 30 days!
             $this->setLastModifiedHeader($upload_ts);
-            //            if ($cache = \Idno\Core\Idno::site()->cache()) {
-            //                $cache->store("{$this->arguments[0]}_modified_ts", $upload_ts);
-            //            }
+
             if (!empty($object->file['mime_type'])) {
                 header('Content-type: ' . $object->file['mime_type']);
             } else {


### PR DESCRIPTION
## Here's what I fixed or added:

When uploading images, the served mimetype will always be the proper image mimetype, and the extension will always be appropriate for the file type.

## Here's why I did it:

This fixes a potential issue with embedding arbitrary code in GIF89a files.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [x] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
