### PR TITLE
Fixes PageHandler compatibility

### DIFF
--- a/Idno/Core/PageHandler.php
+++ b/Idno/Core/PageHandler.php
@@ -181,9 +181,9 @@ namespace Idno\Core {
             return isset($this->routes[$offset]);
         }
 
-        public function offsetGet($offset)
+        public function offsetGet($offset): mixed
         {
-            return isset($this->routes[$offset]) ? $this->routes[$offset] : null;
+            return isset($this->routes[$offset]) ? $this->routes[$offset] : false;
         }
 
         public function offsetSet($offset, $value): void
@@ -200,27 +200,27 @@ namespace Idno\Core {
             unset($this->routes[$offset]);
         }
 
-        function rewind()
+        function rewind(): void
         {
-            return reset($this->routes);
+            reset($this->routes);
         }
 
-        function current()
+        function current(): mixed
         {
             return current($this->routes);
         }
 
-        function key()
+        function key(): mixed
         {
             return key($this->routes);
         }
 
-        function next()
+        function next(): void
         {
-            return next($this->routes);
+            next($this->routes);
         }
 
-        function valid()
+        function valid(): bool
         {
             return key($this->routes) !== null;
         }

--- a/Idno/Core/PageHandler.php
+++ b/Idno/Core/PageHandler.php
@@ -183,7 +183,7 @@ namespace Idno\Core {
 
         public function offsetGet($offset): mixed
         {
-            return isset($this->routes[$offset]) ? $this->routes[$offset] : false;
+            return isset($this->routes[$offset]) ? $this->routes[$offset] : null;
         }
 
         public function offsetSet($offset, $value): void


### PR DESCRIPTION
## Here's what I fixed or added:

I adjusted the methods on `PageHandler` to properly implement inherited methods from ArrayAccess and Iterator.

## Here's why I did it:

In some versions of PHP, a deprecated notice is thrown because the methods don't match.

## Checklist: (`[x]` to check/tick the boxes)

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
