### PR TITLE
Simplify Idno core and common namespaces

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -108,29 +108,31 @@ namespace Idno\Common {
          */
         function getInput($name, $default = null, callable $filter = null)
         {
-            if (!empty($name)) {
-                $value = null;
-                $request = \Idno\Core\Input::getInput($name, $default, $filter);
-                if ($request !== null) {
-                    $value = $request;
-                } else if (isset($this->data[$name])) {
-                    $value = $this->data[$name];
-                }
-                if (($value===null) && ($default!==null)) {
-                    $value = $default;
-                }
-                if (!$value!==null) {
-                    if (isset($filter) && is_callable($filter) && empty($request)) {
-                        $value = call_user_func($filter, $name, $value);
-                    }
-
-                    // TODO, we may want to add some sort of system wide default filter for when $filter is null
-
-                    return $value;
-                }
+            if (empty($name)) {
+                return null;
             }
 
-            return null;
+            $request = \Idno\Core\Input::getInput($name, $default, $filter);
+
+            // Prefer explicit request values
+            if ($request !== null) {
+                return $request;
+            }
+
+            // Fallback to decoded JSON payload stored in $this->data
+            $value = $this->data[$name] ?? null;
+
+            if ($value === null) {
+                $value = $default;
+            }
+
+            // If a filter is provided and wasn't already applied by Input::getInput, apply it here
+            if ($value !== null && $request === null && isset($filter) && is_callable($filter)) {
+                $value = call_user_func($filter, $name, $value);
+            }
+
+            // TODO: we may want a system-wide default filter when $filter is null
+            return $value;
         }
 
         function exception($e)

--- a/Idno/Core/Config.php
+++ b/Idno/Core/Config.php
@@ -664,11 +664,7 @@ namespace Idno\Core {
          */
         function getTitle()
         {
-            if (!empty($this->title)) {
-                return $this->title;
-            }
-
-            return '';
+            return $this->title ?? '';
         }
 
         /**
@@ -678,11 +674,7 @@ namespace Idno\Core {
          */
         function getDescription()
         {
-            if (!empty($this->description)) {
-                return $this->description;
-            }
-
-            return '';
+            return $this->description ?? '';
         }
 
         /**
@@ -718,11 +710,7 @@ namespace Idno\Core {
          */
         function isPublicSite()
         {
-            if (empty($this->walled_garden)) {
-                return true;
-            }
-
-            return false;
+            return empty($this->walled_garden);
         }
 
         /**
@@ -732,11 +720,7 @@ namespace Idno\Core {
          */
         function multipleSyndicationAccounts()
         {
-            if (isset($this->multi_syndication)) {
-                return $this->multi_syndication;
-            }
-
-            return false;
+            return (bool)$this->multi_syndication;
         }
 
         /**
@@ -774,11 +758,7 @@ namespace Idno\Core {
          */
         function isDefaultConfig()
         {
-            if ($this->default_config) {
-                return true;
-            }
-
-            return false;
+            return (bool)$this->default_config;
         }
 
         /**

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -766,49 +766,36 @@ namespace Idno\Core {
          */
         public function componentFactory($className, $expectedBaseClass = "Idno\\Common\\Component" , $defaultClassNameBase = "Idno\\Core\\", $defaultClass = null)
         {
+            $class = null;
 
-            $component = null;
-
-            // Try full namespace
-            if (!empty($className) && class_exists($className)) {
-                if (is_subclass_of($className, $expectedBaseClass)) {
-                    $class = $className;
+            if (is_string($className) && $className !== '') {
+                $candidates = array($className, $defaultClassNameBase . $className);
+                foreach ($candidates as $candidate) {
+                    if (class_exists($candidate) && is_subclass_of($candidate, $expectedBaseClass)) {
+                        $class = $candidate;
+                        break;
+                    }
                 }
             }
 
-            // Attempt base class creation
-            if (empty($class)) {
-                if (class_exists($defaultClassNameBase . $className)) {
-                    $class = $defaultClassNameBase . $className;
-                }
-            }
-
-            // Now try and create it
             if (!empty($class)) {
-                if (is_subclass_of($class, $expectedBaseClass)) {
-                    $component = new $class();
+                return new $class();
+            }
+
+            if (!empty($defaultClass)) {
+                if (is_string($defaultClass)) {
+                    if (class_exists($defaultClass) && is_subclass_of($defaultClass, $expectedBaseClass)) {
+                        return new $defaultClass();
+                    }
+                    return null;
+                }
+
+                if (is_object($defaultClass) && is_subclass_of($defaultClass, $expectedBaseClass)) {
+                    return $defaultClass;
                 }
             }
 
-            // Do we have a class yet? otherwise try a default
-            if (empty($component)) {
-
-                if (!empty($defaultClass)) {
-
-                    if (is_string($defaultClass)) {
-                        $component = new $defaultClass();
-                    } else {
-                        $component = $defaultClass;
-                    }
-
-                    // validate
-                    if (!is_subclass_of($component, $expectedBaseClass)) {
-                            $component = null;
-                    }
-                }
-            }
-
-            return $component;
+            return null;
         }
 
         /**

--- a/Idno/Core/Service.php
+++ b/Idno/Core/Service.php
@@ -11,6 +11,24 @@ namespace Idno\Core {
 
     class Service extends \Idno\Common\Component
     {
+        /**
+         * Normalize a URL for token generation by removing query string and scheme.
+         */
+        private static function normalizeUrlForToken($url)
+        {
+            if (empty($url)) {
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_('Url not provided to token generation.'));
+            }
+
+            $url = explode('?', $url)[0];
+            $url = preg_replace('#^https?://#i', '', $url);
+
+            if (empty($url)) {
+                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_('Url not provided to token generation.'));
+            }
+
+            return $url;
+        }
 
         /**
          * Check that a page is being accessed by a local service.
@@ -42,23 +60,14 @@ namespace Idno\Core {
          */
         public static function generateToken($url)
         {
-
             $site_secret = \Idno\Core\Idno::site()->config()->site_secret;
             if (empty($site_secret)) {
                 throw new \Idno\Exceptions\ConfigurationException(\Idno\Core\Idno::site()->language()->_('Missing site secret'));
             }
 
-            $url = explode('?', $url)[0];
+            $normalized = self::normalizeUrlForToken($url);
 
-            // Normalise url for token generation
-            $url = str_replace('https://', '', $url);
-            $url = str_replace('http://', '', $url);
-
-            if (empty($url)) {
-                throw new \RuntimeException(\Idno\Core\Idno::site()->language()->_('Url not provided to token generation.'));
-            }
-
-            return hash_hmac('sha256', $url, $site_secret);
+            return hash_hmac('sha256', $normalized, $site_secret);
         }
 
         /**


### PR DESCRIPTION
## Here's what I fixed or added:

*   **`Idno\Common\Page::getInput`**: Refactored input retrieval logic to clarify precedence (request > JSON payload > default) and ensure filters are applied correctly, fixing a minor bug.
*   **`Idno\Core\Idno::componentFactory`**: Simplified the factory method to reduce branching, consolidate class existence and subclass validation, and handle default class instantiation more consistently.
*   **`Idno\Core\Config`**: Streamlined several boolean and string return helpers (`getTitle`, `getDescription`, `isPublicSite`, `multipleSyndicationAccounts`, `isDefaultConfig`) using null coalescing and direct boolean casts.
*   **`Idno\Core\Service`**: Extracted URL normalization logic into a new private helper method `normalizeUrlForToken` and reused it in `generateToken` to deduplicate code.

## Here's why I did it:

The primary goal was to simplify and clarify code within the `Idno\Core` and `Idno\Common` namespaces, as requested. This refactoring addresses areas of complexity, reduces redundant logic, improves readability, and fixes a minor bug in `Page::getInput`, making the codebase more maintainable and easier to understand.

## Checklist: (`[x]` to check/tick the boxes)

- [x] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [x] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-2272d074-a6f2-42bc-86a3-0ca9e2f7fe29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2272d074-a6f2-42bc-86a3-0ca9e2f7fe29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

