### PR TITLE
Wrap Checkin.tpl.php map JS for local variables

### DIFF
--- a/IdnoPlugins/Checkin/templates/default/entity/Checkin.tpl.php
+++ b/IdnoPlugins/Checkin/templates/default/entity/Checkin.tpl.php
@@ -39,17 +39,18 @@
 </div>
 <?php if (empty($vars['feed_view'])) { ?>
         <script>
-            var map<?php echo $object->_id?> = L.map('map_<?php echo $object->_id?>', {
-                touchZoom: false,
-                scrollWheelZoom: false
-            }).setView([<?php echo $object->lat() ?>, <?php echo $object->long() ?>], 16);
-            var layer<?php echo $object->_id?> = new L.StamenTileLayer("toner-lite");
-            map<?php echo $object->_id?>.addLayer(layer<?php echo $object->_id?>);
-            var marker<?php echo $object->_id?> = L.marker([<?php echo $object->lat()?>, <?php echo $object->long()?>]);
-            marker<?php echo $object->_id?>.addTo(map<?php echo $object->_id?>);
-            //map<?php echo $object->_id?>.zoomControl.disable();
-            map<?php echo $object->_id?>.scrollWheelZoom.disable();
-            map<?php echo $object->_id?>.touchZoom.disable();
-            map<?php echo $object->_id?>.doubleClickZoom.disable();
+            (function () {
+                var map = L.map('map_<?php echo $object->_id?>', {
+                    touchZoom: false,
+                    scrollWheelZoom: false
+                }).setView([<?php echo $object->lat() ?>, <?php echo $object->long() ?>], 16);
+                var layer = new L.StamenTileLayer("toner-lite");
+                map.addLayer(layer);
+                var marker = L.marker([<?php echo $object->lat()?>, <?php echo $object->long()?>]);
+                marker.addTo(map);
+                map.scrollWheelZoom.disable();
+                map.touchZoom.disable();
+                map.doubleClickZoom.disable();
+            })();
         </script>
 <?php }


### PR DESCRIPTION
## Here's what I fixed or added:

Fixes #3161 by removing random strings from JavaScript variable names. Instead the whole script is wrapped in [an IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) so short variable names can be used without conflicting in the global scope.

## Here's why I did it:

The `$object->_id` code was adding `-` (minus-hyphen) symbols within JavaScript variable names, where they are not allowed. This meant that maps could no longer be rendered on check-in type posts.

## Checklist:

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [x] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
