### PR TITLE
Fix ActivityPub test suite errors: inbox GET, outbox POST, empty hand…

### DIFF
--- a/IdnoPlugins/ActivityPub/Pages/Actor.php
+++ b/IdnoPlugins/ActivityPub/Pages/Actor.php
@@ -76,6 +76,12 @@ class Actor extends \Idno\Common\Page
 
     function postContent()
     {
+        $this->setResponse(405);
+        http_response_code(405);
+        header('Content-Type: application/json');
+        header('Allow: GET');
+        echo json_encode(['error' => 'Method not allowed']);
+        exit;
     }
 
     /**

--- a/IdnoPlugins/ActivityPub/Pages/Followers.php
+++ b/IdnoPlugins/ActivityPub/Pages/Followers.php
@@ -73,5 +73,11 @@ class Followers extends \Idno\Common\Page
 
     function postContent()
     {
+        $this->setResponse(405);
+        http_response_code(405);
+        header('Content-Type: application/json');
+        header('Allow: GET');
+        echo json_encode(['error' => 'Method not allowed']);
+        exit;
     }
 }

--- a/IdnoPlugins/ActivityPub/Pages/Following.php
+++ b/IdnoPlugins/ActivityPub/Pages/Following.php
@@ -39,5 +39,11 @@ class Following extends \Idno\Common\Page
 
     function postContent()
     {
+        $this->setResponse(405);
+        http_response_code(405);
+        header('Content-Type: application/json');
+        header('Allow: GET');
+        echo json_encode(['error' => 'Method not allowed']);
+        exit;
     }
 }

--- a/IdnoPlugins/ActivityPub/Pages/Inbox.php
+++ b/IdnoPlugins/ActivityPub/Pages/Inbox.php
@@ -14,10 +14,29 @@ class Inbox extends \Idno\Common\Page
 
     function getContent()
     {
-        $this->setResponse(405);
-        http_response_code(405);
-        header('Allow: POST');
-        echo json_encode(['error' => 'Method not allowed. POST to this endpoint.']);
+        $handle = $this->arguments[0] ?? '';
+        $user = \Idno\Entities\User::getByHandle($handle);
+
+        if (!$user) {
+            $this->noContent();
+            return;
+        }
+
+        $actorId = $user->getActivityPubActorID();
+        $inboxUrl = $actorId . '/inbox';
+
+        // Per spec, inbox MUST be an OrderedCollection.
+        // We return an empty one since received activities are not publicly exposed.
+        $collection = [
+            '@context'     => 'https://www.w3.org/ns/activitystreams',
+            'id'           => $inboxUrl,
+            'type'         => 'OrderedCollection',
+            'totalItems'   => 0,
+            'orderedItems' => [],
+        ];
+
+        header('Content-Type: application/activity+json');
+        echo json_encode($collection, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
         exit;
     }
 

--- a/IdnoPlugins/ActivityPub/Pages/NodeInfo.php
+++ b/IdnoPlugins/ActivityPub/Pages/NodeInfo.php
@@ -48,5 +48,11 @@ class NodeInfo extends \Idno\Common\Page
 
     function postContent()
     {
+        $this->setResponse(405);
+        http_response_code(405);
+        header('Content-Type: application/json');
+        header('Allow: GET');
+        echo json_encode(['error' => 'Method not allowed']);
+        exit;
     }
 }

--- a/IdnoPlugins/ActivityPub/Pages/NodeInfoIndex.php
+++ b/IdnoPlugins/ActivityPub/Pages/NodeInfoIndex.php
@@ -30,5 +30,11 @@ class NodeInfoIndex extends \Idno\Common\Page
 
     function postContent()
     {
+        $this->setResponse(405);
+        http_response_code(405);
+        header('Content-Type: application/json');
+        header('Allow: GET');
+        echo json_encode(['error' => 'Method not allowed']);
+        exit;
     }
 }

--- a/IdnoPlugins/ActivityPub/Pages/Outbox.php
+++ b/IdnoPlugins/ActivityPub/Pages/Outbox.php
@@ -100,7 +100,9 @@ class Outbox extends \Idno\Common\Page
         // Outbox POST (C2S) is not implemented
         $this->setResponse(405);
         http_response_code(405);
+        header('Content-Type: application/json');
         header('Allow: GET');
         echo json_encode(['error' => 'Client-to-server posting is not supported']);
+        exit;
     }
 }

--- a/IdnoPlugins/ActivityPub/Pages/SharedInbox.php
+++ b/IdnoPlugins/ActivityPub/Pages/SharedInbox.php
@@ -15,10 +15,20 @@ class SharedInbox extends \Idno\Common\Page
 
     function getContent()
     {
-        $this->setResponse(405);
-        http_response_code(405);
-        header('Allow: POST');
-        echo json_encode(['error' => 'Method not allowed. POST to this endpoint.']);
+        $siteUrl = \Idno\Core\Idno::site()->config()->getDisplayURL();
+
+        // Per spec, inbox MUST be an OrderedCollection.
+        // We return an empty one since received activities are not publicly exposed.
+        $collection = [
+            '@context'     => 'https://www.w3.org/ns/activitystreams',
+            'id'           => $siteUrl . 'inbox',
+            'type'         => 'OrderedCollection',
+            'totalItems'   => 0,
+            'orderedItems' => [],
+        ];
+
+        header('Content-Type: application/activity+json');
+        echo json_encode($collection, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
         exit;
     }
 


### PR DESCRIPTION
- Inbox GET now returns an empty OrderedCollection instead of 405. The AP spec requires inbox to be an OrderedCollection; the test suite was getting 405 with text/html content type when trying to resolve it.

- SharedInbox GET returns an empty OrderedCollection for the same reason.

- Outbox POST now returns proper 405 JSON with Content-Type header and exit; call. Previously it was missing both, causing the framework to append HTML to the JSON error response.

- All empty postContent() methods (Actor, Followers, Following, NodeInfo, NodeInfoIndex) now return a proper 405 JSON response with exit; to prevent the framework from falling through and rendering HTML.

https://claude.ai/code/session_01JQWjasJ6H6ofb9WXghW85a
