### PR TITLE
Attempt to fix data export with known.php CLI tool

### DIFF
--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -671,7 +671,7 @@ namespace Idno\Data {
                         $line .= ' values ';
                         $line .= '(' . implode(',', $object) . ');';
                         $output .= $line . "\n";
-                        $metadata_statement = $client->prepare("select * from {$collection}_metadata where `entity` = :uuid");
+                        $metadata_statement = $client->prepare("select * from {$collection}_metadata where `_id` = :uuid");
                         if ($metadata_response = $metadata_statement->execute([':uuid' => $uuid])) {
                             while ($object = $metadata_statement->fetch(\PDO::FETCH_ASSOC)) {
                                 $fields = array_keys($object);


### PR DESCRIPTION
Hello dear Known maintainers 👋🏼

## While trying to do this:

Exporting data with `know.php` CLI tool…

## I encountered this error:

The export didn't go well most likely because  
a column was not renamed for `entities_metadata` table in the `known.php` script.

## Some other notes:

Give us some context: 

* It'd also be really handy if you could tell us the contents of your ```version.known``` file

```
version = '1.3.1'
build = 2020120201
```

* What database are you using? (e.g. mongo, mysql, postgres)

```
mysql
```

* Any warnings or errors in your admin/diagnostics page?

```shell
Known (): debug - Generating export records...
Known (): error - SQLSTATE[42S22]: Column not found: 1054 Unknown column 'entity' in 'where clause'                   
Known (): debug - Archive constructed at /tmp/374c39bb8adc971e5bab602081f36683
```

* If this is a programming bug, can you include examples of any Micropub / API calls / webhook pings you make? Otherwise please don't worry about what this means!

I've executed the following command in CLI:

```shell
php known.php export
```

* Bonus points - are you able to illustrate the issue with a unit test? If so, submit it as a pull request!

The `known.php` script seems to be a bit tricky to test but 
I'd be happy to give it a try with some additional guidance.

Here is a patch otherwise fixing the issue I've encountered. 
There might a better solution or perhaps I didn't cover the issue completely here.

Thank you for your attention!