### PR TITLE
Fix stray PHP closing tag in template

### DIFF
--- a/templates/default/entity/User.tpl.php
+++ b/templates/default/entity/User.tpl.php
@@ -23,7 +23,7 @@ if (empty($vars['user']) && !empty($vars['object'])) {
                 <p>
                     <a href="<?php echo $vars['user']->getDisplayURL() ?>" class="u-url icon-container"><img class="u-photo"
                                                                                                src="<?php echo $vars['user']->getIcon() ?>"
-                                                                                               alt="<?php echo htmlspecialchars($vars['user']->getTitle()) ?>" ?>"/></a>
+                                                                                               alt="<?php echo htmlspecialchars($vars['user']->getTitle()) ?>" /></a>
                 </p>
 
                         <?php


### PR DESCRIPTION
## Here's what I fixed or added:

Removed a stray bit of code in the User template 

## Here's why I did it:

Clear typo leaks into visibility on Safari.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
