### PR TITLE
Add 'smtp_password' redaction

### DIFF
--- a/Idno/Pages/Admin/Diagnostics.php
+++ b/Idno/Pages/Admin/Diagnostics.php
@@ -40,6 +40,7 @@ namespace Idno\Pages\Admin {
                 $config->config['dbpass']     = '** REDACTED **';
                 $config->ini_config['dbpass'] = '** REDACTED **';
                 $config->config['site_secret']     = '** REDACTED **';
+                $config->config['smtp_password']   = '** REDACTED **';
 
                 $report .= "\nRunning config:\n---------------\n" . var_export($config, true) . "\n\n";
                 $report .= "\$_SESSION:\n----------\n" . var_export($_SESSION, true) . "\n\n";


### PR DESCRIPTION
## Here's what I fixed or added:
Added 'smtp_password' redaction when generating a diagnostics report.

## Here's why I did it:
Because sharing SMTP passwords when submitting a diagnostics report is not a great idea.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [N/A] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
