### PR TITLE
Hopeful fix for 500 errors.

### DIFF
--- a/IdnoPlugins/ActivityPub/Pages/Actor.php
+++ b/IdnoPlugins/ActivityPub/Pages/Actor.php
@@ -76,6 +76,12 @@ class Actor extends \Idno\Common\Page
 
     function postContent()
     {
+        $this->setResponse(405);
+        http_response_code(405);
+        header('Content-Type: application/json');
+        header('Allow: GET');
+        echo json_encode(['error' => 'Method not allowed']);
+        exit;
     }
 
     /**

--- a/IdnoPlugins/ActivityPub/Pages/Followers.php
+++ b/IdnoPlugins/ActivityPub/Pages/Followers.php
@@ -73,5 +73,11 @@ class Followers extends \Idno\Common\Page
 
     function postContent()
     {
+        $this->setResponse(405);
+        http_response_code(405);
+        header('Content-Type: application/json');
+        header('Allow: GET');
+        echo json_encode(['error' => 'Method not allowed']);
+        exit;
     }
 }

--- a/IdnoPlugins/ActivityPub/Pages/Following.php
+++ b/IdnoPlugins/ActivityPub/Pages/Following.php
@@ -39,5 +39,11 @@ class Following extends \Idno\Common\Page
 
     function postContent()
     {
+        $this->setResponse(405);
+        http_response_code(405);
+        header('Content-Type: application/json');
+        header('Allow: GET');
+        echo json_encode(['error' => 'Method not allowed']);
+        exit;
     }
 }

--- a/IdnoPlugins/ActivityPub/Pages/Inbox.php
+++ b/IdnoPlugins/ActivityPub/Pages/Inbox.php
@@ -14,10 +14,29 @@ class Inbox extends \Idno\Common\Page
 
     function getContent()
     {
-        $this->setResponse(405);
-        http_response_code(405);
-        header('Allow: POST');
-        echo json_encode(['error' => 'Method not allowed. POST to this endpoint.']);
+        $handle = $this->arguments[0] ?? '';
+        $user = \Idno\Entities\User::getByHandle($handle);
+
+        if (!$user) {
+            $this->noContent();
+            return;
+        }
+
+        $actorId = $user->getActivityPubActorID();
+        $inboxUrl = $actorId . '/inbox';
+
+        // Per spec, inbox MUST be an OrderedCollection.
+        // We return an empty one since received activities are not publicly exposed.
+        $collection = [
+            '@context'     => 'https://www.w3.org/ns/activitystreams',
+            'id'           => $inboxUrl,
+            'type'         => 'OrderedCollection',
+            'totalItems'   => 0,
+            'orderedItems' => [],
+        ];
+
+        header('Content-Type: application/activity+json');
+        echo json_encode($collection, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
         exit;
     }
 

--- a/IdnoPlugins/ActivityPub/Pages/Inbox.php
+++ b/IdnoPlugins/ActivityPub/Pages/Inbox.php
@@ -40,13 +40,46 @@ class Inbox extends \Idno\Common\Page
         exit;
     }
 
-    function postContent()
+    /**
+     * Override the framework's post() to bypass CSRF, parseJSONPayload(),
+     * template detection, and other framework machinery that interferes
+     * with federation inbox handling.
+     *
+     * The framework's default post() calls parseJSONPayload() which
+     * consumes php://input before postContent() can read it, and runs
+     * CSRF token validation that can fail for unsigned federation requests.
+     */
+    function post()
     {
-        // Disable CSRF verification for incoming federation requests
-        \Idno\Core\Idno::site()->session()->setApplyRecaptcha(false);
+        // Capture route arguments (handle) from Toro regex matches
+        $arguments = func_get_args();
+        if (!empty($arguments)) {
+            $this->arguments = $arguments;
+        }
 
+        try {
+            $this->handleInboxPost();
+        } catch (\Throwable $e) {
+            \Idno\Core\Idno::site()->logging()->error(
+                'ActivityPub Inbox: Uncaught error: ' . $e->getMessage() .
+                ' in ' . $e->getFile() . ':' . $e->getLine()
+            );
+            http_response_code(500);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Internal server error']);
+            exit;
+        }
+    }
+
+    /**
+     * Handle the inbox POST request directly.
+     */
+    private function handleInboxPost()
+    {
         $handle = $this->arguments[0] ?? '';
 
+        // Read php://input exactly once — the framework's parseJSONPayload()
+        // is bypassed so this is the only read.
         $rawBody = file_get_contents('php://input');
         $headers = HTTPSignature::getRequestHeaders();
         $method = $_SERVER['REQUEST_METHOD'] ?? 'POST';
@@ -65,18 +98,14 @@ class Inbox extends \Idno\Common\Page
             'ActivityPub Inbox: Response status=' . $result['status'] . ' for handle=' . $handle
         );
 
-        $this->setResponse($result['status']);
         http_response_code($result['status']);
         header('Content-Type: application/json');
         echo $result['body'];
         exit;
     }
 
-    /**
-     * Override to disable CSRF token verification for federation endpoints.
-     */
-    function csrfGatekeeper()
+    function postContent()
     {
-        return true;
+        // Not used — post() is overridden to bypass the framework.
     }
 }

