### PR TITLE
Activitypub/Sprint 1

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1335,12 +1335,13 @@ namespace Idno\Common {
                 if ($images = $doc->getElementsByTagName('img')) {
                     foreach ($images as $image) {
                         if ($source = $image->getAttribute('src')) {
-                            $image_mime = self::getMediaMimeType($image->getAttribute('src'));
+                            $media_mime = self::getMediaMimeType($image->getAttribute('src'));
+                            $media_type = explode('/', $media_mime)[0];
                             $formattedImage = (object)[
-                                'type' => ucfirst(reset(explode('/', $image_mime))),
+                                'type' => ucfirst($media_type),
                                 'name' => $image->getAttribute('alt'),
                                 'url' => $image->getAttribute('src'),
-                                'mediaType' => $image_mime
+                                'mediaType' => $media_mime
                             ];
                             $images_arr[] = $formattedImage;
                         }

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1565,14 +1565,12 @@ namespace Idno\Common {
 
         function getFormattedContent()
         {
-            $body = '';
+            $body = \Idno\Core\Idno::site()->template()->parseHashtags(\Idno\Core\Idno::site()->template()->parseURLs($this->body));
             if ( 'note' === $this?->getActivityStreamsObjectType()) {
-                // note plaintext needs parsing
-                $body = \Idno\Core\Idno::site()->template()->parseHashtags(\Idno\Core\Idno::site()->template()->parseURLs($this->body));
-            } else {
-                //image & article need newline filtering 
-                $body = preg_replace('/\R+/', '', $this->body);
+                // note plaintext needs autop
+                $body = \Idno\Core\Idno::site()->template()->autop($body);
             }
+            $body = preg_replace('/\R+/', '', $body);
             return $body;
         }
 

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1159,7 +1159,8 @@ namespace Idno\Common {
                     else
                         $descr .= ' ' . $this->tags;
                 }
-                if (preg_match_all('/(?<!=)(?<!["\'])(\#[A-Za-z0-9\_]+)/iu', $descr, $matches)) {
+                $pattern = '/(?<=^|>|\s)(\#[A-Za-z0-9\_]+)/iu';
+                if (preg_match_all($pattern, $descr, $matches)) {
                     if (!empty($matches[0])) {
                         return $matches[0];
                     }

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1352,6 +1352,21 @@ namespace Idno\Common {
         }
 
         /**
+         * Gets the mime-type for a given local media url
+         * @param string $media_url
+         * @return string
+         */
+        static function getMediaMimeType($media_url)
+        {
+            $media_object = \Idno\Entities\File::getByURL($media_url);
+            if ($media_object) {
+                return $media_object->file['mime_type'];
+            }
+
+            return false;
+        }
+
+        /**
          * Retrieves paragraphs from the body, optionally limiting the total number to $total
          * @param int $total
          * @return array

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1335,12 +1335,12 @@ namespace Idno\Common {
                 if ($images = $doc->getElementsByTagName('img')) {
                     foreach ($images as $image) {
                         if ($source = $image->getAttribute('src')) {
-                            $get_image = \Idno\Entities\File::getByURL($image->getAttribute('src'));
+                            $image_mime = self::getMediaMimeType($image->getAttribute('src'));
                             $formattedImage = (object)[
-                                'type' => ucfirst(explode('/', $get_image->file['mime_type'])[0]),
+                                'type' => ucfirst(reset(explode('/', $image_mime))),
                                 'name' => $image->getAttribute('alt'),
                                 'url' => $image->getAttribute('src'),
-                                'mediaType' => $get_image->file['mime_type']
+                                'mediaType' => $image_mime
                             ];
                             $images_arr[] = $formattedImage;
                         }

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1251,10 +1251,10 @@ namespace Idno\Common {
          * Retrieves this object's actorID URI
          * @return bool|string
          */
-        function getActorID()
+        function getActivityPubActorID()
         {
             if ($owner = $this->getOwner()) {
-                return $owner->getActorID();
+                return $owner->getActivityPubActorID();
             }
 
             return false;

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1567,7 +1567,7 @@ namespace Idno\Common {
 
         function getFormattedContent()
         {
-            $body = \Idno\Core\Idno::site()->template()->parseHashtags(\Idno\Core\Idno::site()->template()->parseURLs($this->body));
+            $body = \Idno\Core\Idno::site()->template()->parseHashtags(\Idno\Core\Idno::site()->template()->parseURLs($this->body, '', false));
             if ( 'note' === $this?->getActivityStreamsObjectType()) {
                 // note plaintext needs autop
                 $body = \Idno\Core\Idno::site()->template()->autop($body);

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1620,6 +1620,21 @@ namespace Idno\Common {
         }
 
         /**
+         * Retrieves the access group for ActivityPub To
+         * @return array
+         */
+
+        function getAddressedTo()
+        {
+            $to = [];
+            if ($this->isPublic()) {
+                $to[] = 'https://www.w3.org/ns/activitystreams#Public';
+            }
+
+            return $to;
+        }
+
+        /**
          * Is this entity a reply to another entity?
          * @return bool
          */

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1144,6 +1144,31 @@ namespace Idno\Common {
         }
 
         /**
+         * Return an array of hashtags objects (if any) present in this entity's description.
+         * @return array
+         */
+        function getHashTagObjects()
+        {
+            $hash_tags = $this->getTags();
+            $hash_tags_array = [];
+            if (!empty($hash_tags)) {
+                if (is_array($hash_tags)) {
+                    foreach( $hash_tags as $hash_tag ) {
+                        $hash_tag_obj = (object) [
+                            'type' => 'Hashtag',
+                            'href' => \Idno\Core\Idno::site()->config()->url . 'tag/' . ltrim($hash_tag,'#'),
+                            'name' => $hash_tag
+                        ];
+                        $hash_tags_array[] = $hash_tag_obj;
+                    }
+                    return $hash_tags_array;
+                }
+            }
+
+            return array();
+        }
+
+        /**
          * Retrieve a text description of this entity
          * @return string
          */

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -525,6 +525,28 @@ namespace Idno\Common {
         }
 
         /**
+         * Return the published time of the entity.
+         * @return DateTime::RFC3339
+         */
+        function getPublishedTime()
+        {
+            return date(\DateTime::RFC3339, $this->created);
+        }
+
+        /**
+         * Return the created timestamp of the entity.
+         * @return unix timestamp
+         */
+        function getUpdatedTime()
+        {
+            $updated = null;
+            if ($this->created < $this->updated) {
+                $updated = date(\DateTime::RFC3339, $this->updated);
+            }
+            return $updated;
+        }
+
+        /**
          * Retrieve a title for this object suitable for notifications
          * @return string
          */

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -915,9 +915,9 @@ namespace Idno\Common {
 
             // If a file is embeddable we should not allow XSS-able filenames.
             if ($embeddable) {
-              if (substr(strtolower($file['filename']), -5) == '.html' || substr(strtolower($file['filename']), -3) == '.js') $file['filename'] .= '.data';
-              $file['filename'] = str_replace('<', '', $file['filename']);
-              $file['filename'] = str_replace('>', '', $file['filename']);
+                if (substr(strtolower($file['filename']), -5) == '.html' || substr(strtolower($file['filename']), -3) == '.js') $file['filename'] .= '.data';
+                $file['filename'] = str_replace('<', '', $file['filename']);
+                $file['filename'] = str_replace('>', '', $file['filename']);
             }
 
             $attachments = $this->attachments;
@@ -1182,7 +1182,7 @@ namespace Idno\Common {
                     foreach( $hash_tags as $hash_tag ) {
                         $hash_tag_obj = (object) [
                             'type' => 'Hashtag',
-                            'href' => \Idno\Core\Idno::site()->config()->url . 'tag/' . ltrim($hash_tag,'#'),
+                            'href' => \Idno\Core\Idno::site()->config()->url . 'tag/' . ltrim($hash_tag, '#'),
                             'name' => $hash_tag
                         ];
                         $hash_tags_array[] = $hash_tag_obj;
@@ -2824,7 +2824,7 @@ namespace Idno\Common {
          * Allows you to unset a property value as you would an array
          * @param mixed $offset
          */
-        function offsetUnset(mixed $offset): void 
+        function offsetUnset(mixed $offset): void
         {
             unset($this->attributes[$offset]);
         }

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1175,6 +1175,19 @@ namespace Idno\Common {
         }
 
         /**
+         * Retrieves this object's actorID URI
+         * @return bool|string
+         */
+        function getActorID()
+        {
+            if ($owner = $this->getOwner()) {
+                return $owner->getActorID();
+            }
+
+            return false;
+        }
+
+        /**
          * Retrieves the rendered HTML of this body
          * @return string
          */

--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1543,6 +1543,25 @@ namespace Idno\Common {
         }
 
         /**
+         * Retrieve a short description of this page suitable for including in page metatags
+         * @param $words Number of words to limit to, if we're generating a short description on the fly (default: 25)
+         * @return string
+         */
+
+        function getFormattedContent()
+        {
+            $body = '';
+            if ( 'note' === $this?->getActivityStreamsObjectType()) {
+                // note plaintext needs parsing
+                $body = \Idno\Core\Idno::site()->template()->parseHashtags(\Idno\Core\Idno::site()->template()->parseURLs($this->body));
+            } else {
+                //image & article need newline filtering 
+                $body = preg_replace('/\R+/', '', $this->body);
+            }
+            return $body;
+        }
+
+        /**
          * Return a URI endpoint to edit this object (defaults to a variation of
          * the UUID of the object)
          * @return string

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -1283,7 +1283,7 @@ namespace Idno\Common {
                     }
                 }
             } else if (\Idno\Core\Idno::site()->config()->share_backup_url) {
-              $icon = \Idno\Core\Idno::site()->config()->share_backup_url;
+                $icon = \Idno\Core\Idno::site()->config()->share_backup_url;
             }
 
             return \Idno\Core\Idno::site()->events()->triggerEvent('icon', ['object' => $this], $icon);

--- a/Idno/Core/DefaultTemplate.php
+++ b/Idno/Core/DefaultTemplate.php
@@ -294,6 +294,9 @@ namespace Idno\Core {
                     site()->template()->setTemplateType($template);
                 } else if ($page->isAcceptedContentType('application/json')) {
                     site()->template()->setTemplateType('json');
+                } else if ($page->isAcceptedContentType('application/ld+json; profile="https://www.w3.org/ns/activitystreams"') ||
+                    $page->isAcceptedContentType('application/activity+json')) {
+                    site()->template()->setTemplateType('activitypub');
                 } else {
                     site()->template()->setTemplateType('default');
                 }

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -280,6 +280,7 @@ namespace Idno\Core {
             $this->routes()->addRoute('/service/web/unfurl/remove/:id/?', '\Idno\Pages\Service\Web\RemovePreview');
             $this->routes()->addRoute('/service/system/log/?', '\Idno\Pages\Service\System\Log');
             $this->routes()->addRoute('/service/geo/geocoder/?', '\Idno\Pages\Service\Geo\Geocoder');
+            $this->routes()->addRoute('/inbox/?', '\Idno\Pages\Service\ActivityPub\SharedInbox');
 
             // These must be loaded last
             $this->plugins = new Plugins();

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -240,6 +240,7 @@ namespace Idno\Core {
             $this->routes()->addRoute('/profile/([^\/]+)/?', '\Idno\Pages\User\View');
             $this->routes()->addRoute('/profile/([^\/]+)/edit/?', '\Idno\Pages\User\Edit');
             $this->routes()->addRoute('/profile/([^\/]+)/([A-Za-z\-\/]+)+', '\Idno\Pages\User\View');
+            $this->routes()->addRoute('/actor/([^\/]+)/?', '\Idno\Pages\User\View');
 
             /**
              * Search

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -280,7 +280,7 @@ namespace Idno\Core {
             $this->routes()->addRoute('/service/web/unfurl/remove/:id/?', '\Idno\Pages\Service\Web\RemovePreview');
             $this->routes()->addRoute('/service/system/log/?', '\Idno\Pages\Service\System\Log');
             $this->routes()->addRoute('/service/geo/geocoder/?', '\Idno\Pages\Service\Geo\Geocoder');
-            $this->routes()->addRoute('/inbox/?', '\Idno\Pages\Service\ActivityPub\SharedInbox');
+            // $this->routes()->addRoute('/inbox/?', '\Idno\Pages\Service\ActivityPub\SharedInbox');
 
             // These must be loaded last
             $this->plugins = new Plugins();

--- a/Idno/Core/Templating/Parsing.php
+++ b/Idno/Core/Templating/Parsing.php
@@ -11,11 +11,12 @@ namespace Idno\Core\Templating {
         /**
          * Automatically links URLs embedded in a piece of text
          *
-         * @param  stirng $text
+         * @param  string $text
          * @param  string $code Optionally, code to inject into the anchor tag (eg to add classes). '%URL%' is replaced with the URL. Default: blank.
+         * @param  bool $wbr Optionally, inject <wbr /> tag. Default: true.
          * @return string
          */
-        function parseURLs($text, $code = '')
+        function parseURLs($text, $code = '', $wbr = true)
         {
             $r = preg_replace_callback(
                 '/(?<!=)(?<!["\'])((ht|f)tps?:\/\/[^\s<>"\']+)/i', function ($matches) use ($code) {
@@ -43,7 +44,11 @@ namespace Idno\Core\Templating {
                         $result .= ' ' . str_replace("%URL%", $url, $code);
                     }
                     $result .= ">";
-                    $result .= preg_replace('/([\/=]+)/', '${1}<wbr />', static::sampleTextChars($url, 100));
+                    if ($wbr) {
+                        $result .= preg_replace('/([\/=]+)/', '${1}<wbr />', static::sampleTextChars($url, 100));
+                    } else {
+                        $result .= preg_replace('/([\/=]+)/', '${1}', static::sampleTextChars($url, 100));
+                    }
                     $result .= "</a>$punc";
 
                     return $result;

--- a/Idno/Core/Templating/Urls.php
+++ b/Idno/Core/Templating/Urls.php
@@ -20,7 +20,7 @@ namespace Idno\Core\Templating {
             $components = parse_url($this->getCurrentURL());
             if (!empty($components['query'])) {
                 parse_str($components['query'], $url_var_array);
-                if (!empty($url_var_array[$variable_name])) { 
+                if (!empty($url_var_array[$variable_name])) {
                     unset($url_var_array[$variable_name]);
                 }
             } else {
@@ -28,7 +28,7 @@ namespace Idno\Core\Templating {
             }
             $components['query'] = http_build_query($url_var_array);
             $url                 = $components['scheme'] . '://' . $components['host'] . (!empty($components['port']) ? ':' . $components['port'] : '') . $components['path'];
-            if (!empty($components['query'])) { 
+            if (!empty($components['query'])) {
                 $url .= '?' . $components['query'];
             }
 

--- a/Idno/Entities/File.php
+++ b/Idno/Entities/File.php
@@ -294,10 +294,10 @@ namespace Idno\Entities {
         public static function isFileFreeFromScriptTags($file_path, $file_name = '')
         {
             foreach([$file_name, file_get_contents($file_path)] as $contents) {
-              $contents = strtolower($contents);
-              if (stripos($contents, '<script') !== false || stripos($contents, '<?php') !== false) {
-                return false;
-              }
+                $contents = strtolower($contents);
+                if (stripos($contents, '<script') !== false || stripos($contents, '<?php') !== false) {
+                    return false;
+                }
             }
             return true;
         }

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -174,6 +174,18 @@ namespace Idno\Entities {
         }
 
         /**
+         * Retrieve the Icon object to this user's avatar icon image
+         * (if none has been saved, a default is returned)
+         *
+         * @return object
+         */
+        function getIconMimeType()
+        {
+            $mimebits = explode('.', $this->getIcon());
+            return 'image/' . end($mimebits);
+        }
+
+        /**
          * Return the user's current timezone.
          *
          * @return type

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -163,13 +163,10 @@ namespace Idno\Entities {
          */
         function getIconObject()
         {
-            $mimebits = explode('.', $this->getIcon());
-            $icon_mime = 'image/' . end($mimebits);
-
             return [
                 'url' => $this->getIcon(),
                 'type' => 'Image',
-                'mediaType' => $icon_mime,
+                'mediaType' => $this->getIconMimeType(),
             ];
         }
 

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -413,6 +413,45 @@ namespace Idno\Entities {
         }
 
         /**
+         * Generate a (ActivityPub) Key Pair for this user
+         * Props to wordpress-activitypub
+         *
+         * @return string
+         */
+        function generateKeyPair()
+        {
+            $config = array(
+                'digest_alg' => 'sha512',
+                'private_key_bits' => 2048,
+                'private_key_type' => \OPENSSL_KEYTYPE_RSA,
+            );
+    
+            $key = \openssl_pkey_new( $config );
+            $priv_key = null;
+    
+            \openssl_pkey_export( $key, $priv_key );
+    
+            $detail = \openssl_pkey_get_details( $key );
+    
+            // check if keys are valid
+            if (
+                empty( $priv_key ) || ! is_string( $priv_key ) ||
+                ! isset( $detail['key'] ) || ! is_string( $detail['key'] )
+            ) {
+                return array(
+                    'private_key' => null,
+                    'public_key'  => null,
+                );
+            }
+
+            $this->privateKey = $priv_key;
+            $this->publicKeyPem = $detail['key'];
+            $this->save(true);
+
+            return;
+        }
+
+        /**
          * Is this user an admin?
          *
          * @return bool

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -52,7 +52,7 @@ namespace Idno\Entities {
                         [
                           'rel' => 'self',
                           'type' => 'application/activity+json',
-                          'href' => $user->getActorID()
+                          'href' => $user->getActivityPubActorID()
                         ],
                         [
                           'rel'  => 'http://webfinger.net/rel/avatar',
@@ -221,7 +221,7 @@ namespace Idno\Entities {
          *
          * @return string
          */
-        function getActorID()
+        function getActivityPubActorID()
         {
             if (!empty($this->url)) {
                 return $this->url;
@@ -450,8 +450,8 @@ namespace Idno\Entities {
             }
 
             $publicKey = [
-                'id' => $this->getActorID() . '#main-key',
-                'owner' => $this->getActorID(),
+                'id' => $this->getActivityPubActorID() . '#main-key',
+                'owner' => $this->getActivityPubActorID(),
                 'publicKeyPem' => $this->publicKeyPem,
             ];
 

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -49,13 +49,11 @@ namespace Idno\Entities {
 
                     if ($user instanceof User) {
                       $links = [
-/* Uncomment when ActivityPub endpoints are live
                         [
                           'rel' => 'self',
                           'type' => 'application/activity+json',
-                          'href' => $user->getDisplayURL() . '?_t=activitypub'
+                          'href' => $user->getActorID()
                         ],
-*/
                         [
                           'rel'  => 'http://webfinger.net/rel/avatar',
                           'href' => $user->getIcon()

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -43,12 +43,12 @@ namespace Idno\Entities {
                     $user      = $eventdata['object'];
 
                     $links = $event->response();
-                    if (empty($links)) { 
-                      $links = array();
+                    if (empty($links)) {
+                        $links = array();
                     }
 
                     if ($user instanceof User) {
-                      $links = [
+                        $links = [
                         [
                           'rel' => 'self',
                           'type' => 'application/activity+json',
@@ -64,7 +64,7 @@ namespace Idno\Entities {
                           'type' => 'text/html',
                           'href' => $user->getURL()
                         ]
-                      ];
+                        ];
                     }
 
                     $event->setResponse($links);
@@ -501,18 +501,18 @@ namespace Idno\Entities {
                 'private_key_bits' => 2048,
                 'private_key_type' => \OPENSSL_KEYTYPE_RSA,
             );
-    
-            $key = \openssl_pkey_new( $config );
+
+            $key = \openssl_pkey_new($config);
             $priv_key = null;
-    
-            \openssl_pkey_export( $key, $priv_key );
-    
-            $detail = \openssl_pkey_get_details( $key );
-    
+
+            \openssl_pkey_export($key, $priv_key);
+
+            $detail = \openssl_pkey_get_details($key);
+
             // check if keys are valid
             if (
-                empty( $priv_key ) || ! is_string( $priv_key ) ||
-                ! isset( $detail['key'] ) || ! is_string( $detail['key'] )
+                empty($priv_key) || ! is_string($priv_key) ||
+                ! isset($detail['key']) || ! is_string($detail['key'])
             ) {
                 return array(
                     'private_key' => null,

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -413,6 +413,36 @@ namespace Idno\Entities {
         }
 
         /**
+         * Returns this user's PublicKeyPem for ActivityPub, and generates a new one if they don't
+         * have one yet
+         *
+         * @return string
+         */
+        function getPublicKeyPem()
+        {
+            if (empty($this->publicKeyPem)) {
+                $this->generateKeyPair();
+            }
+
+            return $this->publicKeyPem;
+        }
+
+        /**
+         * Returns this user's PrivateKey for ActivityPub, and generates a new one if they don't
+         * have one yet
+         *
+         * @return string
+         */
+        private function getPrivateKey()
+        {
+            if (empty($this->privateKey)) {
+                $this->generateKeyPair();
+            }
+
+            return $this->privateKey;
+        }
+
+        /**
          * Generate a (ActivityPub) Key Pair for this user
          * Props to wordpress-activitypub
          *

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -413,6 +413,26 @@ namespace Idno\Entities {
         }
 
         /**
+         * Returns this user's PublicKey object for an ActivityPub actor Profile
+         *
+         * @return object
+         */
+        function getPublicKey()
+        {
+            if (empty($this->publicKeyPem)) {
+                $this->generateKeyPair();
+            }
+
+            $publicKey = [
+                'id' => $this->getActorID() . '#main-key',
+                'owner' => $this->getActorID(),
+                'publicKeyPem' => $this->publicKeyPem,
+            ];
+
+            return $publicKey;
+        }
+
+        /**
          * Returns this user's PublicKeyPem for ActivityPub, and generates a new one if they don't
          * have one yet
          *

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -269,6 +269,17 @@ namespace Idno\Entities {
         }
 
         /**
+         * Get endpoints for sharedInbox
+         *
+         * @return string
+         */
+
+        function getEndpoints()
+        {
+            return [ 'sharedInbox' => \Idno\Core\Idno::site()->config()->getURL() . 'inbox'];
+        }
+
+        /**
          * Retrieves user by email address
          *
          * @param  string $email

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -202,6 +202,20 @@ namespace Idno\Entities {
         }
 
         /**
+         * Get the ActivityPub actor ID for this user
+         *
+         * @return string
+         */
+        function getActorID()
+        {
+            if (!empty($this->url)) {
+                return $this->url;
+            }
+
+            return \Idno\Core\Idno::site()->config()->getDisplayURL() . 'actor/' . $this->getHandle();
+        }
+
+        /**
          * Get the IndieAuth identity URL for this user
          *
          * @return string

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -56,7 +56,7 @@ namespace Idno\Entities {
                         ],
                         [
                           'rel'  => 'http://webfinger.net/rel/avatar',
-                          'type' => $user->getIconMimetype(),
+                          'type' => \Idno\Entities\File::getByURL($user->getIcon())->file['mime_type'],
                           'href' => $user->getIcon()
                         ],
                         [
@@ -168,20 +168,8 @@ namespace Idno\Entities {
             return [
                 'url' => $this->getIcon(),
                 'type' => 'Image',
-                'mediaType' => $this->getIconMimeType(),
+                'mediaType' => \Idno\Entities\File::getByURL($user->getIcon()),
             ];
-        }
-
-        /**
-         * Retrieve the Icon object to this user's avatar icon image
-         * (if none has been saved, a default is returned)
-         *
-         * @return object
-         */
-        function getIconMimeType()
-        {
-            $mimebits = explode('.', $this->getIcon());
-            return 'image/' . end($mimebits);
         }
 
         /**

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -56,10 +56,12 @@ namespace Idno\Entities {
                         ],
                         [
                           'rel'  => 'http://webfinger.net/rel/avatar',
+                          'type' => $user->getIconMimetype(),
                           'href' => $user->getIcon()
                         ],
                         [
                           'rel'  => 'http://webfinger.net/rel/profile-page',
+                          'type' => 'text/html',
                           'href' => $user->getURL()
                         ]
                       ];

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -56,7 +56,7 @@ namespace Idno\Entities {
                         ],
                         [
                           'rel'  => 'http://webfinger.net/rel/avatar',
-                          'type' => \Idno\Entities\File::getByURL($user->getIcon())->file['mime_type'],
+                          'type' => parent::getMediaMimeType($user->getIcon()),
                           'href' => $user->getIcon()
                         ],
                         [
@@ -168,7 +168,7 @@ namespace Idno\Entities {
             return [
                 'url' => $this->getIcon(),
                 'type' => 'Image',
-                'mediaType' => \Idno\Entities\File::getByURL($user->getIcon()),
+                'mediaType' => parent::getMediaMimeType($this->getIcon()),
             ];
         }
 

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -158,6 +158,24 @@ namespace Idno\Entities {
         }
 
         /**
+         * Retrieve the Icon object to this user's avatar icon image
+         * (if none has been saved, a default is returned)
+         *
+         * @return object
+         */
+        function getIconObject()
+        {
+            $mimebits = explode('.', $this->getIcon());
+            $icon_mime = 'image/' . end($mimebits);
+
+            return [
+                'url' => $this->getIcon(),
+                'type' => 'Image',
+                'mediaType' => $icon_mime,
+            ];
+        }
+
+        /**
          * Return the user's current timezone.
          *
          * @return type

--- a/Idno/Entities/User.php
+++ b/Idno/Entities/User.php
@@ -271,7 +271,7 @@ namespace Idno\Entities {
          * @return string
          */
 
-        function getEndpoints()
+        function getAcivityPubEndpoints()
         {
             return [ 'sharedInbox' => \Idno\Core\Idno::site()->config()->getURL() . 'inbox'];
         }

--- a/Idno/Pages/Webfinger/View.php
+++ b/Idno/Pages/Webfinger/View.php
@@ -31,13 +31,13 @@ namespace Idno\Pages\Webfinger {
             $t = \Idno\Core\Idno::site()->template();
             $t->setTemplateType('json');
             echo $t->__(
-              array(
+                array(
                 'properties' => [
                   'http://webfinger.example/ns/name' => $user->getName(),
                 ],
                 'subject' => $acct,
                 'links'   => $links
-              )
+                )
             )->draw('shell');
         }
 

--- a/Themes/Black/templates/default/content/end.tpl.php
+++ b/Themes/Black/templates/default/content/end.tpl.php
@@ -77,10 +77,10 @@ if ($like_annotations = $vars['object']->getAnnotations('like')) {
             ?></a></span>
     <a class="shares" href="<?php echo $vars['object']->getDisplayURL() ?>#comments"><?php if ($shares = $vars['object']->countAnnotations('share')) {
             echo '<i class="fa fa-retweet"></i> ' . $shares;
-   } ?></a>
+} ?></a>
     <a class="rsvps" href="<?php echo $vars['object']->getDisplayURL() ?>#comments"><?php if ($rsvps = $vars['object']->countAnnotations('rsvp')) {
             echo '<i class="fa fa-calendar-o"></i> ' . $rsvps;
-   } ?></a>
+} ?></a>
 </div>
 <br class="clearall"/>
 <?php

--- a/Themes/Cherwell/Controller.php
+++ b/Themes/Cherwell/Controller.php
@@ -46,7 +46,7 @@ namespace Themes\Cherwell {
             }
 
         }
-        
+
         function registerTranslations()
         {
             \Idno\Core\Idno::site()->language()->register(

--- a/Themes/Cherwell/templates/default/content/end.tpl.php
+++ b/Themes/Cherwell/templates/default/content/end.tpl.php
@@ -76,10 +76,10 @@ if ($like_annotations = $vars['object']->getAnnotations('like')) {
             ?></a></span>
     <a class="shares" href="<?php echo $vars['object']->getDisplayURL() ?>#comments"><?php if ($shares = $vars['object']->countAnnotations('share')) {
             echo '<i class="fa fa-retweet"></i> ' . $shares;
-   } ?></a>
+} ?></a>
     <a class="rsvps" href="<?php echo $vars['object']->getDisplayURL() ?>#comments"><?php if ($rsvps = $vars['object']->countAnnotations('rsvp')) {
             echo '<i class="fa fa-calendar-o"></i> ' . $rsvps;
-   } ?></a>
+} ?></a>
 </div>
 <br class="clearall"/>
 <?php

--- a/Themes/Fauvists/templates/default/content/end.tpl.php
+++ b/Themes/Fauvists/templates/default/content/end.tpl.php
@@ -80,11 +80,11 @@ if (!empty($owner)) {
             <a class="shares"
                href="<?php echo $vars['object']->getDisplayURL() ?>#comments"><?php if ($shares = $vars['object']->countAnnotations('share')) {
                     echo '<i class="fa fa-retweet"></i> ' . $shares;
-              } ?></a>
+} ?></a>
             <a class="rsvps"
                href="<?php echo $vars['object']->getDisplayURL() ?>#comments"><?php if ($rsvps = $vars['object']->countAnnotations('rsvp')) {
                     echo '<i class="fa fa-calendar-o"></i> ' . $rsvps;
-              } ?></a>
+} ?></a>
         </div>
         <br class="clearall"/>
         <?php

--- a/Themes/MarketStreet/templates/default/content/end.tpl.php
+++ b/Themes/MarketStreet/templates/default/content/end.tpl.php
@@ -76,10 +76,10 @@ if ($like_annotations = $vars['object']->getAnnotations('like')) {
             ?></a></span>
     <a class="shares" href="<?php echo $vars['object']->getDisplayURL() ?>#comments"><?php if ($shares = $vars['object']->countAnnotations('share')) {
             echo '<i class="fa fa-retweet"></i> ' . $shares;
-   } ?></a>
+} ?></a>
     <a class="rsvps" href="<?php echo $vars['object']->getDisplayURL() ?>#comments"><?php if ($rsvps = $vars['object']->countAnnotations('rsvp')) {
             echo '<i class="fa fa-calendar-o"></i> ' . $rsvps;
-   } ?></a>
+} ?></a>
 </div>
 <br class="clearall"/>
 <?php

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
         "ramsey/uuid": "^4.1",
         "npm-asset/eonasdan-bootstrap-datetimepicker": "^6.2",
         "composer/installers": "^2",
-        "vlucas/phpdotenv": "^5.3"
+        "vlucas/phpdotenv": "^5.3",
+        "landrok/activitypub": "^0.7.1"
     },
     "license": "Apache-2.0",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,8 @@
         "mapkyca/known-language-tools": "^1.0",
         "mapkyca/mapkyca-known-docker": "^1.0",
         "codeception/aspect-mock": "*",
-        "squizlabs/php_codesniffer": "3.*"
+        "squizlabs/php_codesniffer": "3.*",
+        "mapkyca/known-phpcs": "^1.0"
     },
     "extra": {
         "unused": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d03cbfe1f42adaaa45e56ef9dbdbf18",
+    "content-hash": "aba9ad04f675f532ad7a69ddece5ded9",
     "packages": [
         {
             "name": "brick/math",
@@ -257,16 +257,16 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931"
+                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
-                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
                 "shasum": ""
             },
             "require": {
@@ -298,22 +298,22 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.2"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.3"
             },
-            "time": "2023-09-27T20:04:15+00:00"
+            "time": "2024-01-30T19:34:25+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124"
+                "reference": "861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6",
+                "reference": "861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6",
                 "shasum": ""
             },
             "require": {
@@ -321,11 +321,11 @@
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^10",
+                "doctrine/coding-standard": "^9 || ^12",
                 "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
                 "psalm/plugin-phpunit": "^0.18.3",
-                "vimeo/psalm": "^4.11 || ^5.0"
+                "vimeo/psalm": "^4.11 || ^5.21"
             },
             "type": "library",
             "autoload": {
@@ -362,7 +362,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/2.1.0"
+                "source": "https://github.com/doctrine/lexer/tree/2.1.1"
             },
             "funding": [
                 {
@@ -378,7 +378,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-14T08:49:07+00:00"
+            "time": "2024-02-05T11:35:39+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -1539,16 +1539,16 @@
         },
         {
             "name": "npm-asset/eonasdan-bootstrap-datetimepicker",
-            "version": "v6.7.16",
+            "version": "v6.2.10",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Eonasdan/tempus-dominus.git",
-                "reference": "61829005a713aca670d294922398ccb777657990"
+                "url": "git@github.com:eonasdan/bootstrap-datetimepicker.git",
+                "reference": "1a3ff829e43926002431ef0c0219f276356c4a88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Eonasdan/tempus-dominus/zipball/61829005a713aca670d294922398ccb777657990",
-                "reference": "61829005a713aca670d294922398ccb777657990"
+                "url": "https://api.github.com/repos/eonasdan/bootstrap-datetimepicker/zipball/1a3ff829e43926002431ef0c0219f276356c4a88",
+                "reference": "1a3ff829e43926002431ef0c0219f276356c4a88"
             },
             "type": "npm-asset",
             "license": [
@@ -2779,16 +2779,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v6.4.2",
+            "version": "v6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "14a75869bbb41cb35bc5d9d322473928c6f3f978"
+                "reference": "49f8cdee544a621a621cd21b6cda32a38926d310"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/14a75869bbb41cb35bc5d9d322473928c6f3f978",
-                "reference": "14a75869bbb41cb35bc5d9d322473928c6f3f978",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/49f8cdee544a621a621cd21b6cda32a38926d310",
+                "reference": "49f8cdee544a621a621cd21b6cda32a38926d310",
                 "shasum": ""
             },
             "require": {
@@ -2855,7 +2855,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v6.4.2"
+                "source": "https://github.com/symfony/cache/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -2871,7 +2871,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-29T15:34:34+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -2951,16 +2951,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.2",
+            "version": "v6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "0254811a143e6bc6c8deea08b589a7e68a37f625"
+                "reference": "2aaf83b4de5b9d43b93e4aec6f2f8b676f7c567e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/0254811a143e6bc6c8deea08b589a7e68a37f625",
-                "reference": "0254811a143e6bc6c8deea08b589a7e68a37f625",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2aaf83b4de5b9d43b93e4aec6f2f8b676f7c567e",
+                "reference": "2aaf83b4de5b9d43b93e4aec6f2f8b676f7c567e",
                 "shasum": ""
             },
             "require": {
@@ -3025,7 +3025,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.2"
+                "source": "https://github.com/symfony/console/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -3041,7 +3041,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-10T16:15:48+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3112,16 +3112,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.4.2",
+            "version": "v6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "e95216850555cd55e71b857eb9d6c2674124603a"
+                "reference": "ae9d3a6f3003a6caf56acd7466d8d52378d44fef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e95216850555cd55e71b857eb9d6c2674124603a",
-                "reference": "e95216850555cd55e71b857eb9d6c2674124603a",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ae9d3a6f3003a6caf56acd7466d8d52378d44fef",
+                "reference": "ae9d3a6f3003a6caf56acd7466d8d52378d44fef",
                 "shasum": ""
             },
             "require": {
@@ -3172,7 +3172,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.2"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -3188,7 +3188,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-27T22:16:42+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -3268,16 +3268,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.4.2",
+            "version": "v6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "172d807f9ef3fc3fbed8377cc57c20d389269271"
+                "reference": "5677bdf7cade4619cb17fc9e1e7b31ec392244a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/172d807f9ef3fc3fbed8377cc57c20d389269271",
-                "reference": "172d807f9ef3fc3fbed8377cc57c20d389269271",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/5677bdf7cade4619cb17fc9e1e7b31ec392244a9",
+                "reference": "5677bdf7cade4619cb17fc9e1e7b31ec392244a9",
                 "shasum": ""
             },
             "require": {
@@ -3325,7 +3325,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.4.2"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -3341,20 +3341,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-27T22:16:42+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
-                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
                 "shasum": ""
             },
             "require": {
@@ -3368,9 +3368,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3407,7 +3404,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3423,20 +3420,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "6de50471469b8c9afc38164452ab2b6170ee71c1"
+                "reference": "cd4226d140ecd3d0f13d32ed0a4a095ffe871d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/6de50471469b8c9afc38164452ab2b6170ee71c1",
-                "reference": "6de50471469b8c9afc38164452ab2b6170ee71c1",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/cd4226d140ecd3d0f13d32ed0a4a095ffe871d2f",
+                "reference": "cd4226d140ecd3d0f13d32ed0a4a095ffe871d2f",
                 "shasum": ""
             },
             "require": {
@@ -3450,9 +3447,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3490,7 +3484,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3506,20 +3500,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "875e90aeea2777b6f135677f618529449334a612"
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
-                "reference": "875e90aeea2777b6f135677f618529449334a612",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/32a9da87d7b3245e09ac426c83d334ae9f06f80f",
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f",
                 "shasum": ""
             },
             "require": {
@@ -3530,9 +3524,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3571,7 +3562,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3587,20 +3578,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d"
+                "reference": "a287ed7475f85bf6f61890146edbc932c0fff919"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/ecaafce9f77234a6a449d29e49267ba10499116d",
-                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/a287ed7475f85bf6f61890146edbc932c0fff919",
+                "reference": "a287ed7475f85bf6f61890146edbc932c0fff919",
                 "shasum": ""
             },
             "require": {
@@ -3613,9 +3604,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3658,7 +3646,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3674,20 +3662,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:30:37+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/bc45c394692b948b4d383a08d7753968bed9a83d",
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d",
                 "shasum": ""
             },
             "require": {
@@ -3698,9 +3686,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3742,7 +3727,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3758,20 +3743,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "42292d99c55abe617799667f454222c54c60e229"
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
-                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
                 "shasum": ""
             },
             "require": {
@@ -3785,9 +3770,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3825,7 +3807,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3841,20 +3823,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-28T09:04:16+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179"
+                "reference": "861391a8da9a04cbad2d232ddd9e4893220d6e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/70f4aebd92afca2f865444d30a4d2151c13c3179",
-                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/861391a8da9a04cbad2d232ddd9e4893220d6e25",
+                "reference": "861391a8da9a04cbad2d232ddd9e4893220d6e25",
                 "shasum": ""
             },
             "require": {
@@ -3862,9 +3844,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3901,7 +3880,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3917,20 +3896,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
                 "shasum": ""
             },
             "require": {
@@ -3938,9 +3917,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3984,7 +3960,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -4000,20 +3976,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11"
+                "reference": "86fcae159633351e5fd145d1c47de6c528f8caff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
-                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/86fcae159633351e5fd145d1c47de6c528f8caff",
+                "reference": "86fcae159633351e5fd145d1c47de6c528f8caff",
                 "shasum": ""
             },
             "require": {
@@ -4022,9 +3998,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -4064,7 +4037,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -4080,7 +4053,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-16T06:22:46+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4166,20 +4139,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.2",
+            "version": "v7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "7cb80bc10bfcdf6b5492741c0b9357dac66940bc"
+                "reference": "524aac4a280b90a4420d8d6a040718d0586505ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/7cb80bc10bfcdf6b5492741c0b9357dac66940bc",
-                "reference": "7cb80bc10bfcdf6b5492741c0b9357dac66940bc",
+                "url": "https://api.github.com/repos/symfony/string/zipball/524aac4a280b90a4420d8d6a040718d0586505ac",
+                "reference": "524aac4a280b90a4420d8d6a040718d0586505ac",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -4189,11 +4162,11 @@
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0|^7.0",
-                "symfony/http-client": "^5.4|^6.0|^7.0",
-                "symfony/intl": "^6.2|^7.0",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0|^7.0"
+                "symfony/var-exporter": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -4232,7 +4205,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.2"
+                "source": "https://github.com/symfony/string/tree/v7.0.3"
             },
             "funding": [
                 {
@@ -4248,28 +4221,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-10T16:15:48+00:00"
+            "time": "2024-01-29T15:41:16+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v6.4.2",
+            "version": "v7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "5fe9a0021b8d35e67d914716ec8de50716a68e7e"
+                "reference": "1fb79308cb5fc2b44bff6e8af10a5af6812e05b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/5fe9a0021b8d35e67d914716ec8de50716a68e7e",
-                "reference": "5fe9a0021b8d35e67d914716ec8de50716a68e7e",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/1fb79308cb5fc2b44bff6e8af10a5af6812e05b8",
+                "reference": "1fb79308cb5fc2b44bff6e8af10a5af6812e05b8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "symfony/var-dumper": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -4307,7 +4279,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.4.2"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.0.3"
             },
             "funding": [
                 {
@@ -4323,20 +4295,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-27T08:18:35+00:00"
+            "time": "2024-01-23T15:02:46+00:00"
         },
         {
             "name": "tinymce/tinymce",
-            "version": "6.8.2",
+            "version": "6.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tinymce/tinymce-dist.git",
-                "reference": "b0073db409746748af4fc06fbee337bb99f462d9"
+                "reference": "01d1959b1200e0b872ea078e59ea5abfb5c54100"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tinymce/tinymce-dist/zipball/b0073db409746748af4fc06fbee337bb99f462d9",
-                "reference": "b0073db409746748af4fc06fbee337bb99f462d9",
+                "url": "https://api.github.com/repos/tinymce/tinymce-dist/zipball/01d1959b1200e0b872ea078e59ea5abfb5c54100",
+                "reference": "01d1959b1200e0b872ea078e59ea5abfb5c54100",
                 "shasum": ""
             },
             "type": "component",
@@ -4380,9 +4352,9 @@
                 "wysiwyg"
             ],
             "support": {
-                "source": "https://github.com/tinymce/tinymce-dist/tree/6.8.2"
+                "source": "https://github.com/tinymce/tinymce-dist/tree/6.8.3"
             },
-            "time": "2023-12-11T03:21:56+00:00"
+            "time": "2024-02-08T23:33:30+00:00"
         },
         {
             "name": "twbs/bootstrap",
@@ -4643,6 +4615,7 @@
                 "issues": "https://github.com/Codeception/AspectMock/issues",
                 "source": "https://github.com/Codeception/AspectMock/tree/master"
             },
+            "abandoned": true,
             "time": "2020-02-29T15:39:49+00:00"
         },
         {
@@ -5120,6 +5093,55 @@
             "time": "2020-01-11T09:54:37+00:00"
         },
         {
+            "name": "mapkyca/known-phpcs",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mapkyca/known-phpcs.git",
+                "reference": "227009f853de625875ec9d1eb506b30638b3f824"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mapkyca/known-phpcs/zipball/227009f853de625875ec9d1eb506b30638b3f824",
+                "reference": "227009f853de625875ec9d1eb506b30638b3f824",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Povey",
+                    "email": "marcus@marcus-povey.co.uk",
+                    "homepage": "https://www.marcus-povey.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ben Werdmuller",
+                    "email": "ben@benwerd.com",
+                    "homepage": "https://werd.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHPCS Coding standards for Known",
+            "homepage": "https://withknown.com",
+            "keywords": [
+                "i18n",
+                "known"
+            ],
+            "support": {
+                "issues": "https://github.com/mapkyca/known-phpcs/issues",
+                "source": "https://github.com/mapkyca/known-phpcs/tree/master"
+            },
+            "time": "2019-03-15T22:46:10+00:00"
+        },
+        {
             "name": "mapkyca/mapkyca-known-docker",
             "version": "1.1.2",
             "source": {
@@ -5212,16 +5234,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.17.1",
+            "version": "v4.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
                 "shasum": ""
             },
             "require": {
@@ -5262,9 +5284,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
             },
-            "time": "2023-08-13T19:53:39+00:00"
+            "time": "2023-12-10T21:03:43+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -5379,23 +5401,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.29",
+            "version": "9.2.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -5445,7 +5467,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
             },
             "funding": [
                 {
@@ -5453,7 +5475,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-19T04:57:46+00:00"
+            "time": "2023-12-22T06:47:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -5698,16 +5720,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.13",
+            "version": "9.6.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3767b2c56ce02d01e3491046f33466a1ae60a37f",
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f",
                 "shasum": ""
             },
             "require": {
@@ -5781,7 +5803,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.16"
             },
             "funding": [
                 {
@@ -5797,7 +5819,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-19T05:39:22+00:00"
+            "time": "2024-01-19T07:03:14+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -6042,20 +6064,20 @@
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -6087,7 +6109,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
             },
             "funding": [
                 {
@@ -6095,7 +6117,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -6369,20 +6391,20 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -6414,7 +6436,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
             },
             "funding": [
                 {
@@ -6422,7 +6444,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -6765,16 +6787,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.0",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
                 "shasum": ""
             },
             "require": {
@@ -6784,11 +6806,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -6841,7 +6863,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T12:32:31+00:00"
+            "time": "2024-01-11T20:47:48+00:00"
         },
         {
             "name": "symfony/finder",
@@ -6907,16 +6929,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
@@ -6945,7 +6967,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -6953,7 +6975,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2023-11-20T00:12:19+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb401931d4ac7936b37873c1018ef169",
+    "content-hash": "1d03cbfe1f42adaaa45e56ef9dbdbf18",
     "packages": [
         {
             "name": "brick/math",
@@ -613,6 +613,331 @@
             "time": "2023-11-12T22:16:48+00:00"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/41042bc7ab002487b876a0683fc8dce04ddce104",
+                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.1",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.5.1",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-03T20:35:24+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "bbff78d96034045e58e13dedd6ad91b5d1253223"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/bbff78d96034045e58e13dedd6ad91b5d1253223",
+                "reference": "bbff78d96034045e58e13dedd6ad91b5d1253223",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-03T20:19:20+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/45b30f99ac27b5ca93cb4831afe16285f57b8221",
+                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "^0.9",
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.6.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-03T20:05:35+00:00"
+        },
+        {
             "name": "idno/mentionjs",
             "version": "1.0.0",
             "source": {
@@ -760,6 +1085,55 @@
                 "source": "https://github.com/indieweb/mention-client-php/tree/1.2.1"
             },
             "time": "2021-02-02T13:13:07+00:00"
+        },
+        {
+            "name": "landrok/activitypub",
+            "version": "0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/landrok/activitypub.git",
+                "reference": "25eeae879378e2f276233b2f53d2f0a797b5ea37"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/landrok/activitypub/zipball/25eeae879378e2f276233b2f53d2f0a797b5ea37",
+                "reference": "25eeae879378e2f276233b2f53d2f0a797b5ea37",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": ">=6.3",
+                "monolog/monolog": "^1.12|^2.0|^3.0",
+                "php": "^7.4|^8.0",
+                "phpseclib/phpseclib": "^3.0.7",
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/cache": ">=4.0",
+                "symfony/http-foundation": ">=3.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ActivityPhp\\": "src/ActivityPhp/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP implementation of ActivityPub protocol based upon the ActivityStreams 2.0 data format.",
+            "homepage": "https://github.com/landrok/activitypub",
+            "keywords": [
+                "Federation",
+                "activitypub",
+                "activitystreams"
+            ],
+            "support": {
+                "issues": "https://github.com/landrok/activitypub/issues",
+                "source": "https://github.com/landrok/activitypub/tree/0.7.1"
+            },
+            "time": "2023-12-18T19:33:06+00:00"
         },
         {
             "name": "mapkyca/known-mongo-php-library",
@@ -1024,6 +1398,107 @@
             "time": "2022-02-10T01:05:27+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "c915e2634718dbc8a4a15c61b0e62e7a44e14448"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c915e2634718dbc8a4a15c61b0e62e7a44e14448",
+                "reference": "c915e2634718dbc8a4a15c61b0e62e7a44e14448",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "predis/predis": "^1.1 || ^2",
+                "ruflin/elastica": "^7",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-10-27T15:32:31+00:00"
+        },
+        {
             "name": "npm-asset/bootstrap-accessibility-plugin",
             "version": "v1.0.7",
             "source": {
@@ -1212,6 +1687,123 @@
             "type": "npm-asset"
         },
         {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v2.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "58c3f47f650c94ec05a151692652a868995d2938"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/58c3f47f650c94ec05a151692652a868995d2938",
+                "reference": "58c3f47f650c94ec05a151692652a868995d2938",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7|^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6|^7|^8|^9",
+                "vimeo/psalm": "^1|^2|^3|^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2022-06-14T06:56:20+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
             "name": "phpoption/phpoption",
             "version": "1.9.2",
             "source": {
@@ -1285,6 +1877,116 @@
                 }
             ],
             "time": "2023-11-12T21:59:55+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "3.0.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "4b1827beabce71953ca479485c0ae9c51287f2fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/4b1827beabce71953ca479485c0ae9c51287f2fe",
+                "reference": "4b1827beabce71953ca479485c0ae9c51287f2fe",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1|^2",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "ext-dom": "Install the DOM extension to load XML formatted public keys.",
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib3\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.35"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-29T01:59:53+00:00"
         },
         {
             "name": "psr/cache",
@@ -1439,6 +2141,166 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:10:41+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "3.0.0",
             "source": {
@@ -1487,6 +2349,50 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
             "time": "2021-07-14T16:46:02+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "ramsey/collection",
@@ -6073,5 +6979,5 @@
         "ext-gettext": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/templates/activitypub/shell.tpl.php
+++ b/templates/activitypub/shell.tpl.php
@@ -31,6 +31,7 @@
             'name' => $vars['user']->getAuthorName(),
             'summary' => $vars['user']->getDescription(),
             'icon' => $vars['user']->getIconObject(),
+            'inbox' => $vars['user']->getActorID() . '/inbox',//non-functional placeholder
             'publicKey' => $vars['user']->getPublicKey(),
             // 'endpoints' => $vars['user']->getEndpoints(),
         ]);

--- a/templates/activitypub/shell.tpl.php
+++ b/templates/activitypub/shell.tpl.php
@@ -1,0 +1,46 @@
+<?php
+
+    use ActivityPhp\Type;
+
+    header('Content-type: application/ld+json; profile="https://www.w3.org/ns/activitystreams"');
+
+    unset($vars['body']);
+
+    if (!empty($vars['exception'])) {
+        $e = [
+            'class' => get_class($vars['exception']),
+            'message' => $vars['exception']->getMessage(),
+            'file' => $vars['exception']->getFile(),
+            'line' => $vars['exception']->getLine()
+        ];
+        $vars['exception'] = $e;
+    }
+
+    /* @var \Idno\Common\Entity $object */
+
+    if ( 'person' === $vars['user']?->getActivityStreamsObjectType()) {
+
+        $person       = Type::create('Person', [
+            '@context' => [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/v1',
+                // 'https://purl.archive.org/socialweb/webfinger', //FEP-4adb isn't yet supported by landrok/activitypub
+            ],
+            'id' => $vars['user']->getActorID(),
+            'url' => ($vars['user']->getAuthorURL()),
+            'preferredUsername' => $vars['user']->getHandle(),
+            'name' => $vars['user']->getAuthorName(),
+            'summary' => $vars['user']->getDescription(),
+            'icon' => $vars['user']->getIconObject(),
+            'publicKey' => $vars['user']->getPublicKey(),
+            'endpoints' => $vars['user']->getEndpoints(),
+            // 'webfinger' => $vars['user']->getWebfinger(), //FEP-4adb isn't yet supported by landrok/activitypub
+        ]);
+        echo $person->toJson(JSON_PRETTY_PRINT);
+    } else {
+
+        if ( 'note' === $vars['object']?->getActivityStreamsObjectType()) {
+        }
+        if ( 'article' === $vars['object']?->getActivityStreamsObjectType()) {
+        }
+    }

--- a/templates/activitypub/shell.tpl.php
+++ b/templates/activitypub/shell.tpl.php
@@ -18,7 +18,7 @@
 
     /* @var \Idno\Common\Entity $object */
 
-    if ( 'person' === $vars['user']?->getActivityStreamsObjectType()) {
+    if ( isset($vars['user']) && 'person' === $vars['user']?->getActivityStreamsObjectType()) {
 
         $person = Type::create('Person', [
             '@context' => [

--- a/templates/activitypub/shell.tpl.php
+++ b/templates/activitypub/shell.tpl.php
@@ -56,6 +56,9 @@
             if ($vars['object']->getFormattedAttachments()) {
                 $note->attachment = $vars['object']->getFormattedAttachments();
             }
+            if ( 'image' === $vars['object']?->getActivityStreamsObjectType()) {
+                $note->content = $vars['object']->getTitle();
+            }
             echo $note->toJson(JSON_UNESCAPED_SLASHES);            
         }
     }

--- a/templates/activitypub/shell.tpl.php
+++ b/templates/activitypub/shell.tpl.php
@@ -37,5 +37,23 @@
         echo $person->toJson(JSON_PRETTY_PRINT);
     } else {
         if ( isset($vars['object']) && $vars['object']?->isPublic()) {
+            if ( 'note' === $vars['object']?->getActivityStreamsObjectType()) {
+                $note = Type::create('Note', [
+                    '@context' => [
+                        'https://www.w3.org/ns/activitystreams',
+                    ],
+                    'id' => $vars['object']->getUUID(),
+                    'url' => ($vars['object']->getURL()),
+                    'attributedTo' => $vars['object']->getActorID(),
+                    'to' => $vars['object']->getAddressedTo(),
+                    'published' => $vars['object']->getPublishedTime(),
+                    'content' => \Idno\Core\Idno::site()->template()->autop($vars['object']->getDescription()),
+                    'tag' => $vars['object']->getHashTagObjects(),
+                ]);
+                if ($vars['object']->getUpdatedTime()) {
+                    $note->updated = $vars['object']->getUpdatedTime();
+                }
+                echo $note->toJson(JSON_PRETTY_PRINT);
+            }
         }
     }

--- a/templates/activitypub/shell.tpl.php
+++ b/templates/activitypub/shell.tpl.php
@@ -37,23 +37,24 @@
         echo $person->toJson(JSON_PRETTY_PRINT);
     } else {
         if ( isset($vars['object']) && $vars['object']?->isPublic()) {
-            if ( 'note' === $vars['object']?->getActivityStreamsObjectType()) {
-                $note = Type::create('Note', [
-                    '@context' => [
-                        'https://www.w3.org/ns/activitystreams',
-                    ],
-                    'id' => $vars['object']->getUUID(),
-                    'url' => ($vars['object']->getURL()),
-                    'attributedTo' => $vars['object']->getActorID(),
-                    'to' => $vars['object']->getAddressedTo(),
-                    'published' => $vars['object']->getPublishedTime(),
-                    'content' => \Idno\Core\Idno::site()->template()->autop($vars['object']->getDescription()),
-                    'tag' => $vars['object']->getHashTagObjects(),
-                ]);
-                if ($vars['object']->getUpdatedTime()) {
-                    $note->updated = $vars['object']->getUpdatedTime();
-                }
-                echo $note->toJson(JSON_PRETTY_PRINT);
+            $note = Type::create('Note', [
+                '@context' => [
+                    'https://www.w3.org/ns/activitystreams',
+                ],
+                'id' => $vars['object']->getUUID(),
+                'url' => ($vars['object']->getURL()),
+                'attributedTo' => $vars['object']->getActorID(),
+                'to' => $vars['object']->getAddressedTo(),
+                'published' => $vars['object']->getPublishedTime(),
+                'content' => $vars['object']->getFormattedContent(),
+                'tag' => $vars['object']->getHashTagObjects(),
+            ]);
+            if ($vars['object']->getUpdatedTime()) {
+                $note->updated = $vars['object']->getUpdatedTime();
             }
+            if ($vars['object']->getFormattedAttachments()) {
+                $note->attachment = $vars['object']->getFormattedAttachments();
+            }
+            echo $note->toJson(JSON_UNESCAPED_SLASHES);            
         }
     }

--- a/templates/activitypub/shell.tpl.php
+++ b/templates/activitypub/shell.tpl.php
@@ -36,9 +36,6 @@
         ]);
         echo $person->toJson(JSON_PRETTY_PRINT);
     } else {
-
-        if ( 'note' === $vars['object']?->getActivityStreamsObjectType()) {
-        }
-        if ( 'article' === $vars['object']?->getActivityStreamsObjectType()) {
+        if ( isset($vars['object']) && $vars['object']?->isPublic()) {
         }
     }

--- a/templates/activitypub/shell.tpl.php
+++ b/templates/activitypub/shell.tpl.php
@@ -6,59 +6,59 @@
 
     unset($vars['body']);
 
-    if (!empty($vars['exception'])) {
-        $e = [
-            'class' => get_class($vars['exception']),
-            'message' => $vars['exception']->getMessage(),
-            'file' => $vars['exception']->getFile(),
-            'line' => $vars['exception']->getLine()
-        ];
-        $vars['exception'] = $e;
-    }
+if (!empty($vars['exception'])) {
+    $e = [
+        'class' => get_class($vars['exception']),
+        'message' => $vars['exception']->getMessage(),
+        'file' => $vars['exception']->getFile(),
+        'line' => $vars['exception']->getLine()
+    ];
+    $vars['exception'] = $e;
+}
 
     /* @var \Idno\Common\Entity $object */
 
-    if ( isset($vars['user']) && 'person' === $vars['user']?->getActivityStreamsObjectType()) {
+if ( isset($vars['user']) && 'person' === $vars['user']?->getActivityStreamsObjectType()) {
 
-        $person = Type::create('Person', [
+    $person = Type::create('Person', [
+        '@context' => [
+            'https://www.w3.org/ns/activitystreams',
+            'https://w3id.org/security/v1',
+        ],
+        'id' => $vars['user']->getActivityPubActorID(),
+        'url' => ($vars['user']->getAuthorURL()),
+        'preferredUsername' => $vars['user']->getHandle(),
+        'name' => $vars['user']->getAuthorName(),
+        'summary' => $vars['user']->getDescription(),
+        'icon' => $vars['user']->getIconObject(),
+        'inbox' => $vars['user']->getActivityPubActorID() . '/inbox',//non-functional placeholder
+        'publicKey' => $vars['user']->getPublicKey(),
+        // 'endpoints' => $vars['user']->getEndpoints(),
+    ]);
+    echo $person->toJson(JSON_PRETTY_PRINT);
+} else {
+    if ( isset($vars['object']) && $vars['object']?->isPublic()) {
+        $note = Type::create('Note', [
             '@context' => [
                 'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/v1',
             ],
-            'id' => $vars['user']->getActivityPubActorID(),
-            'url' => ($vars['user']->getAuthorURL()),
-            'preferredUsername' => $vars['user']->getHandle(),
-            'name' => $vars['user']->getAuthorName(),
-            'summary' => $vars['user']->getDescription(),
-            'icon' => $vars['user']->getIconObject(),
-            'inbox' => $vars['user']->getActivityPubActorID() . '/inbox',//non-functional placeholder
-            'publicKey' => $vars['user']->getPublicKey(),
-            // 'endpoints' => $vars['user']->getEndpoints(),
+            'id' => $vars['object']->getUUID(),
+            'url' => ($vars['object']->getURL()),
+            'attributedTo' => $vars['object']->getActivityPubActorID(),
+            'to' => $vars['object']->getAddressedTo(),
+            'published' => $vars['object']->getPublishedTime(),
+            'content' => $vars['object']->getFormattedContent(),
+            'tag' => $vars['object']->getHashTagObjects(),
         ]);
-        echo $person->toJson(JSON_PRETTY_PRINT);
-    } else {
-        if ( isset($vars['object']) && $vars['object']?->isPublic()) {
-            $note = Type::create('Note', [
-                '@context' => [
-                    'https://www.w3.org/ns/activitystreams',
-                ],
-                'id' => $vars['object']->getUUID(),
-                'url' => ($vars['object']->getURL()),
-                'attributedTo' => $vars['object']->getActivityPubActorID(),
-                'to' => $vars['object']->getAddressedTo(),
-                'published' => $vars['object']->getPublishedTime(),
-                'content' => $vars['object']->getFormattedContent(),
-                'tag' => $vars['object']->getHashTagObjects(),
-            ]);
-            if ($vars['object']->getUpdatedTime()) {
-                $note->updated = $vars['object']->getUpdatedTime();
-            }
-            if ($vars['object']->getFormattedAttachments()) {
-                $note->attachment = $vars['object']->getFormattedAttachments();
-            }
-            if ( 'image' === $vars['object']?->getActivityStreamsObjectType()) {
-                $note->content = $vars['object']->getTitle();
-            }
-            echo $note->toJson(JSON_UNESCAPED_SLASHES);            
+        if ($vars['object']->getUpdatedTime()) {
+            $note->updated = $vars['object']->getUpdatedTime();
         }
+        if ($vars['object']->getFormattedAttachments()) {
+            $note->attachment = $vars['object']->getFormattedAttachments();
+        }
+        if ( 'image' === $vars['object']?->getActivityStreamsObjectType()) {
+            $note->content = $vars['object']->getTitle();
+        }
+        echo $note->toJson(JSON_UNESCAPED_SLASHES);
     }
+}

--- a/templates/activitypub/shell.tpl.php
+++ b/templates/activitypub/shell.tpl.php
@@ -2,7 +2,7 @@
 
     use ActivityPhp\Type;
 
-    header('Content-type: application/ld+json; profile="https://www.w3.org/ns/activitystreams"');
+    header('Content-Type: application/ld+json; profile="https://www.w3.org/ns/activitystreams"');
 
     unset($vars['body']);
 
@@ -25,13 +25,13 @@
                 'https://www.w3.org/ns/activitystreams',
                 'https://w3id.org/security/v1',
             ],
-            'id' => $vars['user']->getActorID(),
+            'id' => $vars['user']->getActivityPubActorID(),
             'url' => ($vars['user']->getAuthorURL()),
             'preferredUsername' => $vars['user']->getHandle(),
             'name' => $vars['user']->getAuthorName(),
             'summary' => $vars['user']->getDescription(),
             'icon' => $vars['user']->getIconObject(),
-            'inbox' => $vars['user']->getActorID() . '/inbox',//non-functional placeholder
+            'inbox' => $vars['user']->getActivityPubActorID() . '/inbox',//non-functional placeholder
             'publicKey' => $vars['user']->getPublicKey(),
             // 'endpoints' => $vars['user']->getEndpoints(),
         ]);
@@ -44,7 +44,7 @@
                 ],
                 'id' => $vars['object']->getUUID(),
                 'url' => ($vars['object']->getURL()),
-                'attributedTo' => $vars['object']->getActorID(),
+                'attributedTo' => $vars['object']->getActivityPubActorID(),
                 'to' => $vars['object']->getAddressedTo(),
                 'published' => $vars['object']->getPublishedTime(),
                 'content' => $vars['object']->getFormattedContent(),

--- a/templates/activitypub/shell.tpl.php
+++ b/templates/activitypub/shell.tpl.php
@@ -20,11 +20,10 @@
 
     if ( 'person' === $vars['user']?->getActivityStreamsObjectType()) {
 
-        $person       = Type::create('Person', [
+        $person = Type::create('Person', [
             '@context' => [
                 'https://www.w3.org/ns/activitystreams',
                 'https://w3id.org/security/v1',
-                // 'https://purl.archive.org/socialweb/webfinger', //FEP-4adb isn't yet supported by landrok/activitypub
             ],
             'id' => $vars['user']->getActorID(),
             'url' => ($vars['user']->getAuthorURL()),
@@ -33,8 +32,7 @@
             'summary' => $vars['user']->getDescription(),
             'icon' => $vars['user']->getIconObject(),
             'publicKey' => $vars['user']->getPublicKey(),
-            'endpoints' => $vars['user']->getEndpoints(),
-            // 'webfinger' => $vars['user']->getWebfinger(), //FEP-4adb isn't yet supported by landrok/activitypub
+            // 'endpoints' => $vars['user']->getEndpoints(),
         ]);
         echo $person->toJson(JSON_PRETTY_PRINT);
     } else {

--- a/templates/default/admin/plugins/plugin.tpl.php
+++ b/templates/default/admin/plugins/plugin.tpl.php
@@ -59,7 +59,7 @@ foreach (['php', 'known', 'idno', 'build', 'extension', 'plugin'] as $field) {
                             [
                             'version' => $requirements['known'],
                             ]
-                                  )->draw('admin/dependencies/idno'); ?> </label>
+                        )->draw('admin/dependencies/idno'); ?> </label>
                         </p>
                         <?php
                     }
@@ -72,7 +72,7 @@ foreach (['php', 'known', 'idno', 'build', 'extension', 'plugin'] as $field) {
                             [
                             'version' => $requirements['build'],
                             ]
-                                  )->draw('admin/dependencies/build'); ?> </label>
+                        )->draw('admin/dependencies/build'); ?> </label>
                         </p>
                         <?php
                     }
@@ -85,7 +85,7 @@ foreach (['php', 'known', 'idno', 'build', 'extension', 'plugin'] as $field) {
                             [
                             'version' => $requirements['php']
                             ]
-                                  )->draw('admin/dependencies/php'); ?> </label>
+                        )->draw('admin/dependencies/php'); ?> </label>
                         </p>
                         <?php
                     }

--- a/templates/default/shell.tpl.php
+++ b/templates/default/shell.tpl.php
@@ -21,6 +21,7 @@
     echo $template->draw('shell/bootstrap');
     echo $template->draw('shell/javascript');
     echo $template->draw('shell/css');
+    echo $template->draw('shell/activitypub');
     echo $template->draw('shell/syndication');
     echo $template->draw('shell/identities');
     echo $template->draw('shell/head');

--- a/templates/default/shell/activitypub.tpl.php
+++ b/templates/default/shell/activitypub.tpl.php
@@ -1,0 +1,11 @@
+<?php
+
+$currentPage = \Idno\Core\Idno::site()->currentPage();
+$pageOwner = $currentPage->getOwner();
+
+if (!empty($vars['user']) && $vars['user'] instanceof Idno\Entities\User) {
+    ?>
+    <link rel="alternate" type="application/activity+json" href="<?php echo $vars['user']->getActorID() ?>" />
+    <?php
+} elseif (!empty($vars['object'])) {
+}

--- a/templates/default/shell/activitypub.tpl.php
+++ b/templates/default/shell/activitypub.tpl.php
@@ -5,7 +5,7 @@ $pageOwner = $currentPage->getOwner();
 $alt_link = '';
 
 if (!empty($vars['user']) && $vars['user'] instanceof Idno\Entities\User) {
-    $alt_link = $vars['user']->getActorID();
+    $alt_link = $vars['user']->getActivityPubActorID();
 } elseif (!empty($vars['object'])) {
     $alt_link = $vars['object']->getUUID();
 }

--- a/templates/default/shell/activitypub.tpl.php
+++ b/templates/default/shell/activitypub.tpl.php
@@ -2,10 +2,16 @@
 
 $currentPage = \Idno\Core\Idno::site()->currentPage();
 $pageOwner = $currentPage->getOwner();
+$alt_link = '';
 
 if (!empty($vars['user']) && $vars['user'] instanceof Idno\Entities\User) {
-    ?>
-    <link rel="alternate" type="application/activity+json" href="<?php echo $vars['user']->getActorID() ?>" />
-    <?php
+    $alt_link = $vars['user']->getActorID();
 } elseif (!empty($vars['object'])) {
+    $alt_link = $vars['object']->getUUID();
+}
+
+if (!empty($alt_link)) {
+    ?>
+    <link rel="alternate" type="application/activity+json" href="<?php echo $alt_link ?>" />
+    <?php
 }

--- a/templates/json/shell.tpl.php
+++ b/templates/json/shell.tpl.php
@@ -7,14 +7,14 @@
 
     unset($vars['body']);
 
-    if (!empty($vars['exception'])) {
-        $e = [
-            'class' => get_class($vars['exception']),
-            'message' => $vars['exception']->getMessage(),
-            'file' => $vars['exception']->getFile(),
-            'line' => $vars['exception']->getLine()
-        ];
-        $vars['exception'] = $e;
-    }
+if (!empty($vars['exception'])) {
+    $e = [
+        'class' => get_class($vars['exception']),
+        'message' => $vars['exception']->getMessage(),
+        'file' => $vars['exception']->getFile(),
+        'line' => $vars['exception']->getLine()
+    ];
+    $vars['exception'] = $e;
+}
 
     echo json_encode($vars, JSON_PRETTY_PRINT);


### PR DESCRIPTION
# ActivityPub Sprint 1 
#3186 
- Setup / Planning
- [x] Add new json_activity templates and endpoints (profiles, posts)
- [x] Add ActivityPub actor URI to webfinger
- [x] Add ActivityPub link-rel discovery to html templates

Additional
- [x] Adjust parseURLs to allow exclusion of `<wbr />` injection
- [x] Fix `getTags` regex to ignore url fragments #3197

## Here's what I fixed or added:
This PR is focused on the Actor/user Profile and default enabled Post types (note, article, image). 
The PR is pointing to idno:dev branch but perhaps a feature branch might be more appropriate. 

- Some methods to the User class
  - getActorID 
  - getIconObject 
  - getPublicKey
  - getPublicKeyPem
  - getPrivateKey
  - generateKeyPair
  - ...
- Some methods to the Entity class
  - ...
- A separate `/actor/` route specifically for ActivityPub profile 
- A new activitypub default/shell template for `<link rel="alternate" type="application/activity+json" ...>`

## Here's why I did it:
### Separate Actor routes 
#### Content-Negotiation
By adding separate actor routes, we seek to avoid Content-Negotiation (accessing the same route with different `Accept` headers) which can cause different servers, caching solutions to cache and serve the [wrong version](https://github.com/Automattic/wordpress-activitypub/issues/580) (html/json).

#### Mastodon's Signature verification issue 
While it would be possible to use existing routes with the `?_t=activitypub` template query, mastodon has a [known issue](https://github.com/superseriousbusiness/gotosocial/issues/894) with verifying HTTP signatures. Though the issue was recently [solved](https://github.com/mastodon/mastodon/pull/28476) in mastodon, it requires a [second request](https://github.com/mastodon/mastodon/pull/28788) for backwards compatibility.

## Checklist: (`[x]` to check/tick the boxes)

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
