### PR TITLE
Fix CSRF bypass enabling unauthenticated SSRF via URL unfurl endpoint

### DIFF
--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -496,8 +496,6 @@ namespace Idno\Core {
             if (!$return && !empty($apiUsername) && !empty($apiSignature)) {
                 \Idno\Core\Idno::site()->logging()->debug("Attempting to auth via API credentials");
 
-                $this->setIsAPIRequest(true);
-
                 $t = \Idno\Core\Input::getInput('_t');
                 if (empty($t)) {
                     \Idno\Core\Idno::site()->template()->setTemplateType('json');
@@ -515,6 +513,7 @@ namespace Idno\Core {
                     $compare_hmac = base64_encode(hash_hmac('sha256', ($_SERVER['REQUEST_URI']), $key, true));
 
                     if ($hmac == $compare_hmac) {
+                        $this->setIsAPIRequest(true);
                         \Idno\Core\Idno::site()->logging()->debug("API auth verified signature for user: " . $user->getName());
                         // TODO maybe this should set the current user without modifying $_SESSION?
                         $return = $this->refreshSessionUser($user);

--- a/Idno/Entities/UnfurledUrl.php
+++ b/Idno/Entities/UnfurledUrl.php
@@ -60,6 +60,17 @@ namespace Idno\Entities {
                 return false;
             }
 
+            // Block requests to private/reserved IP ranges (SSRF protection)
+            $host = parse_url($url, PHP_URL_HOST);
+            if (empty($host)) {
+                return false;
+            }
+            $ip = gethostbyname($host);
+            if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                \Idno\Core\Idno::site()->logging()->warning("Blocked unfurl request to private/reserved address: {$url}");
+                return false;
+            }
+
             $contents = \Idno\Core\Webservice::file_get_contents($url);
             if (!empty($contents)) {
 


### PR DESCRIPTION
Move setIsAPIRequest(true) to after successful HMAC signature verification in Session::tryAuthUser(). Previously, the API request flag was set unconditionally when X-IDNO-USERNAME and X-IDNO-SIGNATURE headers were present, regardless of whether the credentials were valid. This allowed any attacker to bypass CSRF token validation in tokenGatekeeper() by supplying fabricated API headers.

As defense in depth, add SSRF protection to UnfurledUrl::unfurl() by resolving the target hostname and rejecting requests to private (RFC 1918) and reserved IP ranges, preventing the server from being used as a proxy to reach internal network resources.
