### PR TITLE
Adding alt text to user icons

### DIFF
--- a/templates/default/entity/annotations/image.tpl.php
+++ b/templates/default/entity/annotations/image.tpl.php
@@ -1,0 +1,3 @@
+<a href="<?php echo strip_tags($annotation['owner_url']) ?>" rel="nofollow" class="icon-container"><img
+        src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL(strip_tags($annotation['owner_image'])) ?>"
+        alt="<?php echo htmlentities($annotation['owner_name']) ?>"/></a>

--- a/templates/default/entity/annotations/likes.tpl.php
+++ b/templates/default/entity/annotations/likes.tpl.php
@@ -17,13 +17,13 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" class="icon-container" rel="nofollow"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <?php echo $this->__(['annotation' => $annotation])->draw('entity/annotations/image'); ?>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">
                     <p>
                         <a href="<?php echo htmlspecialchars($annotation['owner_url'])?>" rel="nofollow"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8')?></a>
-                    <?php echo \Idno\Core\Idno::site()->language()->_('liked this post'); ?>
+                        <?php echo \Idno\Core\Idno::site()->language()->_('liked this post'); ?>
                     </p>
                     <p><small><a href="<?php echo htmlspecialchars($permalink) ?>" rel="nofollow"><?php echo date('M d Y', $annotation['time']);?></a> on <a href="<?php echo htmlspecialchars($permalink) ?>" rel="nofollow"><?php echo parse_url($permalink, PHP_URL_HOST)?></a></small></p>
                 </div>

--- a/templates/default/entity/annotations/mentions.tpl.php
+++ b/templates/default/entity/annotations/mentions.tpl.php
@@ -13,7 +13,7 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo htmlspecialchars($annotation['owner_url'])?>" rel="nofollow" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <?php echo $this->__(['annotation' => $annotation])->draw('entity/annotations/image'); ?>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">

--- a/templates/default/entity/annotations/replies.tpl.php
+++ b/templates/default/entity/annotations/replies.tpl.php
@@ -13,8 +13,7 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row u-comment h-cite">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo strip_tags($annotation['owner_url']) ?>" rel="nofollow" class="icon-container"><img
-                                    src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL(strip_tags($annotation['owner_image'])) ?>"/></a>
+                        <?php echo $this->__(['annotation' => $annotation])->draw('entity/annotations/image'); ?>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-9">

--- a/templates/default/entity/annotations/rsvps.tpl.php
+++ b/templates/default/entity/annotations/rsvps.tpl.php
@@ -18,7 +18,7 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" rel="nofollow" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <?php echo $this->__(['annotation' => $annotation])->draw('entity/annotations/image'); ?>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">

--- a/templates/default/entity/annotations/shares.tpl.php
+++ b/templates/default/entity/annotations/shares.tpl.php
@@ -14,7 +14,7 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
             <div class="idno-annotation row">
                 <div class="idno-annotation-image col-md-1 hidden-sm">
                     <p>
-                        <a href="<?php echo htmlspecialchars($annotation['owner_url']) ?>" rel="nofollow" class="icon-container"><img src="<?php echo \Idno\Core\Idno::site()->config()->sanitizeAttachmentURL($annotation['owner_image'])?>" /></a>
+                        <?php echo $this->__(['annotation' => $annotation])->draw('entity/annotations/image'); ?>
                     </p>
                 </div>
                 <div class="idno-annotation-content col-md-6">

--- a/templates/default/entity/shell.tpl.php
+++ b/templates/default/entity/shell.tpl.php
@@ -14,7 +14,7 @@ if ($object) {
                 <div class="col-md-1 col-md-offset-1 owner p-author h-card visible-md visible-lg">
                     <p>
                         <a href="<?php echo $owner->getDisplayURL() ?>" class="u-url icon-container">
-                            <img class="u-photo" src="<?php echo $owner->getIcon() ?>"/></a><br/>
+                            <img class="u-photo" src="<?php echo $owner->getIcon() ?>" alt="<?php echo htmlentities($owner->getName()); ?>"/></a><br/>
                         <a href="<?php echo $owner->getDisplayURL() ?>" class="p-name u-url fn"><?php echo htmlentities(strip_tags($owner->getTitle()), ENT_QUOTES, 'UTF-8'); ?></a>
                     </p>
                 </div>
@@ -23,7 +23,7 @@ if ($object) {
                     <!--<div class="visible-xs">
                         <p class="p-author author h-card vcard">
                             <a href="<?php echo $owner->getDisplayURL() ?>" class="icon-container"><img
-                                    class="u-logo logo u-photo photo" src="<?php echo $owner->getIcon() ?>"/></a>
+                                    class="u-logo logo u-photo photo" src="<?php echo $owner->getIcon() ?>" alt="<?php echo htmlentities($owner->getName()); ?>"/></a>
                             <a class="p-name fn u-url url" href="<?php echo $owner->getDisplayURL() ?>"><?php echo htmlentities(strip_tags($owner->getTitle()), ENT_QUOTES, 'UTF-8') ?></a>
                             <a class="u-url" href="<?php echo $owner->getDisplayURL() ?>">
                                 </a>


### PR DESCRIPTION
## Here's what I fixed or added:

User icons now have alt text. In addition, content attachments now call a single piece of code to render user icons.

## Here's why I did it:

Accessibility improvement. Refs #2980 

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
