### PR TITLE
Fix infinite queue loop: dispatch save was silently failing

### DIFF
--- a/Idno/Core/AsynchronousQueue.php
+++ b/Idno/Core/AsynchronousQueue.php
@@ -15,7 +15,7 @@ class AsynchronousQueue extends EventQueue
         \Idno\Core\Idno::site()->routes()->addRoute('/service/queue/gc/?', '\Idno\Pages\Service\Queues\GC');
     }
 
-    function enqueue($queueName, $eventName, array $eventData)
+    function enqueue($queueName, $eventName, array $eventData, $runAsUser = null)
     {
         if (empty($queueName)) {
             $queueName = 'default';
@@ -25,7 +25,10 @@ class AsynchronousQueue extends EventQueue
         $queuedEvent->queue = $queueName;
         $queuedEvent->event = $eventName;
         $queuedEvent->eventData = serialize($eventData);
-        $queuedEvent->runAsContext = \Idno\Core\Idno::site()->session()->currentUserUUID();
+        // Use explicit user context if provided (needed for unauthenticated
+        // callers like ActivityPub inbox handlers), otherwise fall back to
+        // the currently logged-in user.
+        $queuedEvent->runAsContext = $runAsUser ?: \Idno\Core\Idno::site()->session()->currentUserUUID();
         $queuedEvent->complete = false;
         $queuedEvent->queuedTs = time();
 
@@ -110,8 +113,12 @@ class AsynchronousQueue extends EventQueue
         $event->complete = true;
         $event->completedTs = time();
 
-        // Save before logging off so the canEdit() check in Entity::save() passes
-        $saved = $event->save();
+        // Use save(true) to bypass canEdit() — queue events are system-level
+        // entities.  When runAsContext is empty (e.g. events queued from an
+        // unauthenticated federation request) no user is logged in, so a
+        // normal save() would fail the canEdit() check and silently drop the
+        // "complete" flag, causing the event to be re-dispatched forever.
+        $saved = $event->save(true);
 
         \Idno\Core\Idno::site()->session()->logUserOff();
 

--- a/IdnoPlugins/ActivityPub/ActivityHandler.php
+++ b/IdnoPlugins/ActivityPub/ActivityHandler.php
@@ -197,7 +197,8 @@ class ActivityHandler
 
         \Idno\Core\Idno::site()->logging()->info('ActivityPub: New follower ' . $actorData['handle'] . ' for user ' . $user->getHandle());
 
-        // Auto-accept: queue Accept delivery
+        // Auto-accept: queue Accept delivery (passing user UUID explicitly
+        // because no user is logged in during federation inbox requests)
         self::sendAccept($activity, $user, $actorData['inbox']);
 
         return ['status' => 202, 'body' => ''];
@@ -214,12 +215,15 @@ class ActivityHandler
     {
         $acceptActivity = ActivityBuilder::buildAccept($followActivity, $user);
 
-        // Queue Accept delivery via async pipeline
+        // Queue Accept delivery via async pipeline.
+        // Pass user UUID as runAsUser because no session user is logged in
+        // during federation inbox requests — without this, the queued event
+        // has no runAsContext and dispatch() can't mark it complete.
         \Idno\Core\Idno::site()->queue()->enqueue('default', 'activitypub/deliver', [
             'user_uuid' => $user->getUUID(),
             'activity'  => $acceptActivity,
             'inbox'     => $targetInbox,
-        ]);
+        ], $user->getUUID());
     }
 
     /**

--- a/IdnoPlugins/ActivityPub/Delivery.php
+++ b/IdnoPlugins/ActivityPub/Delivery.php
@@ -88,7 +88,7 @@ class Delivery
                 'user_uuid' => $user->getUUID(),
                 'activity'  => $activity,
                 'inbox'     => $inbox,
-            ]);
+            ], $user->getUUID());
         }
     }
 


### PR DESCRIPTION
The root cause of the infinite event re-dispatch loop:

1. ActivityPub inbox requests (Follow, etc.) run with no logged-in user
2. enqueue() stored runAsContext = currentUserUUID() which is false when no user is in session
3. dispatch() skipped logUserOn() when runAsContext was empty
4. dispatch() called event->save() without overrideAccess, which calls canEdit() — returns false with no logged-in user
5. save() silently returned false, so complete=true was never persisted to the database
6. getPendingFromQueue() kept returning the same events forever

Two fixes:

- dispatch() now uses save(true) to bypass canEdit() for queue events, which are system-level entities that must always be saveable
- enqueue() accepts an optional $runAsUser parameter so callers without a session (like AP inbox handlers) can specify which user context to dispatch under. sendAccept() and deliverToFollowers() now pass the user UUID explicitly.

https://claude.ai/code/session_01JQWjasJ6H6ofb9WXghW85a

