### PR TITLE
Remove documented support for Postgres

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ about: Something not working? Let us know to help us improve.
 Give us some context: 
 
 * It'd also be really handy if you could tell us the contents of your ```version.known``` file
-* What database are you using? (e.g. mongo, mysql, postgres)
+* What database are you using? (e.g. mongo, mysql)
 * Any warnings or errors in your admin/diagnostics page?
 * If this is a programming bug, can you include examples of any Micropub / API calls / webhook pings you make? Otherwise please don't worry about what this means!
 * Bonus points - are you able to illustrate the issue with a unit test? If so, submit it as a pull request!

--- a/docs/install/instructions.md
+++ b/docs/install/instructions.md
@@ -56,12 +56,6 @@ If you need to use a non-standard database port, you can also select this:
 
 Additionally, you will need to create the database referred to in this configuration file, and ensure that it can be connected to using the user credentials you supply. For now, you will need to load the SQL schema stored in `/warmup/schemas/mysql/mysql.sql`.
 
-### If you’re using Postgres
-
-Postgres users follow the MySQL instructions above, but set your database engine as follows:
-
-    database = "Postgres"
-
 ### If you're using SQLite
 
 As with MySQL, currently SQLite users need to create a ```config.ini``` in the root of their installation. This should contain the following information:

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -43,7 +43,7 @@ Additionally, Known requires the following PHP components:
 + json
 + libxml
 + mbstring
-+ mysql (or postgresql or sqlite, depending on database backend)
++ mysql (or sqlite, depending on database backend)
 + reflection
 + session
 + xmlrpc


### PR DESCRIPTION
## Here's what I fixed or added:
Remove documented support for Postgres 
- Fixes #3226 
- Modifies scope of #3216
## Here's why I did it:
Postgres support was removed in https://github.com/idno/known/commit/737502f98c51351562844df9203020b2e9300f29

## Checklist: 

- [x] This pull request addresses a single issue
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
