### PR TITLE
Security: Improve image import and template validation

### DIFF
--- a/Idno/Core/Bonita/Templates.php
+++ b/Idno/Core/Bonita/Templates.php
@@ -86,6 +86,22 @@ namespace Idno\Core\Bonita {
         function draw($templateName, $returnBlank = true)
         {
             $templateName = preg_replace('/^_[A-Z0-9\/]+/i', '', $templateName);
+
+            // Reject template names with path traversal sequences or invalid characters
+            if (strpos($templateName, '..') !== false) {
+                if ($returnBlank) {
+                    return '';
+                }
+                return false;
+            }
+            // Only allow alphanumeric characters, forward slashes, hyphens, and underscores
+            if (!preg_match('/^[a-zA-Z0-9\/_-]+$/', $templateName)) {
+                if ($returnBlank) {
+                    return '';
+                }
+                return false;
+            }
+
             if (!empty($templateName)) {
 
                 // Add the Bonita base path to our additional paths list
@@ -230,6 +246,9 @@ namespace Idno\Core\Bonita {
         function setTemplateType($templateType)
         {
             $templateType = preg_replace('/^_[A-Z0-9\/]+/i', '', $templateType);
+            if (strpos($templateType, '..') !== false || !preg_match('/^[a-zA-Z0-9\/_-]+$/', $templateType)) {
+                return false;
+            }
             if ($this->templateTypeExists($templateType)) {
                 $this->templateType = $templateType;
                 return true;
@@ -246,6 +265,9 @@ namespace Idno\Core\Bonita {
         function templateTypeExists($templateType)
         {
             $templateType = preg_replace('/^_[A-Z0-9\/]+/i', '', $templateType);
+            if (strpos($templateType, '..') !== false || !preg_match('/^[a-zA-Z0-9\/_-]+$/', $templateType)) {
+                return false;
+            }
             if (!empty($templateType)) {
                 $paths = \Idno\Core\Bonita\Main::getPaths();
                 foreach ($paths as $basepath) {

--- a/Idno/Core/Migration.php
+++ b/Idno/Core/Migration.php
@@ -366,37 +366,63 @@ namespace Idno\Core {
 
         static function importImagesFromBodyHTML(string $body, string $src_url): string
         {
+            $allowed_extensions = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+
             $doc = new \DOMDocument();
             if (@$doc->loadHTML($body)) {
                 if ($images = $doc->getElementsByTagName('img')) {
                     foreach ($images as $image) {
                         $src = $image->getAttribute('src');
-                        if (substr_count($src, $src_url)) {
-                            $dir = Idno::site()->config()->getTempDir();
-                            $name = md5($src);
-                            $newname = $dir . $name . basename($src);
-                            if (@file_put_contents($newname, fopen($src, 'r'))) {
-                                switch (strtolower(pathinfo($src, PATHINFO_EXTENSION))) {
-                                    case 'jpg':
-                                    case 'jpeg':
-                                        $mime = 'image/jpg';
-                                        break;
-                                    case 'gif':
-                                        $mime = 'image/gif';
-                                        break;
-                                    case 'png':
-                                        $mime = 'image/png';
-                                        break;
-                                    default:
-                                        $mime = 'application/octet-stream';
-                                }
-                                if ($file = File::createFromFile($newname, basename($src), $mime, true)) {
-                                    $newsrc = \Idno\Core\Idno::site()->config()->getURL() . 'file/' . $file->file['_id'];
-                                    $body = str_replace($src, $newsrc, $body);
-                                    @unlink($newname);
-                                }
+
+                        // Validate the URL hostname matches the expected source domain
+                        $parsed_url = parse_url($src);
+                        if (empty($parsed_url['host'])) {
+                            continue;
+                        }
+                        $host = strtolower($parsed_url['host']);
+                        $expected_domain = strtolower($src_url);
+                        if ($host !== $expected_domain && substr($host, -(strlen($expected_domain) + 1)) !== '.' . $expected_domain) {
+                            continue;
+                        }
+
+                        // Validate file extension is an allowed image type
+                        $path_part = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+                        $extension = strtolower(pathinfo($path_part, PATHINFO_EXTENSION));
+                        if (!in_array($extension, $allowed_extensions)) {
+                            continue;
+                        }
+
+                        // Use tempnam() for safe temp file creation
+                        $dir = Idno::site()->config()->getTempDir();
+                        $newname = tempnam($dir, 'import_');
+                        if ($newname === false) {
+                            continue;
+                        }
+
+                        if (@file_put_contents($newname, fopen($src, 'r'))) {
+                            switch ($extension) {
+                                case 'jpg':
+                                case 'jpeg':
+                                    $mime = 'image/jpg';
+                                    break;
+                                case 'gif':
+                                    $mime = 'image/gif';
+                                    break;
+                                case 'png':
+                                    $mime = 'image/png';
+                                    break;
+                                case 'webp':
+                                    $mime = 'image/webp';
+                                    break;
+                                default:
+                                    $mime = 'application/octet-stream';
+                            }
+                            if ($file = File::createFromFile($newname, basename($path_part), $mime, true)) {
+                                $newsrc = \Idno\Core\Idno::site()->config()->getURL() . 'file/' . $file->file['_id'];
+                                $body = str_replace($src, $newsrc, $body);
                             }
                         }
+                        @unlink($newname);
                     }
                 }
             }


### PR DESCRIPTION
## Here's what I fixed or added:

### Image Import Security (`Migration.php`)
- Added whitelist of allowed image extensions (jpg, jpeg, png, gif, webp)
- Implemented hostname validation to ensure imported images come from the expected source domain
- Replaced unsafe temp file creation with `tempnam()` for secure temporary file handling
- Added extension validation before processing image files
- Added support for webp image format with proper MIME type

### Template Path Validation (`Bonita/Templates.php`)
- Added path traversal protection in `draw()` method to reject template names containing `..`
- Implemented character whitelist validation (alphanumeric, forward slashes, hyphens, underscores only)
- Applied same validation checks to `setTemplateType()` and `templateTypeExists()` methods
- All validation checks return early with appropriate empty/false values

## Here's why I did it:

These changes address critical security vulnerabilities:

1. **Image Import**: The original code could be exploited to import arbitrary files from any domain and create predictable file paths. The fixes ensure only legitimate images from the expected source are imported, with proper temporary file handling.

2. **Template Loading**: Template names were not properly validated, allowing potential path traversal attacks (e.g., `../../etc/passwd`) or loading unintended template files. The validation now restricts template names to safe characters and prevents directory traversal.

## Checklist:

- [x] This pull request addresses a single issue
- [x] I've adhered to Idno's style guide
- [x] My code contains descriptive comments
- [ ] I've tested my code in-browser
- [ ] I've added tests where applicable
