### PR TITLE
Fix ActivityPub Accept activity JSON-LD compatibility

### DIFF
--- a/IdnoPlugins/ActivityPub/ActivityBuilder.php
+++ b/IdnoPlugins/ActivityPub/ActivityBuilder.php
@@ -223,26 +223,44 @@ class ActivityBuilder
     {
         $actorId = $user->getActivityPubActorID();
 
-        // Strip @context from the embedded Follow so it inherits the Accept's
-        // context cleanly.  Nested @context creates a JSON-LD scope override
-        // that can prevent Fedify-based implementations (e.g. Ghost) from
-        // deserializing the object as a Follow instance.
-        $followObject = $followActivity;
-        unset($followObject['@context']);
+        // Build a minimal embedded Follow object containing only the standard
+        // ActivityPub properties.  The original Follow from the remote server
+        // may include implementation-specific fields whose short names are
+        // defined in contexts we don't carry.  Echoing those fields back
+        // without their original context causes strict JSON-LD processors
+        // (e.g. Fedify, used by Ghost) to fail deserialization.  Keeping
+        // only id/type/actor/object ensures every term resolves under the
+        // Accept's own ActivityStreams context.
+        $followObject = [
+            'id'     => $followActivity['id'] ?? '',
+            'type'   => $followActivity['type'] ?? 'Follow',
+            'actor'  => is_string($followActivity['actor'] ?? null)
+                            ? $followActivity['actor']
+                            : ($followActivity['actor']['id'] ?? ''),
+            'object' => is_string($followActivity['object'] ?? null)
+                            ? $followActivity['object']
+                            : ($followActivity['object']['id'] ?? ''),
+        ];
+
+        $followerActor = $followObject['actor'];
 
         $accept = [
-            '@context'  => self::CONTEXT,
+            // Use only the ActivityStreams context — the security/v1 context
+            // is not needed for Accept activities and adding unnecessary
+            // contexts can cause issues with strict JSON-LD processors.
+            '@context'  => 'https://www.w3.org/ns/activitystreams',
             'id'        => $actorId . '#accept-' . md5($followActivity['id'] ?? time()),
             'type'      => 'Accept',
             'actor'     => $actorId,
             'object'    => $followObject,
-            'published' => date(\DateTime::RFC3339),
         ];
 
-        // Address the Accept to the remote actor who sent the Follow
-        $followerActor = $followActivity['actor'] ?? '';
+        // Address the Accept to the remote actor who sent the Follow.
+        // Use an array for the `to` field per ActivityStreams convention —
+        // while JSON-LD normalizes strings and arrays equivalently, some
+        // implementations pre-process addressing fields expecting arrays.
         if (!empty($followerActor)) {
-            $accept['to'] = $followerActor;
+            $accept['to'] = [$followerActor];
         }
 
         return $accept;

--- a/IdnoPlugins/ActivityPub/Tests/ActivityPubTest.php
+++ b/IdnoPlugins/ActivityPub/Tests/ActivityPubTest.php
@@ -2,6 +2,7 @@
 
 namespace IdnoPlugins\ActivityPub\Tests {
 
+    use Idno\Entities\User;
     use IdnoPlugins\ActivityPub\ActivityBuilder;
     use IdnoPlugins\ActivityPub\HTTPSignature;
     use PHPUnit\Framework\TestCase;
@@ -128,6 +129,197 @@ namespace IdnoPlugins\ActivityPub\Tests {
             $activity = ActivityBuilder::wrapActivity('Create', null, $object, $explicitId);
 
             $this->assertEquals($explicitId, $activity['id']);
+        }
+
+        // -----------------------------------------------------------------
+        // ActivityBuilder::buildAccept
+        // -----------------------------------------------------------------
+
+        /**
+         * Helper: create a mock User that returns a fixed actor ID.
+         */
+        private function createMockUser(string $actorId = 'https://example.com/actor/testuser'): User
+        {
+            $user = $this->createMock(User::class);
+            $user->method('getActivityPubActorID')->willReturn($actorId);
+            return $user;
+        }
+
+        /**
+         * Test that buildAccept uses only the ActivityStreams context string.
+         * The security/v1 context is not needed and extra contexts can cause
+         * issues with strict JSON-LD processors like Fedify.
+         */
+        public function testBuildAcceptUsesSimpleContext()
+        {
+            $follow = [
+                '@context' => 'https://www.w3.org/ns/activitystreams',
+                'id'       => 'https://remote.example/follow/1',
+                'type'     => 'Follow',
+                'actor'    => 'https://remote.example/users/alice',
+                'object'   => 'https://example.com/actor/testuser',
+            ];
+
+            $accept = ActivityBuilder::buildAccept($follow, $this->createMockUser());
+
+            $this->assertEquals(
+                'https://www.w3.org/ns/activitystreams',
+                $accept['@context'],
+                'Accept should use only the ActivityStreams context string'
+            );
+        }
+
+        /**
+         * Test that buildAccept produces the correct structure.
+         */
+        public function testBuildAcceptStructure()
+        {
+            $follow = [
+                '@context' => 'https://www.w3.org/ns/activitystreams',
+                'id'       => 'https://remote.example/follow/1',
+                'type'     => 'Follow',
+                'actor'    => 'https://remote.example/users/alice',
+                'object'   => 'https://example.com/actor/testuser',
+            ];
+
+            $accept = ActivityBuilder::buildAccept($follow, $this->createMockUser());
+
+            $this->assertEquals('Accept', $accept['type']);
+            $this->assertEquals('https://example.com/actor/testuser', $accept['actor']);
+            $this->assertStringStartsWith('https://example.com/actor/testuser#accept-', $accept['id']);
+            $this->assertArrayHasKey('object', $accept);
+        }
+
+        /**
+         * Test that the embedded Follow in the Accept contains only the
+         * essential standard properties (id, type, actor, object) and no
+         * implementation-specific fields from the original Follow.
+         */
+        public function testBuildAcceptSanitizesEmbeddedFollow()
+        {
+            $follow = [
+                '@context'       => ['https://www.w3.org/ns/activitystreams', 'https://custom.context/v1'],
+                'id'             => 'https://remote.example/follow/1',
+                'type'           => 'Follow',
+                'actor'          => 'https://remote.example/users/alice',
+                'object'         => 'https://example.com/actor/testuser',
+                'customProperty' => 'should be stripped',
+                'published'      => '2026-01-01T00:00:00Z',
+            ];
+
+            $accept = ActivityBuilder::buildAccept($follow, $this->createMockUser());
+            $embedded = $accept['object'];
+
+            // Only standard Follow properties should be present
+            $this->assertEquals('https://remote.example/follow/1', $embedded['id']);
+            $this->assertEquals('Follow', $embedded['type']);
+            $this->assertEquals('https://remote.example/users/alice', $embedded['actor']);
+            $this->assertEquals('https://example.com/actor/testuser', $embedded['object']);
+
+            // @context and implementation-specific fields must NOT be in the embedded Follow
+            $this->assertArrayNotHasKey('@context', $embedded, 'Embedded Follow must not have @context');
+            $this->assertArrayNotHasKey('customProperty', $embedded, 'Implementation-specific fields must be stripped');
+            $this->assertArrayNotHasKey('published', $embedded, 'Non-essential fields must be stripped');
+
+            // Verify the embedded Follow has exactly 4 keys
+            $this->assertCount(4, $embedded, 'Embedded Follow should have exactly id, type, actor, object');
+        }
+
+        /**
+         * Test that the to field in the Accept is an array, not a string.
+         * Some implementations (notably Fedify/Ghost) pre-process addressing
+         * fields expecting arrays before JSON-LD normalization.
+         */
+        public function testBuildAcceptToFieldIsArray()
+        {
+            $follow = [
+                'id'     => 'https://remote.example/follow/1',
+                'type'   => 'Follow',
+                'actor'  => 'https://remote.example/users/alice',
+                'object' => 'https://example.com/actor/testuser',
+            ];
+
+            $accept = ActivityBuilder::buildAccept($follow, $this->createMockUser());
+
+            $this->assertArrayHasKey('to', $accept);
+            $this->assertIsArray($accept['to'], 'The to field must be an array');
+            $this->assertEquals(['https://remote.example/users/alice'], $accept['to']);
+        }
+
+        /**
+         * Test that buildAccept does not include a published field.
+         * Mastodon and other implementations that work with Ghost do not
+         * include published in Accept activities.
+         */
+        public function testBuildAcceptDoesNotIncludePublished()
+        {
+            $follow = [
+                'id'     => 'https://remote.example/follow/1',
+                'type'   => 'Follow',
+                'actor'  => 'https://remote.example/users/alice',
+                'object' => 'https://example.com/actor/testuser',
+            ];
+
+            $accept = ActivityBuilder::buildAccept($follow, $this->createMockUser());
+
+            $this->assertArrayNotHasKey('published', $accept, 'Accept should not include published');
+        }
+
+        /**
+         * Test that buildAccept handles Follow with actor/object as objects
+         * (not just string URIs) by extracting the id.
+         */
+        public function testBuildAcceptHandlesObjectActorAsObject()
+        {
+            $follow = [
+                'id'     => 'https://remote.example/follow/2',
+                'type'   => 'Follow',
+                'actor'  => ['id' => 'https://remote.example/users/bob', 'type' => 'Person'],
+                'object' => ['id' => 'https://example.com/actor/testuser', 'type' => 'Person'],
+            ];
+
+            $accept = ActivityBuilder::buildAccept($follow, $this->createMockUser());
+            $embedded = $accept['object'];
+
+            $this->assertEquals('https://remote.example/users/bob', $embedded['actor']);
+            $this->assertEquals('https://example.com/actor/testuser', $embedded['object']);
+            $this->assertEquals(['https://remote.example/users/bob'], $accept['to']);
+        }
+
+        /**
+         * Test that buildAccept generates a deterministic ID based on the
+         * Follow activity's ID.
+         */
+        public function testBuildAcceptDeterministicId()
+        {
+            $follow = [
+                'id'     => 'https://remote.example/follow/stable-id',
+                'type'   => 'Follow',
+                'actor'  => 'https://remote.example/users/alice',
+                'object' => 'https://example.com/actor/testuser',
+            ];
+
+            $user = $this->createMockUser();
+            $accept1 = ActivityBuilder::buildAccept($follow, $user);
+            $accept2 = ActivityBuilder::buildAccept($follow, $user);
+
+            $this->assertEquals($accept1['id'], $accept2['id'], 'Accept ID should be deterministic for the same Follow');
+        }
+
+        /**
+         * Test that buildAccept omits the to field when the Follow has no actor.
+         */
+        public function testBuildAcceptOmitsToWhenNoActor()
+        {
+            $follow = [
+                'id'     => 'https://remote.example/follow/1',
+                'type'   => 'Follow',
+                'object' => 'https://example.com/actor/testuser',
+            ];
+
+            $accept = ActivityBuilder::buildAccept($follow, $this->createMockUser());
+
+            $this->assertArrayNotHasKey('to', $accept, 'Accept should not have to field when Follow has no actor');
         }
 
         // -----------------------------------------------------------------


### PR DESCRIPTION
## Here's what I fixed or added:

Modified `ActivityBuilder::buildAccept()` to improve JSON-LD compatibility with strict processors like Fedify (used by Ghost):

1. **Simplified context**: Changed from `self::CONTEXT` (which includes security/v1) to only `https://www.w3.org/ns/activitystreams` to avoid unnecessary context overhead
2. **Sanitized embedded Follow**: Instead of copying the entire Follow activity and removing `@context`, now explicitly builds a minimal Follow object containing only standard ActivityPub properties (id, type, actor, object). This prevents echoing back implementation-specific fields whose short names are undefined in the Accept's context
3. **Fixed `to` field format**: Changed from string to array format (`[$followerActor]` instead of `$followerActor`) to match ActivityStreams convention and accommodate implementations that pre-process addressing fields before JSON-LD normalization
4. **Removed `published` field**: Omitted from Accept activities to match Mastodon and other implementations' behavior
5. **Improved actor/object handling**: Added logic to extract `id` from object-form actor/object references (not just string URIs)

Added comprehensive test coverage with 8 new test cases validating:
- Simple context usage
- Correct Accept structure
- Embedded Follow sanitization (no @context, no extra fields)
- `to` field as array
- Absence of `published` field
- Handling of object-form actor/object references
- Deterministic ID generation
- Omission of `to` when Follow has no actor

## Here's why I did it:

Strict JSON-LD processors like Fedify fail to deserialize Accept activities when they contain:
- Nested `@context` declarations that create scope overrides
- Implementation-specific fields whose short names aren't defined in the current context
- Unnecessary context declarations

These changes ensure Accept activities are compatible with Ghost's ActivityPub implementation while maintaining correctness per the ActivityStreams specification.

## Checklist:

- [x] This pull request addresses a single issue
- [x] I've adhered to Idno's style guide
- [x] My code contains descriptive comments
- [x] I've added tests where applicable (8 new test cases)
- [x] Unit tests pass successfully

https://claude.ai/code/session_01Bqv3jfw6akojj6JfUCuF8L