### PR TITLE
Fix export memory issues, error handling, and add WXR format support

### DIFF
--- a/Idno/Common/Entity.php
+++ b/Idno/Common/Entity.php
@@ -1968,6 +1968,7 @@ namespace Idno\Common {
         {
 
             $item = $this;
+            $wxr_mode = !empty($vars['wxr_mode']);
 
             $page = new \DOMDocument();
 
@@ -1989,38 +1990,57 @@ namespace Idno\Common {
             $rssItem->appendChild($page->createElement('wp:post_type', 'post'));
             $rssItem->appendChild($page->createElement('wp:status', 'publish'));
 
+            // WXR-specific item elements
+            if ($wxr_mode) {
+                $rssItem->appendChild($page->createElement('wp:post_id', (string)$item->getID()));
+                $rssItem->appendChild($page->createElement('wp:post_date', date('Y-m-d H:i:s', $item->created)));
+                $rssItem->appendChild($page->createElement('wp:post_date_gmt', gmdate('Y-m-d H:i:s', $item->created)));
+
+                $slug = $item->getSlug();
+                if (empty($slug)) {
+                    $slug = preg_replace('/[^a-z0-9]+/', '-', strtolower(trim($title)));
+                    $slug = trim($slug, '-');
+                    if (empty($slug)) {
+                        $slug = (string)$item->getID();
+                    }
+                }
+                $rssItem->appendChild($page->createElement('wp:post_name', htmlspecialchars($slug)));
+            }
+
             $owner = $item->getOwner();
             if (!empty($owner)) {
                 $rssItem->appendChild($page->createElement('dc:creator', "{$owner->title}"));
             } else {
                 $rssItem->appendChild($page->createElement('dc:creator', "Deleted User"));
             }
-            //$rssItem->appendChild($page->createElement('dc:creator', $owner->title));
+
+            // Draw content once and reuse for both description and content:encoded
+            $drawn_content = $item->draw(true);
 
             $description = $page->createElement('description');
             if (empty($vars['nocdata'])) {
-                $description->appendChild($page->createCDATASection($item->draw(true)));
+                $description->appendChild($page->createCDATASection($drawn_content));
             } else {
-                //$description->appendChild($page->create($item->draw(true)));
-                //$description->textContent = $item->draw(true);
                 $tpl = new \DOMDocument;
-                $tpl->loadHtml($item->draw(true), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-                //$body->appendChild($dom->importNode($tpl->documentElement, TRUE));
+                $tpl->loadHtml($drawn_content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
                 $description->appendChild($page->importNode($tpl->documentElement, true));
+                unset($tpl);
             }
             $rssItem->appendChild($description);
+
+            // WXR: add content:encoded (WordPress reads this preferentially over description)
+            if ($wxr_mode) {
+                $contentEncoded = $page->createElement('content:encoded');
+                $contentEncoded->appendChild($page->createCDATASection($drawn_content));
+                $rssItem->appendChild($contentEncoded);
+            }
+
+            unset($drawn_content);
+
             if (!empty($item->lat) && !empty($item->long)) {
                 $rssItem->appendChild($page->createElement('geo:lat', $item->lat));
                 $rssItem->appendChild($page->createElement('geo:long', $item->long));
             }
-            /*
-             * Some feed readers choke on references to webmention, so this is removed for now
-             *
-                $webmentionItem = $page->createElement('atom:link');
-                $webmentionItem->setAttribute('rel', 'webmention');
-                $webmentionItem->setAttribute('href', \Idno\Core\Idno::site()->config()->getDisplayURL() . 'webmention/');
-                $rssItem->appendChild($webmentionItem);
-            */
             if ($attachments = $item->getAttachments()) {
                 foreach($attachments as $attachment) {
                     if (!empty($attachment['url'])) { // Only include attachments with set URLs
@@ -2036,6 +2056,55 @@ namespace Idno\Common {
                 foreach($tags as $tag) {
                     $tagItem = $page->createElement('category', $tag);
                     $rssItem->appendChild($tagItem);
+                }
+            }
+
+            // WXR: export comments from annotations
+            if ($wxr_mode) {
+                $allAnnotations = $item->getAllAnnotations();
+                if (!empty($allAnnotations)) {
+                    $commentId = 1;
+                    foreach ($allAnnotations as $subtype => $annotations) {
+                        if (!in_array($subtype, ['reply', 'comment'])) {
+                            continue;
+                        }
+                        foreach ($annotations as $annotation) {
+                            $wpComment = $page->createElement('wp:comment');
+                            $wpComment->appendChild(
+                                $page->createElement('wp:comment_id', (string)$commentId++)
+                            );
+                            $wpComment->appendChild(
+                                $page->createElement('wp:comment_author',
+                                    htmlspecialchars(!empty($annotation['owner_name']) ? $annotation['owner_name'] : 'Anonymous'))
+                            );
+                            $wpComment->appendChild(
+                                $page->createElement('wp:comment_author_url',
+                                    htmlspecialchars(!empty($annotation['owner_url']) ? $annotation['owner_url'] : ''))
+                            );
+
+                            $commentContent = $page->createElement('wp:comment_content');
+                            $commentContent->appendChild(
+                                $page->createCDATASection(!empty($annotation['content']) ? $annotation['content'] : '')
+                            );
+                            $wpComment->appendChild($commentContent);
+
+                            $commentDate = !empty($annotation['time']) ? $annotation['time'] : time();
+                            $wpComment->appendChild(
+                                $page->createElement('wp:comment_date', date('Y-m-d H:i:s', $commentDate))
+                            );
+                            $wpComment->appendChild(
+                                $page->createElement('wp:comment_date_gmt', gmdate('Y-m-d H:i:s', $commentDate))
+                            );
+                            $wpComment->appendChild(
+                                $page->createElement('wp:comment_approved', '1')
+                            );
+                            $wpComment->appendChild(
+                                $page->createElement('wp:comment_type', 'comment')
+                            );
+
+                            $rssItem->appendChild($wpComment);
+                        }
+                    }
                 }
             }
 

--- a/Idno/Core/Account.php
+++ b/Idno/Core/Account.php
@@ -36,6 +36,7 @@ namespace Idno\Core {
             // Per-user export
             Idno::site()->routes()->addRoute('/account/export/?', '\Idno\Pages\Account\Export');
             Idno::site()->routes()->addRoute('/account/export/rss/?', '\Idno\Pages\Account\Export\RSS');
+            Idno::site()->routes()->addRoute('/account/export/wxr/?', '\Idno\Pages\Account\Export\WXR');
 
             // Override the page shell
             Idno::site()->template()->addUrlShellOverride('account', 'settings-shell');

--- a/Idno/Core/Admin.php
+++ b/Idno/Core/Admin.php
@@ -27,6 +27,7 @@ namespace Idno\Core {
             \Idno\Core\Idno::site()->routes()->addRoute('/admin/export/generate/?', '\Idno\Pages\Admin\Export\Generate');
             //\Idno\Core\Idno::site()->routes()->addRoute('/admin/export/download/?', '\Idno\Pages\Admin\Export\Download');
             \Idno\Core\Idno::site()->routes()->addRoute('/admin/export/rss/?', '\Idno\Pages\Admin\Export\RSS');
+            \Idno\Core\Idno::site()->routes()->addRoute('/admin/export/wxr/?', '\Idno\Pages\Admin\Export\WXR');
             \Idno\Core\Idno::site()->routes()->addRoute('/admin/import/?', '\Idno\Pages\Admin\Import');
             \Idno\Core\Idno::site()->routes()->addRoute('/admin/diagnostics/?', '\Idno\Pages\Admin\Diagnostics');
             \Idno\Core\Idno::site()->routes()->addRoute('/admin/statistics/?', '\Idno\Pages\Admin\Statistics');

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -554,9 +554,10 @@ namespace Idno\Core {
          *
          * @param  bool|true $hide_private Should we hide private posts? Default: true.
          * @param  string    $user_uuid    User UUID to export for. Default: all users.
+         * @param  bool|false $wxr_mode    Generate WXR (WordPress eXtended RSS) format. Default: false.
          * @return resource a file pointer resource on success, false on error
          */
-        static function getExportRSS($hide_private = true, $user_uuid = '')
+        static function getExportRSS($hide_private = true, $user_uuid = '', $wxr_mode = false)
         {
             $types = \Idno\Common\ContentType::getRegisteredClasses();
             if ($hide_private) {
@@ -602,6 +603,8 @@ namespace Idno\Core {
 
             $f = fopen($rss_path . 'items.rss.fragment', 'wb');
 
+            $rssVars = $wxr_mode ? ['wxr_mode' => true] : [];
+
             while ($feed = \Idno\Common\Entity::getFromX($types, $search, array(), $limit, $offset, $groups)) {
 
                 foreach ($feed as $item) {
@@ -609,15 +612,20 @@ namespace Idno\Core {
                     $tmp = new \DOMDocument();
                     $tmp->formatOutput = true;
 
-                    fwrite($f, $tmp->saveXML($tmp->importNode($item->rssSerialise(), true)) . "\n");
+                    $rssNode = $item->rssSerialise($rssVars);
+                    fwrite($f, $tmp->saveXML($tmp->importNode($rssNode, true)) . "\n");
+                    unset($rssNode, $tmp);
                 }
 
+                unset($feed);
+                gc_collect_cycles();
                 $offset += $limit;
             }
 
             fclose($f);
 
-            // Build the empty export template
+            // Build the empty export template (items are injected from the fragment file,
+            // not from the template, so pass an empty items array)
             $rss_theme = new DefaultTemplate();
             $rss_theme->setTemplateType('rss');
 
@@ -628,14 +636,15 @@ namespace Idno\Core {
                         'description' => $description,
                         'body' => $rss_theme->__(
                             array(
-                            'items' => $feed,
+                            'items' => [],
                             'offset' => 0,
-                            'count' => sizeof($feed),
+                            'count' => 0,
                             'subject' => [],
-                            //'nocdata'  => true,
-                            'base_url' => $base_url
+                            'base_url' => $base_url,
+                            'wxr_mode' => $wxr_mode,
                             )
                         )->draw('pages/home'),
+                        'wxr_mode' => $wxr_mode,
                     )
                 )->drawPage(false)
             );

--- a/Idno/Pages/Account/Export/WXR.php
+++ b/Idno/Pages/Account/Export/WXR.php
@@ -6,7 +6,7 @@ namespace Idno\Pages\Account\Export {
     use Idno\Core\Idno;
     use Idno\Core\Migration;
 
-    class RSS extends Page
+    class WXR extends Page
     {
 
         function postContent()
@@ -21,13 +21,17 @@ namespace Idno\Pages\Account\Export {
                 $hide_private = false;
             }
 
-            $f = Migration::getExportRSS($hide_private, Idno::site()->session()->currentUserUUID());
+            $f = Migration::getExportRSS(
+                $hide_private,
+                Idno::site()->session()->currentUserUUID(),
+                true // wxr_mode
+            );
 
             if ($f) {
                 $stats = fstat($f);
 
-                header('Content-type: text/rss');
-                header('Content-disposition: attachment; filename=user_export.rss');
+                header('Content-type: application/xml');
+                header('Content-disposition: attachment; filename=user_export.xml');
                 header('Content-Length: ' . $stats['size']);
 
                 while ($content = fgets($f)) {
@@ -37,7 +41,7 @@ namespace Idno\Pages\Account\Export {
                 fclose($f);
             } else {
                 Idno::site()->session()->addMessage(
-                    Idno::site()->language()->_('There was a problem generating your export. Please try again later.'),
+                    Idno::site()->language()->_('There was a problem generating your WXR export. Please try again later.'),
                     'alert-danger'
                 );
                 $this->forward(Idno::site()->config()->getDisplayURL() . 'account/export/');
@@ -49,4 +53,3 @@ namespace Idno\Pages\Account\Export {
     }
 
 }
-

--- a/Idno/Pages/Admin/Export/RSS.php
+++ b/Idno/Pages/Admin/Export/RSS.php
@@ -15,18 +15,18 @@ namespace Idno\Pages\Admin\Export {
 
             set_time_limit(0);
 
-            header('Content-type: text/rss');
-            header('Content-disposition: attachment; filename=export.rss');
-
             $hide_private = true;
             if ($private = $this->getInput('allposts')) {
                 $hide_private = false;
             }
 
-            if ($f = Migration::getExportRSS($hide_private)) {
+            $f = Migration::getExportRSS($hide_private);
 
+            if ($f) {
                 $stats = fstat($f);
 
+                header('Content-type: text/rss');
+                header('Content-disposition: attachment; filename=export.rss');
                 header('Content-Length: ' . $stats['size']);
 
                 while ($content = fgets($f)) {
@@ -34,6 +34,12 @@ namespace Idno\Pages\Admin\Export {
                 }
 
                 fclose($f);
+            } else {
+                \Idno\Core\Idno::site()->session()->addMessage(
+                    \Idno\Core\Idno::site()->language()->_('There was a problem generating the export. Please try again later.'),
+                    'alert-danger'
+                );
+                $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'admin/export/');
             }
             exit;
 

--- a/Idno/Pages/Admin/Export/WXR.php
+++ b/Idno/Pages/Admin/Export/WXR.php
@@ -1,18 +1,17 @@
 <?php
 
-namespace Idno\Pages\Account\Export {
+namespace Idno\Pages\Admin\Export {
 
     use Idno\Common\Page;
-    use Idno\Core\Idno;
     use Idno\Core\Migration;
 
-    class RSS extends Page
+    class WXR extends Page
     {
 
         function postContent()
         {
 
-            $this->gatekeeper();
+            $this->adminGatekeeper();
 
             set_time_limit(0);
 
@@ -21,13 +20,13 @@ namespace Idno\Pages\Account\Export {
                 $hide_private = false;
             }
 
-            $f = Migration::getExportRSS($hide_private, Idno::site()->session()->currentUserUUID());
+            $f = Migration::getExportRSS($hide_private, '', true); // wxr_mode
 
             if ($f) {
                 $stats = fstat($f);
 
-                header('Content-type: text/rss');
-                header('Content-disposition: attachment; filename=user_export.rss');
+                header('Content-type: application/xml');
+                header('Content-disposition: attachment; filename=export.xml');
                 header('Content-Length: ' . $stats['size']);
 
                 while ($content = fgets($f)) {
@@ -36,11 +35,11 @@ namespace Idno\Pages\Account\Export {
 
                 fclose($f);
             } else {
-                Idno::site()->session()->addMessage(
-                    Idno::site()->language()->_('There was a problem generating your export. Please try again later.'),
+                \Idno\Core\Idno::site()->session()->addMessage(
+                    \Idno\Core\Idno::site()->language()->_('There was a problem generating the WXR export. Please try again later.'),
                     'alert-danger'
                 );
-                $this->forward(Idno::site()->config()->getDisplayURL() . 'account/export/');
+                $this->forward(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'admin/export/');
             }
             exit;
 
@@ -49,4 +48,3 @@ namespace Idno\Pages\Account\Export {
     }
 
 }
-

--- a/templates/default/account/export.tpl.php
+++ b/templates/default/account/export.tpl.php
@@ -41,6 +41,39 @@
 
         </form>
 
+        <hr>
+
+        <form action="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL() ?>account/export/wxr" method="post">
+
+            <h2>
+                <?php echo \Idno\Core\Idno::site()->language()->_('Export as WordPress (WXR)'); ?>
+            </h2>
+            <p class="explanation">
+                <?php echo \Idno\Core\Idno::site()->language()->_("Download a WordPress eXtended RSS (WXR) file. This format includes additional metadata such as post dates, slugs, and comments, and is the standard format for importing into WordPress."); ?>
+            </p>
+
+            <div class="row">
+                <div class="col-md-3">
+                    <p><label class="control-label" for="allposts_wxr"><strong><?php echo \Idno\Core\Idno::site()->language()->_('Include private posts?'); ?></strong></label></p>
+                </div>
+                <div class="config-toggle col-md-2">
+                    <input type="checkbox" data-toggle="toggle" data-onstyle="info"
+                           data-on="<?php echo \Idno\Core\Idno::site()->language()->_('Yes'); ?>"
+                           data-off="<?php echo \Idno\Core\Idno::site()->language()->_('No'); ?>"
+                           name="allposts" id="allposts_wxr"
+                           value="0">
+                </div>
+                <div class="col-md-7">
+                    <p class="config-desc"><?php echo \Idno\Core\Idno::site()->language()->_('Platforms like WordPress may assume that all your posts should be displayed publicly. In order to protect your privacy, you may wish to just download your public posts.'); ?></p>
+                </div>
+            </div>
+            <div class="">
+                <button type="submit" class="btn btn-primary"><?php echo \Idno\Core\Idno::site()->language()->_('Download WXR File'); ?></button>
+                <?php echo \Idno\Core\Idno::site()->actions()->signForm('/account/export/wxr') ?>
+            </div>
+
+        </form>
+
     </div>
 
 </div>

--- a/templates/default/admin/export.tpl.php
+++ b/templates/default/admin/export.tpl.php
@@ -45,5 +45,39 @@
             ?>
         </form>
 
+        <hr>
+
+        <h3>
+            <?php echo \Idno\Core\Idno::site()->language()->_('Generate WordPress (WXR) file'); ?>
+        </h3>
+        <p class="explanation">
+            <?php echo \Idno\Core\Idno::site()->language()->_('Export your content as a WordPress eXtended RSS (WXR) file. This format includes additional metadata such as post dates, slugs, and comments, and is the standard format for importing into WordPress.'); ?>
+        </p>
+        <form action="<?php echo \Idno\Core\Idno::site()->config()->getDisplayURL()?>admin/export/wxr" method="post">
+            <div class="row">
+                <div class="col-md-3">
+                    <p><label class="control-label" for="allposts_wxr"><strong><?php echo \Idno\Core\Idno::site()->language()->_('Include private posts?'); ?></strong></label></p>
+                </div>
+                <div class="config-toggle col-md-3">
+                    <input type="checkbox" data-toggle="toggle" data-onstyle="info"
+                           data-on="<?php echo \Idno\Core\Idno::site()->language()->_('Yes'); ?>"
+                           data-off="<?php echo \Idno\Core\Idno::site()->language()->_('No'); ?>"
+                           name="allposts" id="allposts_wxr"
+                           value="1">
+                </div>
+                <div class="col-md-6">
+                    <p class="config-desc"><?php echo \Idno\Core\Idno::site()->language()->_('Some platforms may assume that your content should be displayed publicly. To protect your privacy, you may wish to only download your public content.'); ?></p>
+                </div>
+            </div>
+            <p>
+                <input type="submit" class="btn btn-primary" value="<?php echo \Idno\Core\Idno::site()->language()->_('Download WXR file'); ?>">
+            </p>
+            <?php
+
+                echo \Idno\Core\Idno::site()->actions()->signForm(\Idno\Core\Idno::site()->config()->getDisplayURL() . 'admin/export/wxr');
+
+            ?>
+        </form>
+
     </div>
 </div>

--- a/templates/rss/shell.tpl.php
+++ b/templates/rss/shell.tpl.php
@@ -29,6 +29,7 @@ if (empty($vars['base_url'])) {
     $rss->setAttribute('xmlns:dc', 'http://purl.org/dc/elements/1.1/');
     $rss->setAttribute('xmlns:itunes', 'http://www.itunes.com/dtds/podcast-1.0.dtd');
     $rss->setAttribute('xmlns:wp', 'http://wordpress.org/export/1.2/');
+    $rss->setAttribute('xmlns:content', 'http://purl.org/rss/1.0/modules/content/');
     $channel = $page->createElement('channel');
     $channel->appendChild($page->createElement('title', htmlspecialchars($vars['title'])));
     $channel->appendChild($page->createElement('itunes:author', htmlspecialchars($vars['title'])));
@@ -76,6 +77,13 @@ if (!empty(\Idno\Core\Idno::site()->config()->hub)) {
     $self->setAttribute('type', 'application/rss+xml');
     $channel->appendChild($self);
     $channel->appendChild($page->createElement('generator', 'Idno https://idno.co'));
+
+if (!empty($vars['wxr_mode'])) {
+    $channel->appendChild($page->createElement('wp:wxr_version', '1.2'));
+    $wxr_base_url = !empty($vars['base_url']) ? $vars['base_url'] : \Idno\Core\Idno::site()->config()->getDisplayURL();
+    $channel->appendChild($page->createElement('wp:base_site_url', htmlspecialchars($wxr_base_url)));
+    $channel->appendChild($page->createElement('wp:base_blog_url', htmlspecialchars($wxr_base_url)));
+}
 
     // In case this isn't a feed page, find any objects
 if (empty($vars['items']) && !empty($vars['object'])) {


### PR DESCRIPTION
- Fix memory exhaustion in RSS export by adding gc_collect_cycles() and explicit unset() calls between batches in Migration::getExportRSS()
- Fix stale $feed variable bug that could cause double-rendering of the last batch of entities in the RSS template
- Fix RSS export error pages being downloaded as .rss files (#3324) by deferring Content-Type/Content-Disposition headers until after export succeeds, and redirecting with an error message on failure
- Add WXR (WordPress eXtended RSS) export format with wp:post_id, wp:post_date, wp:post_name, content:encoded, and wp:comment elements
- Add WXR export endpoints (/account/export/wxr, /admin/export/wxr) with corresponding UI forms on the export pages
- Optimize Entity::rssSerialise() to call draw() once and reuse the result for both description and content:encoded elements

