### PR TITLE
Adding alt text to icons in default theme

### DIFF
--- a/templates/default/account/settings/following/mf2user.tpl.php
+++ b/templates/default/account/settings/following/mf2user.tpl.php
@@ -38,7 +38,7 @@ $nickname =  $properties['nickname'][0];
     <div class="col-md-8 idno-object idno-content">
         <div class="visible-sm">
         <p class="p-author author h-card vcard">
-            <img class="u-logo logo u-photo photo" src="<?php echo htmlspecialchars($photo) ?>" />
+            <img class="u-logo logo u-photo photo" src="<?php echo htmlspecialchars($photo) ?>" alt="<?php echo htmlspecialchars($name) ?>" />
             <span class="p-name fn"><?php echo $name ?></span>
         </p>
         </div>

--- a/templates/default/content/notification/wrapper.tpl.php
+++ b/templates/default/content/notification/wrapper.tpl.php
@@ -15,7 +15,9 @@ if (!empty($post)) {
             <?php if (!empty($owner_image)) { ?>
                     <p>
                         <a href="<?php echo $owner_url ?>" class="u-url icon-container">
-                            <img class="u-photo" src="<?php echo $owner_image ?>"/></a><br/>
+                            <img class="u-photo" 
+                                 src="<?php echo $owner_image ?>"
+                                 alt="<?php echo $owner_name ?>" /></a><br/>
                     </p>
             <?php } ?>
             </div>

--- a/templates/default/entity/FeedItem.tpl.php
+++ b/templates/default/entity/FeedItem.tpl.php
@@ -22,7 +22,8 @@ if (preg_match('@\\\\([\w]+)$@', get_class($item), $matches)) {
         <div class="visible-sm">
             <p class="p-author author h-card vcard">
                 <a href="<?php echo $item->getAuthorURL() ?>" class="icon-container"><img
-                        class="u-logo logo u-photo photo" src="<?php echo $item->getAuthorPhoto() ?>"/></a>
+                        class="u-logo logo u-photo photo" src="<?php echo $item->getAuthorPhoto() ?>"
+                        alt="<?php echo htmlspecialchars($item->getAuthorName()) ?>" /></a>
                 <a class="p-name fn u-url url" href="<?php echo $item->getAuthorURL() ?>"><?php echo $item->getAuthorName() ?></a>
             </p>
         </div>

--- a/templates/default/entity/User.tpl.php
+++ b/templates/default/entity/User.tpl.php
@@ -22,7 +22,8 @@ if (empty($vars['user']) && !empty($vars['object'])) {
             <div class="col-md-4 namebadge">
                 <p>
                     <a href="<?php echo $vars['user']->getDisplayURL() ?>" class="u-url icon-container"><img class="u-photo"
-                                                                                               src="<?php echo $vars['user']->getIcon() ?>"/></a>
+                                                                                               src="<?php echo $vars['user']->getIcon() ?>"
+                                                                                               alt="<?php echo htmlspecialchars($vars['user']->getTitle()) ?>" ?>"/></a>
                 </p>
 
                         <?php

--- a/templates/default/entity/annotations/comment/main.tpl.php
+++ b/templates/default/entity/annotations/comment/main.tpl.php
@@ -9,7 +9,8 @@ if (!empty($user) && !empty($object)) {
     <div class="row annotation-add">
         <div class="col-md-2 owner h-card visible-md visible-lg">
             <a href="<?php echo $user->getDisplayURL() ?>" class="u-url icon-container"><img class="u-photo"
-                                                                                      src="<?php echo $user->getIcon() ?>"/></a>
+                                                                                      src="<?php echo $user->getIcon() ?>"
+                                                                                      alt="<?php echo htmlspecialchars($user->getTitle()) ?>" /></a>
         </div>
         <div class="col-md-10 idno-comment-container">
             <form action="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>annotation/post" method="post">

--- a/templates/default/entity/annotations/replies.tpl.php
+++ b/templates/default/entity/annotations/replies.tpl.php
@@ -23,7 +23,7 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
                     <span class="p-author h-card">
                         <a class="u-photo" rel="nofollow" href="<?php echo strip_tags($annotation['owner_image']) ?>"></a>
                         <a class="p-name u-url"
-                           href="<?php echo htmlspecialchars(strip_tags($annotation['owner_url'])) ?>" rel="nofollow"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8') ?></a></span>,
+                           href="<?php echo htmlspecialchars(strip_tags($annotation['owner_url'])) ?>" alt="<?php echo htmlspecialchars($annotation['owner_name']) ?>" rel="nofollow"><?php echo htmlentities($annotation['owner_name'], ENT_QUOTES, 'UTF-8') ?></a></span>,
                             <a href="<?php echo $permalink ?>" rel="nofollow"><?php echo date('M d Y', $annotation['time']); ?></a>
                             on <a href="<?php echo $permalink ?>" rel="nofollow" class="u-url"><?php echo parse_url($permalink, PHP_URL_HOST) ?></a>
                         </small>

--- a/templates/default/settings-shell/toolbar/logged-in.tpl.php
+++ b/templates/default/settings-shell/toolbar/logged-in.tpl.php
@@ -20,6 +20,6 @@
     <?php } ?>
 
 <li>
-    <a href="<?= \Idno\Core\Idno::site()->session()->currentUser()->getURL(); ?>"><img class="u-photo" src="<?php echo  \Idno\Core\Idno::site()->session()->currentUser()->getIcon(); ?>" /></a> 
+    <a href="<?php echo \Idno\Core\Idno::site()->session()->currentUser()->getURL(); ?>"><img class="u-photo" src="<?php echo  \Idno\Core\Idno::site()->session()->currentUser()->getIcon(); ?>" alt="<?php echo htmlspecialchars(\Idno\Core\Idno::site()->session()->currentUser()->getTitle()) ?>" /></a> 
 </li>
 

--- a/templates/default/shell/toolbar/logged-in.tpl.php
+++ b/templates/default/shell/toolbar/logged-in.tpl.php
@@ -2,7 +2,8 @@
 <!--<ul class="nav navbar-nav">-->
 <li class="dropdown">
     <a class="dropdown-toggle" data-toggle="dropdown" href="">
-        <img class="u-photo" src="<?php echo \Idno\Core\Idno::site()->session()->currentUser()->getIcon(); ?>" />
+        <img class="u-photo" src="<?php echo \Idno\Core\Idno::site()->session()->currentUser()->getIcon() ?>" 
+             alt="<?php echo htmlspecialchars(\Idno\Core\Idno::site()->session()->currentUser()->getTitle()) ?>" />
         <?php echo htmlspecialchars(\Idno\Core\Idno::site()->session()->currentUser()->getTitle())?>
         <?php
             $notifs = \Idno\Core\Idno::site()->session()->currentUser()->countUnreadNotifications();


### PR DESCRIPTION
## Here's what I fixed or added:

The basic theme doesn't include alt text in user icons. A Lighthouse or other accessibility test knocks off a bunch of marks for this. It's also the right thing to do.

