### PR TITLE
Fixes static page editing screen

### DIFF
--- a/IdnoPlugins/StaticPages/Main.php
+++ b/IdnoPlugins/StaticPages/Main.php
@@ -36,7 +36,7 @@ namespace IdnoPlugins\StaticPages {
             \Idno\Core\Idno::site()->routes()->addRoute('/admin/staticpages/reorder/?', 'IdnoPlugins\StaticPages\Pages\Admin\ReorderCategory');
             \Idno\Core\Idno::site()->routes()->addRoute('/admin/staticpages/reorder/page/?', 'IdnoPlugins\StaticPages\Pages\Admin\ReorderPage');
 
-            \Idno\Core\Idno::site()->routes()->addRoute('/pages/([A-Za-z0-9\-\_\%]+)/?', 'IdnoPlugins\StaticPages\Pages\View');
+            \Idno\Core\Idno::site()->routes()->addRoute('/pages/:id/?', 'IdnoPlugins\StaticPages\Pages\View');
 
             // This makes sure that the homepage is accessible even when it is overridden.
             \Idno\Core\Idno::site()->routes()->addRoute('/content/default/?', 'Idno\Pages\Homepage');

--- a/IdnoPlugins/StaticPages/Main.php
+++ b/IdnoPlugins/StaticPages/Main.php
@@ -226,6 +226,9 @@ namespace IdnoPlugins\StaticPages {
                 $categories = str_replace("\r", '', \Idno\Core\Idno::site()->config()->staticPages['categories']);
                 $categories = explode("\n", $categories);
 
+                // Add "no category"
+                array_unshift($categories, 'No Category');
+
                 // Trim all categories first
                 array_filter($categories, function ($var) {
                     return trim($var);
@@ -233,6 +236,9 @@ namespace IdnoPlugins\StaticPages {
 
                 // Then remove any empty categories
                 array_filter($categories);
+                
+                // Set keys to equal values
+                $categories = array_combine($categories, $categories);
 
                 // Now send back the array
                 return $categories;

--- a/IdnoPlugins/StaticPages/Main.php
+++ b/IdnoPlugins/StaticPages/Main.php
@@ -36,7 +36,7 @@ namespace IdnoPlugins\StaticPages {
             \Idno\Core\Idno::site()->routes()->addRoute('/admin/staticpages/reorder/?', 'IdnoPlugins\StaticPages\Pages\Admin\ReorderCategory');
             \Idno\Core\Idno::site()->routes()->addRoute('/admin/staticpages/reorder/page/?', 'IdnoPlugins\StaticPages\Pages\Admin\ReorderPage');
 
-            \Idno\Core\Idno::site()->routes()->addRoute('/pages/:id/?', 'IdnoPlugins\StaticPages\Pages\View');
+            \Idno\Core\Idno::site()->routes()->addRoute('/pages/([A-Za-z0-9\-\_\%]+)/?', 'IdnoPlugins\StaticPages\Pages\View');
 
             // This makes sure that the homepage is accessible even when it is overridden.
             \Idno\Core\Idno::site()->routes()->addRoute('/content/default/?', 'Idno\Pages\Homepage');

--- a/IdnoPlugins/StaticPages/templates/default/entity/StaticPage/edit.tpl.php
+++ b/IdnoPlugins/StaticPages/templates/default/entity/StaticPage/edit.tpl.php
@@ -71,7 +71,6 @@ if ($title == 'Untitled') {
                             'name' => 'category',
                             'id' => 'category',
                             'class' => 'selectpicker input-select form-control',
-                            'label' => \Idno\Core\Idno::site()->language()->_('Parent category'),
                             'options' => $vars['categories'],
                             'value' => $vars['category'],
                             'blank-default' => false,
@@ -87,9 +86,16 @@ if ($title == 'Untitled') {
                     <p>
                         <label for="forward_url">
                             <?php echo \Idno\Core\Idno::site()->language()->_('Forwarding URL'); ?></label>
-                        <input type="text" name="forward_url" id="forward_url"
-                                placeholder="<?php echo \Idno\Core\Idno::site()->language()->_('Website to forward users to'); ?>"
-                                value="<?php echo htmlspecialchars($forward_url) ?>" class="form-control"/>
+
+                        <?php
+                            echo $this->__([
+                                'name' => 'forward_url',
+                                'id' => 'forward_url',
+                                'class' => 'input-text form-control',
+                                'value' => $forward_url,
+                                'placeholder' => \Idno\Core\Idno::site()->language()->_('Website to forward users to')
+                            ])->draw('forms/input/url');
+                        ?>                            
                         <small><?php echo \Idno\Core\Idno::site()->language()->_('Most of the time, you should leave this blank. Include a URL here if you want users to be forwarded to an external page instead of displaying page content.'); ?></small>
                     </p>
                 </div>

--- a/IdnoPlugins/StaticPages/templates/default/entity/StaticPage/edit.tpl.php
+++ b/IdnoPlugins/StaticPages/templates/default/entity/StaticPage/edit.tpl.php
@@ -60,63 +60,40 @@ if ($title == 'Untitled') {
 
                 <?php echo $this->draw('entity/tags/input'); ?>
 
-                <div class="page-cat">
-                    <label>
-                        <?php echo \Idno\Core\Idno::site()->language()->_('Parent category'); ?></label><br>
-                    <select name="category" class="selectpicker">
-                        <option <?php if ($vars['category'] == 'No Category') {
-                            echo 'selected';
-} ?>><?php echo \Idno\Core\Idno::site()->language()->_('No Category'); ?>
-                        </option>
-                        <?php
+                <div class="page-cat form-group">
+                    <p>
+                    <label for="forward_url">
+                                <?php echo \Idno\Core\Idno::site()->language()->_('Page Category'); ?></label><br>
+                    <?php
+                        if (empty($vars['categories'])) $vars['categories'] = ['No category' => 'No Category'];
 
-                        if (!empty($vars['categories'])) {
-                            foreach ($vars['categories'] as $category) {
-
-                                ?>
-                                    <option <?php if ($category == $vars['category']) {
-                                        echo 'selected';
-} ?>><?php echo htmlspecialchars($category) ?></option>
-                                <?php
-
-                            }
-                        }
-
-                        ?>
-                    </select>
-
+                        echo $this->__([
+                            'name' => 'category',
+                            'id' => 'category',
+                            'class' => 'selectpicker input-select form-control',
+                            'label' => \Idno\Core\Idno::site()->language()->_('Parent category'),
+                            'options' => $vars['categories'],
+                            'value' => $vars['category'],
+                            'blank-default' => false,
+                        ])->draw('forms/input/select');
+                    ?>
+                        <small>
+                        <?php echo \Idno\Core\Idno::site()->language()->_('If a category is selected, this page will be placed under a drop-down menu for that category in the main menu bar.'); ?>
+                        </small>
+                    </p>
                 </div>
 
-                <p id="show-options">
-                    <small><a href="#" onclick="$('#moreoptions').toggle(); $('#show-options').hide(); return false;"><i
-                                class="fa fa-plus"></i>
-                            <?php echo \Idno\Core\Idno::site()->language()->_('Show advanced options'); ?></a></small>
-                </p>
-                <div id="moreoptions" <?php
-                if (empty($hide_title) && empty($forward_url)) {
-                    ?>
-                        style="display:none"
-                    <?php
-                }
-                ?>>
-
-                    <p id="hide-options">
-                        <small><a href="#"
-                                  onclick="$('#moreoptions').toggle(); $('#show-options').show(); return false;"><i
-                                    class="fa fa-minus"></i>
-                                <?php echo \Idno\Core\Idno::site()->language()->_('Hide advanced options'); ?></a></small>
+                <div class="form-group">
+                    <p>
+                        <label for="forward_url">
+                            <?php echo \Idno\Core\Idno::site()->language()->_('Forwarding URL'); ?></label>
+                        <input type="text" name="forward_url" id="forward_url"
+                                placeholder="<?php echo \Idno\Core\Idno::site()->language()->_('Website to forward users to'); ?>"
+                                value="<?php echo htmlspecialchars($forward_url) ?>" class="form-control"/>
+                        <small><?php echo \Idno\Core\Idno::site()->language()->_('Most of the time, you should leave this blank. Include a URL here if you want users to be forwarded to an external page instead of displaying page content.'); ?></small>
                     </p>
-
-                    <div>
-                        <p>
-                            <label for="forward_url">
-                                <?php echo \Idno\Core\Idno::site()->language()->_('Forward URL'); ?></label>
-                            <input type="text" name="forward_url" id="forward_url"
-                                   placeholder="<?php echo \Idno\Core\Idno::site()->language()->_('Website to forward users to'); ?>"
-                                   value="<?php echo htmlspecialchars($forward_url) ?>" class="form-control"/>
-                            <small><?php echo \Idno\Core\Idno::site()->language()->_('Most of the time, you should leave this blank. Include a URL here if you want users to be forwarded to an external page instead of displaying page content.'); ?></small>
-                        </p>
-                    </div>
+                </div>
+                <div class="form-group">
                     <p style="margin-bottom: 20px">
                         <strong><?php echo \Idno\Core\Idno::site()->language()->_('Show the page title as a heading?'); ?></strong><br>
                         <label class="radio-inline">
@@ -140,12 +117,9 @@ if ($title == 'Untitled') {
                             No
                         </label>
                     </p>
+                </div>
 
-                    <div class="page-cat">
-
-
-                    </div>
-
+                <div class="page-cat">
                 </div>
 
                 <?php echo $this->draw('content/extra'); ?>

--- a/IdnoPlugins/StaticPages/templates/default/entity/StaticPage/edit.tpl.php
+++ b/IdnoPlugins/StaticPages/templates/default/entity/StaticPage/edit.tpl.php
@@ -125,9 +125,6 @@ if ($title == 'Untitled') {
                     </p>
                 </div>
 
-                <div class="page-cat">
-                </div>
-
                 <?php echo $this->draw('content/extra'); ?>
                 <?php echo $this->draw('content/access'); ?>
 

--- a/IdnoPlugins/StaticPages/templates/default/staticpages/admin.tpl.php
+++ b/IdnoPlugins/StaticPages/templates/default/staticpages/admin.tpl.php
@@ -28,7 +28,7 @@
         </h1>
 
         <p class="explanation">
-            <?php echo \Idno\Core\Idno::site()->language()->_('Pages are a great way to add content to your site that you want to keep separate from your stream of normal posts and updates.  Common examples of pages include an about page, a contact page, or a resume.'); ?>
+            <?php echo \Idno\Core\Idno::site()->language()->_('Pages allow you to add content to your site that you want to keep separate from your stream of normal posts and updates.  Common examples of pages include an about page, a contact page, or a resume.'); ?>
         </p>
 
     </div>
@@ -132,7 +132,7 @@
         </h2>
 
         <p class="explanation">
-            <?php echo \Idno\Core\Idno::site()->language()->_('If you plan on adding many pages, you may want to group them under categories.  However, you don’t have to assign a page to a category.'); ?>
+            <?php echo \Idno\Core\Idno::site()->language()->_('If you plan on adding many pages, you may want to group them into drop-down menu categories. These are optional.'); ?>
         </p>
     </div>
 </div>


### PR DESCRIPTION
## Here's what I fixed or added:

The static page editing screen now has more standard input for categories and doesn't bother hiding settings under an inaccessible "advanced settings" button.

Also, I fixed some of the text.

## Here's why I did it:

Styles had broken somewhere along the line.

## Checklist: (`[x]` to check/tick the boxes)

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