--- a/IdnoPlugins/ActivityPub/Pages/NodeInfo.php
+++ b/IdnoPlugins/ActivityPub/Pages/NodeInfo.php
@@ -48,5 +48,11 @@ class NodeInfo extends \Idno\Common\Page
 
     function postContent()
     {
+        $this->setResponse(405);
+        http_response_code(405);
+        header('Content-Type: application/json');
+        header('Allow: GET');
+        echo json_encode(['error' => 'Method not allowed']);
+        exit;
     }
 }

--- a/IdnoPlugins/ActivityPub/Pages/NodeInfoIndex.php
+++ b/IdnoPlugins/ActivityPub/Pages/NodeInfoIndex.php
@@ -30,5 +30,11 @@ class NodeInfoIndex extends \Idno\Common\Page
 
     function postContent()
     {
+        $this->setResponse(405);
+        http_response_code(405);
+        header('Content-Type: application/json');
+        header('Allow: GET');
+        echo json_encode(['error' => 'Method not allowed']);
+        exit;
     }
 }

--- a/IdnoPlugins/ActivityPub/Pages/Outbox.php
+++ b/IdnoPlugins/ActivityPub/Pages/Outbox.php
@@ -100,7 +100,9 @@ class Outbox extends \Idno\Common\Page
         // Outbox POST (C2S) is not implemented
         $this->setResponse(405);
         http_response_code(405);
+        header('Content-Type: application/json');
         header('Allow: GET');
         echo json_encode(['error' => 'Client-to-server posting is not supported']);
+        exit;
     }
 }

--- a/IdnoPlugins/ActivityPub/Pages/SharedInbox.php
+++ b/IdnoPlugins/ActivityPub/Pages/SharedInbox.php
@@ -15,10 +15,20 @@ class SharedInbox extends \Idno\Common\Page
 
     function getContent()
     {
-        $this->setResponse(405);
-        http_response_code(405);
-        header('Allow: POST');
-        echo json_encode(['error' => 'Method not allowed. POST to this endpoint.']);
+        $siteUrl = \Idno\Core\Idno::site()->config()->getDisplayURL();
+
+        // Per spec, inbox MUST be an OrderedCollection.
+        // We return an empty one since received activities are not publicly exposed.
+        $collection = [
+            '@context'     => 'https://www.w3.org/ns/activitystreams',
+            'id'           => $siteUrl . 'inbox',
+            'type'         => 'OrderedCollection',
+            'totalItems'   => 0,
+            'orderedItems' => [],
+        ];
+
+        header('Content-Type: application/activity+json');
+        echo json_encode($collection, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
         exit;
     }
 

--- a/IdnoPlugins/ActivityPub/Pages/SharedInbox.php
+++ b/IdnoPlugins/ActivityPub/Pages/SharedInbox.php
@@ -32,10 +32,36 @@ class SharedInbox extends \Idno\Common\Page
         exit;
     }
 
-    function postContent()
+    /**
+     * Override the framework's post() to bypass CSRF, parseJSONPayload(),
+     * and other framework machinery that interferes with federation inbox handling.
+     */
+    function post()
     {
-        \Idno\Core\Idno::site()->session()->setApplyRecaptcha(false);
+        $arguments = func_get_args();
+        if (!empty($arguments)) {
+            $this->arguments = $arguments;
+        }
 
+        try {
+            $this->handleInboxPost();
+        } catch (\Throwable $e) {
+            \Idno\Core\Idno::site()->logging()->error(
+                'ActivityPub SharedInbox: Uncaught error: ' . $e->getMessage() .
+                ' in ' . $e->getFile() . ':' . $e->getLine()
+            );
+            http_response_code(500);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Internal server error']);
+            exit;
+        }
+    }
+
+    /**
+     * Handle the shared inbox POST request directly.
+     */
+    private function handleInboxPost()
+    {
         $rawBody = file_get_contents('php://input');
         $headers = HTTPSignature::getRequestHeaders();
         $method = $_SERVER['REQUEST_METHOD'] ?? 'POST';
@@ -54,15 +80,14 @@ class SharedInbox extends \Idno\Common\Page
             'ActivityPub SharedInbox: Response status=' . $result['status']
         );
 
-        $this->setResponse($result['status']);
         http_response_code($result['status']);
         header('Content-Type: application/json');
         echo $result['body'];
         exit;
     }
 
-    function csrfGatekeeper()
+    function postContent()
     {
-        return true;
+        // Not used — post() is overridden to bypass the framework.
     }
 }


### PR DESCRIPTION
The inbox was returning HTTP 500 with no error logs. The root cause is
that the framework's Page::post() method runs parseJSONPayload() which
consumes php://input before postContent() can read it for signature
verification. It also runs CSRF validation, template detection, and
event hooks that can fail silently on unauthenticated federation
requests.

Fix: override post() in Inbox and SharedInbox to bypass the framework
entirely. The overridden method reads php://input exactly once, wraps
the handler in try/catch(\Throwable) for comprehensive error capture,
and returns clean JSON responses. This eliminates the double-read of
php://input and removes all framework interference from the federation
inbox path.