### PR TITLE
Fix webmention processing to handle mf2 data types correctly

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -2335,36 +2335,37 @@ namespace Idno\Common {
             }
 
             if ($item) {
-                error_log(json_encode($item));
                 $mention = array();
                 if (!empty($item['properties'])) {
                     if (!empty($item['properties']['content'])) {
                         $mention['content'] = '';
                         if (is_array($item['properties']['content'])) {
                             foreach ($item['properties']['content'] as $content) {
-                                if (!empty($content['value'])) {
+                                if (is_string($content)) {
+                                    $parsed_content = \Idno\Core\Idno::site()->template()->sanitize_html($content);
+                                } else if (is_array($content) && !empty($content['value'])) {
                                     $parsed_content = \Idno\Core\Idno::site()->template()->sanitize_html($content['value']);
-                                    if (!substr_count($mention['content'], $parsed_content)) {
-                                        $mention['content'] .= $parsed_content;
-                                    }
+                                } else {
+                                    continue;
+                                }
+                                if (!empty($parsed_content) && !substr_count($mention['content'], $parsed_content)) {
+                                    $mention['content'] .= $parsed_content;
                                 }
                             }
-                        } else {
-                            $mention['content'] = $item['properties']['content'];
+                        } else if (is_string($item['properties']['content'])) {
+                            $mention['content'] = \Idno\Core\Idno::site()->template()->sanitize_html($item['properties']['content']);
                         }
                     } else if (!empty($item['properties']['summary'])) {
-                        // TODO properties are always arrays, are these checks unnecessary?
-                        if (is_array($item['properties']['summary'])) {
-                            $mention['content'] = \Idno\Core\Idno::site()->template()->sanitize_html(implode(' ', $item['properties']['summary']));
-                        } else {
-                            $mention['content'] = $item['properties']['summary'];
-                        }
+                        // mf2 properties are always arrays; filter to strings before imploding
+                        $summaries = is_array($item['properties']['summary'])
+                            ? array_filter($item['properties']['summary'], 'is_string')
+                            : [];
+                        $mention['content'] = \Idno\Core\Idno::site()->template()->sanitize_html(implode(' ', $summaries));
                     } else if (!empty($item['properties']['name'])) {
-                        if (is_array($item['properties']['name'])) {
-                            $mention['content'] = \Idno\Core\Idno::site()->template()->sanitize_html(implode(' ', $item['properties']['name']));
-                        } else {
-                            $mention['content'] = $item['properties']['name'];
-                        }
+                        $names = is_array($item['properties']['name'])
+                            ? array_filter($item['properties']['name'], 'is_string')
+                            : [];
+                        $mention['content'] = \Idno\Core\Idno::site()->template()->sanitize_html(implode(' ', $names));
                     }
                     if (!empty($item['properties']['published'])) {
                         $mention['created'] = strtotime($item['properties']['published'][0]);
@@ -2373,11 +2374,13 @@ namespace Idno\Common {
                         $mention['created'] = time();
                     }
                     if (!empty($item['properties']['url'])) {
+                        $urls = static::getStringURLs($item['properties']['url'], false);
                         if (!empty($item['properties']['uid'])) {
-                            $mention['url'] = array_intersect($item['properties']['uid'], $item['properties']['url']);
+                            $uids = static::getStringURLs($item['properties']['uid'], false);
+                            $mention['url'] = array_values(array_intersect($uids, $urls));
                         }
                         if (empty($mention['url'])) {
-                            $mention['url'] = $item['properties']['url'];
+                            $mention['url'] = $urls;
                         }
                     }
 
@@ -2407,7 +2410,6 @@ namespace Idno\Common {
                             }
                         }
                     }
-                    error_log(json_encode($mention));
                 }
                 if (empty($mention['content'])) {
                     $mention['content'] = '';
@@ -2426,14 +2428,26 @@ namespace Idno\Common {
         {
             $owner = [];
             if (!empty($hcard['properties']['name'])) {
-                $owner['name'] = $hcard['properties']['name'][0];
+                $name = $hcard['properties']['name'][0];
+                $owner['name'] = is_string($name) ? $name : '';
             }
             if (!empty($hcard['properties']['url'])) {
-                $owner['url'] = $hcard['properties']['url'][0];
+                $url = $hcard['properties']['url'][0];
+                // Handle h-cite-style nested objects
+                if (is_array($url) && !empty($url['properties']['url'][0])) {
+                    $url = $url['properties']['url'][0];
+                }
+                $owner['url'] = is_string($url) ? $url : '';
             }
             if (!empty($hcard['properties']['photo'])) {
-
-                $owner['photo'] =  \Idno\Core\Idno::site()->template()->getProxiedImageUrl($hcard['properties']['photo'][0], 300, 'square');
+                $photo = $hcard['properties']['photo'][0];
+                // mf2 photo values can be objects with 'value' and 'alt' keys
+                if (is_array($photo) && !empty($photo['value'])) {
+                    $photo = $photo['value'];
+                }
+                if (is_string($photo)) {
+                    $owner['photo'] = \Idno\Core\Idno::site()->template()->getProxiedImageUrl($photo, 300, 'square');
+                }
             }
 
             return $owner;

--- a/Tests/Common/EntityTest.php
+++ b/Tests/Common/EntityTest.php
@@ -270,6 +270,92 @@ EOD;
     }
 
     /**
+     * Test that plain string content values (not {value, html} objects) are handled.
+     * Regression test for https://github.com/idno/known/issues/3199
+     */
+    function testAddWebmentions_PlainStringContent()
+    {
+        $entity = $this->webmentionEntityProvider();
+        $this->toDelete[] = $entity;
+        $target = $entity->getURL();
+
+        $source = 'http://example.com/2024/plain-content-reply';
+        $sourceContent = <<<EOD
+<!DOCTYPE html>
+<html>
+<body class="h-entry">
+  <a class="u-in-reply-to" href="$target">in reply to</a>
+  <span class="p-name">This is plain text content</span>
+  <a class="u-url" href="$source">permalink</a>
+  <a class="p-author h-card" href="https://example.com/">Plain Jane</a>
+</body>
+</html>
+EOD;
+        $sourceResp = ['response' => 200, 'content' => $sourceContent];
+        $sourceMf2 = (new \Mf2\Parser($sourceContent, $source))->parse();
+        $entity->addWebmentions($source, $target, $sourceResp, $sourceMf2);
+
+        $this->assertArrayHasKey('reply', $entity->getAllAnnotations(), 'A reply annotation should have been created.');
+        $anno = array_values($entity->getAllAnnotations()['reply'])[0];
+        $this->assertIsString($anno['content'], 'Annotation content should be a string.');
+        $this->assertIsString($anno['permalink'], 'Annotation permalink should be a string.');
+        $this->assertIsString($anno['owner_name'], 'Annotation owner_name should be a string.');
+    }
+
+    /**
+     * Test that mf2 photo values with alt text objects are handled.
+     * Regression test for https://github.com/idno/known/issues/3199
+     */
+    function testAddWebmentions_PhotoWithAltText()
+    {
+        $entity = $this->webmentionEntityProvider();
+        $this->toDelete[] = $entity;
+        $target = $entity->getURL();
+
+        // Construct mf2 data directly with a photo that has alt text (object form)
+        $source = 'http://example.com/2024/photo-alt-mention';
+        $sourceContent = <<<EOD
+<!DOCTYPE html>
+<html>
+<body class="h-entry">
+  <a class="u-in-reply-to" href="$target">in reply to</a>
+  <span class="p-name e-content">A reply with author photo</span>
+  <a class="u-url" href="$source">permalink</a>
+  <div class="p-author h-card">
+    <a class="p-name u-url" href="https://example.com/">Photo Jane</a>
+    <img class="u-photo" src="https://example.com/photo.jpg" alt="Jane's photo" />
+  </div>
+</body>
+</html>
+EOD;
+        $sourceResp = ['response' => 200, 'content' => $sourceContent];
+        $sourceMf2 = (new \Mf2\Parser($sourceContent, $source))->parse();
+
+        // Simulate the case where the mf2 parser returns photo as an object with alt text
+        // by modifying the parsed data to use the {value, alt} form
+        foreach ($sourceMf2['items'] as &$item) {
+            if (isset($item['type']) && in_array('h-entry', $item['type'])) {
+                if (!empty($item['properties']['author'])) {
+                    foreach ($item['properties']['author'] as &$author) {
+                        if (is_array($author) && isset($author['properties']['photo'])) {
+                            $author['properties']['photo'] = [
+                                ['value' => 'https://example.com/photo.jpg', 'alt' => "Jane's photo"]
+                            ];
+                        }
+                    }
+                }
+            }
+        }
+
+        $entity->addWebmentions($source, $target, $sourceResp, $sourceMf2);
+
+        $this->assertArrayHasKey('reply', $entity->getAllAnnotations(), 'A reply annotation should have been created.');
+        $anno = array_values($entity->getAllAnnotations()['reply'])[0];
+        $this->assertEquals('Photo Jane', $anno['owner_name'], 'Owner name should be set.');
+        $this->assertIsString($anno['permalink'], 'Permalink should be a string.');
+    }
+
+    /**
      * A particularly knotty case when we get a webmention from *our
      * own* feed. It looks valid because it includes a link, but it's
      * not really.


### PR DESCRIPTION
Webmentions from external services (e.g. brid.gy backfeeding Mastodon) fail with HTTP 500 because the mf2 property handling code doesn't account for all valid mf2 data formats. In the mf2 spec, property values are always arrays, and elements can be either plain strings or complex objects. The code only handled the object case for content, passed raw arrays for URLs, and didn't handle photo objects with alt text.

Changes in addWebmentionItem():
- Content extraction now handles both plain string and {value, html} object elements
- Summary/name extraction filters to strings before imploding
- URL extraction uses the existing getStringURLs() helper to normalize mixed string/h-cite arrays

Changes in parseHCard():
- Photo values now handle the {value, alt} object form from mf2
- URL and name values have defensive type checks

Also removes leftover error_log debug statements and adds regression tests.

Fixes https://github.com/idno/known/issues/3199

https://claude.ai/code/session_015V7HUKCLuCLgTrUmZnU2Zw


## Here's what I fixed or added:

## Here's why I did it:

## Checklist: (`[x]` to check/tick the boxes)

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [ ] I've adhered to [Known's style guide](http://docs.withknown.com/en/latest/developers/standards/) ([these codesniffer rules](http://docs.withknown.com/en/latest/developers/testing/#code-style-testing) might help!)
- [ ] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [ ] I've tested my code in-browser
- [ ] My code contains descriptive comments
- [ ] I've added tests where applicable, and...
- [ ] I can run the [unit tests](http://docs.withknown.com/en/latest/developers/testing/#unit-testing) successfully.
