### PR TITLE
Replace external language tools with built-in PotGenerator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ IdnoPlugins/
 !IdnoPlugins/ActivityPub
 
 ConsolePlugins/*
+!ConsolePlugins/BuildLanguage
 !ConsolePlugins/Export
 !ConsolePlugins/GhostExport
 !ConsolePlugins/EventQueueService

--- a/ConsolePlugins/BuildLanguage/Main.php
+++ b/ConsolePlugins/BuildLanguage/Main.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace ConsolePlugins\BuildLanguage;
+
+use Idno\Core\PotGenerator;
+
+class Main extends \Idno\Common\ConsolePlugin
+{
+
+    public function getCommand(): string
+    {
+        return 'build-lang';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Extract translatable strings from PHP files and generate .pot files';
+    }
+
+    public function getParameters(): array
+    {
+        return [
+            new \Symfony\Component\Console\Input\InputArgument(
+                'target',
+                \Symfony\Component\Console\Input\InputArgument::OPTIONAL,
+                'Target: "core", "plugin:Name", "theme:Name", or "all"',
+                'core'
+            ),
+        ];
+    }
+
+    public function execute(
+        \Symfony\Component\Console\Input\InputInterface $input,
+        \Symfony\Component\Console\Output\OutputInterface $output
+    ): void {
+
+        $target = $input->getArgument('target');
+        $basePath = \Idno\Core\Idno::site()->config()->getPath();
+
+        if ($target === 'all') {
+            $this->buildAll($basePath, $output);
+            return;
+        }
+
+        if ($target === 'core') {
+            $this->buildCore($basePath, $output);
+            return;
+        }
+
+        if (str_starts_with($target, 'plugin:')) {
+            $name = substr($target, 7);
+            $this->buildPlugin($basePath, $name, $output);
+            return;
+        }
+
+        if (str_starts_with($target, 'theme:')) {
+            $name = substr($target, 6);
+            $this->buildTheme($basePath, $name, $output);
+            return;
+        }
+
+        $output->writeln("<error>Unknown target: {$target}</error>");
+        $output->writeln('Usage: build-lang [core|all|plugin:Name|theme:Name]');
+    }
+
+    private function buildCore(string $basePath, \Symfony\Component\Console\Output\OutputInterface $output): void
+    {
+        $generator = new PotGenerator();
+
+        $dirs = [
+            $basePath . '/Idno',
+            $basePath . '/templates',
+        ];
+
+        foreach ($dirs as $dir) {
+            if (is_dir($dir)) {
+                $generator->extractFromDirectory($dir, $basePath);
+            }
+        }
+
+        // Also extract from the console entry point
+        $consoleFile = $basePath . '/idno.php';
+        if (file_exists($consoleFile)) {
+            $generator->extractFromFile($consoleFile, $basePath);
+        }
+
+        $outputDir = $basePath . '/languages/source';
+        if (!is_dir($outputDir)) {
+            mkdir($outputDir, 0755, true);
+        }
+
+        $potFile = $outputDir . '/idno.pot';
+        $content = $generator->generatePot('idno');
+        file_put_contents($potFile, $content);
+
+        $count = count($generator->getStrings());
+        $output->writeln("Core: extracted {$count} strings -> languages/source/idno.pot");
+    }
+
+    private function buildPlugin(
+        string $basePath,
+        string $name,
+        \Symfony\Component\Console\Output\OutputInterface $output
+    ): void {
+
+        $pluginDir = $basePath . '/IdnoPlugins/' . $name;
+        if (!is_dir($pluginDir)) {
+            // Try ConsolePlugins
+            $pluginDir = $basePath . '/ConsolePlugins/' . $name;
+            if (!is_dir($pluginDir)) {
+                $output->writeln("<error>Plugin directory not found: {$name}</error>");
+                return;
+            }
+        }
+
+        $domain = strtolower($name);
+        $generator = new PotGenerator();
+        $generator->extractFromDirectory($pluginDir, $pluginDir);
+
+        $outputDir = $pluginDir . '/languages';
+        if (!is_dir($outputDir)) {
+            mkdir($outputDir, 0755, true);
+        }
+
+        $potFile = $outputDir . '/' . $domain . '.pot';
+        $content = $generator->generatePot($domain);
+        file_put_contents($potFile, $content);
+
+        $count = count($generator->getStrings());
+        $relative = str_starts_with($pluginDir, $basePath)
+            ? substr($pluginDir, strlen($basePath) + 1)
+            : $pluginDir;
+        $output->writeln("{$name}: extracted {$count} strings -> {$relative}/languages/{$domain}.pot");
+    }
+
+    private function buildTheme(
+        string $basePath,
+        string $name,
+        \Symfony\Component\Console\Output\OutputInterface $output
+    ): void {
+
+        $themeDir = $basePath . '/Themes/' . $name;
+        if (!is_dir($themeDir)) {
+            $output->writeln("<error>Theme directory not found: {$name}</error>");
+            return;
+        }
+
+        $domain = strtolower($name);
+        $generator = new PotGenerator();
+        $generator->extractFromDirectory($themeDir, $themeDir);
+
+        $outputDir = $themeDir . '/languages';
+        if (!is_dir($outputDir)) {
+            mkdir($outputDir, 0755, true);
+        }
+
+        $potFile = $outputDir . '/' . $domain . '.pot';
+        $content = $generator->generatePot($domain);
+        file_put_contents($potFile, $content);
+
+        $count = count($generator->getStrings());
+        $output->writeln("{$name}: extracted {$count} strings -> Themes/{$name}/languages/{$domain}.pot");
+    }
+
+    private function buildAll(string $basePath, \Symfony\Component\Console\Output\OutputInterface $output): void
+    {
+        $output->writeln('Building all language files...');
+        $output->writeln('');
+
+        // Core
+        $this->buildCore($basePath, $output);
+
+        // IdnoPlugins
+        $pluginDir = $basePath . '/IdnoPlugins';
+        if (is_dir($pluginDir)) {
+            foreach (new \DirectoryIterator($pluginDir) as $item) {
+                if ($item->isDot() || !$item->isDir()) {
+                    continue;
+                }
+                $this->buildPlugin($basePath, $item->getFilename(), $output);
+            }
+        }
+
+        // ConsolePlugins
+        $consoleDir = $basePath . '/ConsolePlugins';
+        if (is_dir($consoleDir)) {
+            foreach (new \DirectoryIterator($consoleDir) as $item) {
+                if ($item->isDot() || !$item->isDir()) {
+                    continue;
+                }
+                $this->buildPlugin($basePath, $item->getFilename(), $output);
+            }
+        }
+
+        // Themes
+        $themeDir = $basePath . '/Themes';
+        if (is_dir($themeDir)) {
+            foreach (new \DirectoryIterator($themeDir) as $item) {
+                if ($item->isDot() || !$item->isDir()) {
+                    continue;
+                }
+                $this->buildTheme($basePath, $item->getFilename(), $output);
+            }
+        }
+
+        $output->writeln('');
+        $output->writeln('Done.');
+    }
+}

--- a/ConsolePlugins/Example/Gruntfile.js
+++ b/ConsolePlugins/Example/Gruntfile.js
@@ -11,14 +11,15 @@ module.exports = function (grunt) {
     
 // Build language pack (todo: find a cleaner way)
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	execSync('touch ./languages/example.pot'); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/example.pot'); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php ../../languages/processfile.php >> ./languages/example.pot'); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -206,15 +206,8 @@ module.exports = function (grunt) {
     const {execSync} = require('child_process');
     /*jshint ignore:end*/
 
-    var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-    
-    console.log("Building language file as ./languages/" + pot);
-    
-    execSync('touch ./languages/source/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-    execSync('rm ./languages/source/' + pot); // Remove existing
-
-    execSync('find ./Idno ./templates -type f -regex ".*\.php" | sort | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/source/' + pot); // Build from idno core
-    execSync('echo ./idno.php | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/source/' + pot); // Build from console
+    console.log("Building language files...");
+    execSync('php idno.php build-lang all', {stdio: 'inherit'});
   });
 
   // Default task(s).

--- a/Idno/Core/PotGenerator.php
+++ b/Idno/Core/PotGenerator.php
@@ -1,0 +1,370 @@
+<?php
+
+namespace Idno\Core;
+
+/**
+ * Extracts translatable strings from PHP source files and generates
+ * gettext .pot (Portable Object Template) files.
+ *
+ * Uses PHP's built-in token_get_all() for reliable parsing, looking
+ * for ->_() and ->esc_() method calls used by the Idno i18n system.
+ *
+ * Replaces the external mapkyca/known-language-tools package.
+ */
+class PotGenerator
+{
+
+    /**
+     * Extracted strings: msgid => array of {file, line} references.
+     * @var array<string, array<array{file: string, line: int}>>
+     */
+    private array $strings = [];
+
+    /**
+     * Method names to extract translations from.
+     * @var string[]
+     */
+    private array $methodNames = ['_', 'esc_'];
+
+    /**
+     * Extract translatable strings from a single PHP file.
+     *
+     * Tokenizes the file and scans for the pattern:
+     *   -> _( 'string' )  or  -> esc_( 'string' )
+     *
+     * @param string $filePath Absolute path to the PHP file
+     * @param string $basePath Base path to compute relative file references
+     */
+    public function extractFromFile(string $filePath, string $basePath = ''): void
+    {
+        $code = @file_get_contents($filePath);
+        if ($code === false || $code === '') {
+            return;
+        }
+
+        $relativePath = $filePath;
+        if (!empty($basePath)) {
+            $basePath = rtrim($basePath, '/') . '/';
+            if (str_starts_with($filePath, $basePath)) {
+                $relativePath = './' . substr($filePath, strlen($basePath));
+            }
+        }
+
+        $this->extractFromSource($code, $relativePath);
+    }
+
+    /**
+     * Extract translatable strings from PHP source code.
+     *
+     * @param string $source PHP source code
+     * @param string $fileReference File path to use in #: references
+     */
+    public function extractFromSource(string $source, string $fileReference = 'unknown'): void
+    {
+        try {
+            $tokens = token_get_all($source);
+        } catch (\ParseError $e) {
+            return;
+        }
+
+        $count = count($tokens);
+        $i = 0;
+
+        while ($i < $count) {
+            $token = $tokens[$i];
+
+            // Look for T_OBJECT_OPERATOR (->)
+            if (is_array($token) && $token[0] === T_OBJECT_OPERATOR) {
+                $nextIdx = $this->skipWhitespace($tokens, $i + 1, $count);
+                if ($nextIdx === null) {
+                    $i++;
+                    continue;
+                }
+
+                $nextToken = $tokens[$nextIdx];
+
+                // Check if it's a method name we're interested in (_ or esc_)
+                if (is_array($nextToken) && $nextToken[0] === T_STRING
+                    && in_array($nextToken[1], $this->methodNames, true)) {
+
+                    $parenIdx = $this->skipWhitespace($tokens, $nextIdx + 1, $count);
+                    if ($parenIdx === null) {
+                        $i++;
+                        continue;
+                    }
+
+                    // Check for opening parenthesis
+                    if (is_string($tokens[$parenIdx]) && $tokens[$parenIdx] === '(') {
+                        $stringIdx = $this->skipWhitespace($tokens, $parenIdx + 1, $count);
+                        if ($stringIdx === null) {
+                            $i++;
+                            continue;
+                        }
+
+                        $stringToken = $tokens[$stringIdx];
+
+                        // Check if the first argument is a constant string
+                        if (is_array($stringToken) && $stringToken[0] === T_CONSTANT_ENCAPSED_STRING) {
+                            $rawString = $stringToken[1];
+                            $line = $stringToken[2];
+                            $decoded = $this->decodePhpString($rawString);
+
+                            if ($decoded !== null) {
+                                $this->addString($decoded, $fileReference, $line);
+                            }
+                        }
+                    }
+                }
+            }
+
+            $i++;
+        }
+    }
+
+    /**
+     * Scan a directory recursively for PHP files and extract strings.
+     *
+     * @param string $directory Directory to scan
+     * @param string $basePath Base path for relative references
+     */
+    public function extractFromDirectory(string $directory, string $basePath = ''): void
+    {
+        if (empty($basePath)) {
+            $basePath = $directory;
+        }
+
+        $directory = rtrim($directory, '/');
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        $files = [];
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        sort($files);
+
+        foreach ($files as $filePath) {
+            $this->extractFromFile($filePath, $basePath);
+        }
+    }
+
+    /**
+     * Extract from specific file paths.
+     *
+     * @param string[] $files Array of file paths
+     * @param string $basePath Base path for relative references
+     */
+    public function extractFromFiles(array $files, string $basePath = ''): void
+    {
+        sort($files);
+        foreach ($files as $filePath) {
+            $this->extractFromFile($filePath, $basePath);
+        }
+    }
+
+    /**
+     * Get all extracted strings.
+     *
+     * @return array<string, array<array{file: string, line: int}>>
+     */
+    public function getStrings(): array
+    {
+        return $this->strings;
+    }
+
+    /**
+     * Reset extracted strings.
+     */
+    public function reset(): void
+    {
+        $this->strings = [];
+    }
+
+    /**
+     * Generate a .pot file content string.
+     *
+     * @param string $domain Translation domain name
+     * @return string Valid gettext .pot file content
+     */
+    public function generatePot(string $domain = ''): string
+    {
+        $output = '';
+
+        // POT header
+        $date = date('Y-m-d H:iO');
+        $output .= "# Translation template for {$domain}.\n";
+        $output .= "#\n";
+        $output .= "#, fuzzy\n";
+        $output .= "msgid \"\"\n";
+        $output .= "msgstr \"\"\n";
+        $output .= "\"Project-Id-Version: {$domain}\\n\"\n";
+        $output .= "\"Report-Msgid-Bugs-To: \\n\"\n";
+        $output .= "\"POT-Creation-Date: {$date}\\n\"\n";
+        $output .= "\"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n\"\n";
+        $output .= "\"Last-Translator: \\n\"\n";
+        $output .= "\"Language-Team: \\n\"\n";
+        $output .= "\"MIME-Version: 1.0\\n\"\n";
+        $output .= "\"Content-Type: text/plain; charset=UTF-8\\n\"\n";
+        $output .= "\"Content-Transfer-Encoding: 8bit\\n\"\n";
+        $output .= "\n";
+
+        // Sort strings by their first reference for deterministic output
+        $sorted = $this->strings;
+        uksort($sorted, function ($a, $b) use ($sorted) {
+            $refA = $sorted[$a][0];
+            $refB = $sorted[$b][0];
+            $cmp = strcmp($refA['file'], $refB['file']);
+            if ($cmp !== 0) {
+                return $cmp;
+            }
+            return $refA['line'] <=> $refB['line'];
+        });
+
+        foreach ($sorted as $msgid => $references) {
+            // Output file references
+            foreach ($references as $ref) {
+                $output .= "#: {$ref['file']}:{$ref['line']}\n";
+            }
+
+            // Output msgid with proper escaping
+            $escaped = $this->escapeForPot($msgid);
+            $output .= "msgid \"{$escaped}\"\n";
+            $output .= "msgstr \"\"\n";
+            $output .= "\n";
+        }
+
+        return $output;
+    }
+
+    /**
+     * Generate a .pot file without the header (legacy-compatible format).
+     *
+     * This produces output compatible with the old buildpot.php script,
+     * which did not include a POT header.
+     *
+     * @return string POT entries without header
+     */
+    public function generatePotWithoutHeader(): string
+    {
+        $output = '';
+
+        // Sort strings by their first reference for deterministic output
+        $sorted = $this->strings;
+        uksort($sorted, function ($a, $b) use ($sorted) {
+            $refA = $sorted[$a][0];
+            $refB = $sorted[$b][0];
+            $cmp = strcmp($refA['file'], $refB['file']);
+            if ($cmp !== 0) {
+                return $cmp;
+            }
+            return $refA['line'] <=> $refB['line'];
+        });
+
+        foreach ($sorted as $msgid => $references) {
+            // Use only the first reference (like the old buildpot.php)
+            $ref = $references[0];
+            $escaped = $this->escapeForPot($msgid);
+
+            $output .= "#: {$ref['file']}:{$ref['line']}\n";
+            $output .= "msgid \"{$escaped}\"\n";
+            $output .= "msgstr \"\"\n";
+            $output .= "\n";
+        }
+
+        return $output;
+    }
+
+    /**
+     * Add a translatable string with its file reference.
+     *
+     * @param string $string The translatable string
+     * @param string $file File path reference
+     * @param int $line Line number
+     */
+    private function addString(string $string, string $file, int $line): void
+    {
+        if (!isset($this->strings[$string])) {
+            $this->strings[$string] = [];
+        }
+
+        $this->strings[$string][] = [
+            'file' => $file,
+            'line' => $line,
+        ];
+    }
+
+    /**
+     * Skip whitespace/comment tokens and return the index of the next meaningful token.
+     *
+     * @param array $tokens Token array
+     * @param int $start Start index
+     * @param int $count Total token count
+     * @return int|null Index of next meaningful token, or null if none found
+     */
+    private function skipWhitespace(array $tokens, int $start, int $count): ?int
+    {
+        for ($i = $start; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (is_array($token)) {
+                if ($token[0] === T_WHITESPACE || $token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT) {
+                    continue;
+                }
+            }
+            return $i;
+        }
+        return null;
+    }
+
+    /**
+     * Decode a PHP string token value (strip quotes, process escape sequences).
+     *
+     * @param string $raw Raw token value including quotes
+     * @return string|null Decoded string value, or null if invalid
+     */
+    private function decodePhpString(string $raw): ?string
+    {
+        if (strlen($raw) < 2) {
+            return null;
+        }
+
+        $quote = $raw[0];
+
+        if ($quote === "'") {
+            // Single-quoted string: only \\ and \' are escape sequences
+            $inner = substr($raw, 1, -1);
+            $result = str_replace("\\'", "'", $inner);
+            $result = str_replace("\\\\", "\\", $result);
+            return $result;
+        }
+
+        if ($quote === '"') {
+            // Double-quoted string: full PHP escape sequence processing
+            $inner = substr($raw, 1, -1);
+            return stripcslashes($inner);
+        }
+
+        return null;
+    }
+
+    /**
+     * Escape a string for inclusion in a .pot file msgid.
+     *
+     * @param string $string The string to escape
+     * @return string Escaped string suitable for .pot file
+     */
+    private function escapeForPot(string $string): string
+    {
+        $string = str_replace('\\', '\\\\', $string);
+        $string = str_replace('"', '\\"', $string);
+        $string = str_replace("\n", '\\n', $string);
+        $string = str_replace("\r", '\\r', $string);
+        $string = str_replace("\t", '\\t', $string);
+        return $string;
+    }
+}

--- a/IdnoPlugins/Bridgy/Gruntfile.js
+++ b/IdnoPlugins/Bridgy/Gruntfile.js
@@ -14,18 +14,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/IdnoPlugins/Bridgy/composer.json
+++ b/IdnoPlugins/Bridgy/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/IdnoPlugins/Checkin/Gruntfile.js
+++ b/IdnoPlugins/Checkin/Gruntfile.js
@@ -60,18 +60,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
     
     // Default task(s).

--- a/IdnoPlugins/Checkin/composer.json
+++ b/IdnoPlugins/Checkin/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/IdnoPlugins/Event/Gruntfile.js
+++ b/IdnoPlugins/Event/Gruntfile.js
@@ -14,18 +14,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/IdnoPlugins/Event/composer.json
+++ b/IdnoPlugins/Event/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/IdnoPlugins/IndiePub/Gruntfile.js
+++ b/IdnoPlugins/IndiePub/Gruntfile.js
@@ -14,18 +14,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/IdnoPlugins/IndiePub/composer.json
+++ b/IdnoPlugins/IndiePub/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/IdnoPlugins/Like/Gruntfile.js
+++ b/IdnoPlugins/Like/Gruntfile.js
@@ -14,18 +14,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/IdnoPlugins/Like/composer.json
+++ b/IdnoPlugins/Like/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/IdnoPlugins/Media/Gruntfile.js
+++ b/IdnoPlugins/Media/Gruntfile.js
@@ -14,18 +14,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/IdnoPlugins/Media/composer.json
+++ b/IdnoPlugins/Media/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/IdnoPlugins/Photo/Gruntfile.js
+++ b/IdnoPlugins/Photo/Gruntfile.js
@@ -14,18 +14,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/IdnoPlugins/Photo/composer.json
+++ b/IdnoPlugins/Photo/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/IdnoPlugins/StaticPages/Gruntfile.js
+++ b/IdnoPlugins/StaticPages/Gruntfile.js
@@ -14,18 +14,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/IdnoPlugins/StaticPages/composer.json
+++ b/IdnoPlugins/StaticPages/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/IdnoPlugins/Status/Gruntfile.js
+++ b/IdnoPlugins/Status/Gruntfile.js
@@ -14,18 +14,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/IdnoPlugins/Status/composer.json
+++ b/IdnoPlugins/Status/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/IdnoPlugins/Styles/Gruntfile.js
+++ b/IdnoPlugins/Styles/Gruntfile.js
@@ -14,18 +14,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/IdnoPlugins/Styles/composer.json
+++ b/IdnoPlugins/Styles/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/IdnoPlugins/Text/Gruntfile.js
+++ b/IdnoPlugins/Text/Gruntfile.js
@@ -14,18 +14,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/IdnoPlugins/Text/composer.json
+++ b/IdnoPlugins/Text/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/IdnoPlugins/Webhooks/Gruntfile.js
+++ b/IdnoPlugins/Webhooks/Gruntfile.js
@@ -14,18 +14,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang plugin:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/IdnoPlugins/Webhooks/composer.json
+++ b/IdnoPlugins/Webhooks/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/Tests/Core/LanguageTest.php
+++ b/Tests/Core/LanguageTest.php
@@ -41,14 +41,114 @@ namespace Tests\Core {
             $french->register(new EnglishTest('en_GB'));
             $french->register(new FrenchTest('fr_FR'));
 
-            echo "English: " . $english->_('Hello!');
-            echo "\nFrench: " . $french->_('Hello!');
-
             $txt = $english->_('Hello!');
             $this->assertNotEmpty($txt, 'A translation for "Hello!" should have been found in the English language.');
             $txt2 = $french->_('Hello!');
             $this->assertNotEmpty($txt2, 'A translation for "Hello!" should have been found in the French language.');
-            $this->assertFalse($french->_('Hello!') == $english->_('Hello!'), 'The English translation should not have been the same as the French translation of "Hello!".');
+            $this->assertNotEquals($french->_('Hello!'), $english->_('Hello!'), 'The English translation should not have been the same as the French translation of "Hello!".');
+        }
+
+        public function testTranslationFallback()
+        {
+            $lang = new \Idno\Core\Language('en_US');
+
+            // With no translations registered, should return the original string
+            $result = $lang->_('Untranslated string');
+            $this->assertEquals('Untranslated string', $result);
+        }
+
+        public function testTranslationFallbackReturnsFalse()
+        {
+            $lang = new \Idno\Core\Language('en_US');
+
+            // With failover=false, should return false for missing translation
+            $result = $lang->getTranslation('Missing string', false);
+            $this->assertFalse($result);
+        }
+
+        public function testSubstitution()
+        {
+            $lang = new \Idno\Core\Language('en_US');
+
+            $result = $lang->_('Hello %s, you have %d messages', ['World', 5]);
+            $this->assertEquals('Hello World, you have 5 messages', $result);
+        }
+
+        public function testHtmlEscaping()
+        {
+            $lang = new \Idno\Core\Language('en_US');
+
+            $result = $lang->esc_('Hello <b>%s</b>', ['<script>alert("xss")</script>']);
+            $this->assertStringNotContainsString('<script>', $result);
+            $this->assertStringContainsString('&lt;script&gt;', $result);
+        }
+
+        public function testGetLanguage()
+        {
+            $lang = new \Idno\Core\Language('fr_FR');
+            $this->assertEquals('fr_FR', $lang->getLanguage());
+        }
+
+        public function testRegisterOnlyAcceptsMatchingLanguage()
+        {
+            $english = new \Idno\Core\Language('en_GB');
+
+            // Register French translation for English language - should be ignored
+            $english->register(new FrenchTest('fr_FR'));
+
+            // Should return fallback since French translation was rejected
+            $result = $english->_('Hello!');
+            $this->assertEquals('Hello!', $result);
+        }
+
+        public function testMagicGet()
+        {
+            $lang = new \Idno\Core\Language('en_GB');
+            $lang->register(new EnglishTest('en_GB'));
+
+            // __get should work like get()
+            $result = $lang->{'Hello!'};
+            $this->assertEquals('Hello!', $result);
+        }
+
+        public function testUncurlQuotes()
+        {
+            $lang = new \Idno\Core\Language('en_US');
+
+            // Test that curly quotes are converted to straight quotes
+            $result = $lang->uncurlQuotes("\xE2\x80\x9CHello\xE2\x80\x9D");
+            $this->assertEquals('"Hello"', $result);
+
+            $result2 = $lang->uncurlQuotes("\xE2\x80\x98it\xE2\x80\x99s\xE2\x80\x99");
+            $this->assertStringContainsString("'", $result2);
+        }
+
+        public function testDetectBrowserLanguage()
+        {
+            // Test with no browser language set
+            unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+            $lang = \Idno\Core\Language::detectBrowserLanguage();
+            $this->assertIsString($lang);
+        }
+
+        public function testDetectBrowserLanguageWithHeader()
+        {
+            $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'fr-FR,fr;q=0.9,en-US;q=0.8';
+            $lang = \Idno\Core\Language::detectBrowserLanguage();
+            $this->assertEquals('fr_FR', $lang);
+
+            // Restore
+            unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+        }
+
+        public function testDetectBrowserLanguageShort()
+        {
+            $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'de-DE,de;q=0.9';
+            $lang = \Idno\Core\Language::detectBrowserLanguage(false);
+            $this->assertEquals('de', $lang);
+
+            // Restore
+            unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
         }
 
     }

--- a/Tests/Core/PotGeneratorTest.php
+++ b/Tests/Core/PotGeneratorTest.php
@@ -1,0 +1,426 @@
+<?php
+
+namespace Tests\Core;
+
+use Idno\Core\PotGenerator;
+use PHPUnit\Framework\TestCase;
+
+class PotGeneratorTest extends TestCase
+{
+
+    private PotGenerator $generator;
+
+    protected function setUp(): void
+    {
+        $this->generator = new PotGenerator();
+    }
+
+    public function testExtractBasicSingleQuotedString()
+    {
+        $code = '<?php $language->_(\'Hello World\'); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('Hello World', $strings);
+        $this->assertEquals('test.php', $strings['Hello World'][0]['file']);
+    }
+
+    public function testExtractBasicDoubleQuotedString()
+    {
+        $code = '<?php $language->_("Hello World"); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('Hello World', $strings);
+    }
+
+    public function testExtractEscapedSingleQuotes()
+    {
+        $code = "<?php \$language->_('Don\\'t worry'); ?>";
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey("Don't worry", $strings);
+    }
+
+    public function testExtractEscapedDoubleQuotes()
+    {
+        $code = '<?php $language->_("She said \\"hello\\""); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('She said "hello"', $strings);
+    }
+
+    public function testExtractWithSubstitutions()
+    {
+        $code = '<?php $language->_(\'Hello %s\', [$name]); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('Hello %s', $strings);
+    }
+
+    public function testExtractEscMethod()
+    {
+        $code = '<?php $language->esc_(\'Escaped string\'); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('Escaped string', $strings);
+    }
+
+    public function testExtractFullCallChain()
+    {
+        $code = '<?php \Idno\Core\Idno::site()->language()->_(\'Full chain string\'); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('Full chain string', $strings);
+    }
+
+    public function testExtractFullCallChainEsc()
+    {
+        $code = '<?php \Idno\Core\Idno::site()->language()->esc_(\'Escaped chain\'); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('Escaped chain', $strings);
+    }
+
+    public function testExtractMultipleStringsInOneFile()
+    {
+        $code = '<?php
+            $language->_(\'First string\');
+            $language->_(\'Second string\');
+            $language->esc_(\'Third string\');
+        ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertCount(3, $strings);
+        $this->assertArrayHasKey('First string', $strings);
+        $this->assertArrayHasKey('Second string', $strings);
+        $this->assertArrayHasKey('Third string', $strings);
+    }
+
+    public function testDeduplicateAcrossFiles()
+    {
+        $code1 = '<?php $language->_(\'Duplicate\'); ?>';
+        $code2 = '<?php $language->_(\'Duplicate\'); ?>';
+
+        $this->generator->extractFromSource($code1, 'file1.php');
+        $this->generator->extractFromSource($code2, 'file2.php');
+
+        $strings = $this->generator->getStrings();
+        $this->assertCount(1, $strings);
+        $this->assertArrayHasKey('Duplicate', $strings);
+        $this->assertCount(2, $strings['Duplicate']);
+        $this->assertEquals('file1.php', $strings['Duplicate'][0]['file']);
+        $this->assertEquals('file2.php', $strings['Duplicate'][1]['file']);
+    }
+
+    public function testDoesNotExtractNonMethodCalls()
+    {
+        // A standalone function _() should not be extracted (only method calls ->_())
+        $code = '<?php _(\'Not a method call\'); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertEmpty($strings);
+    }
+
+    public function testDoesNotExtractVariableArguments()
+    {
+        $code = '<?php $language->_($variable); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertEmpty($strings);
+    }
+
+    public function testDoesNotExtractFromComments()
+    {
+        $code = '<?php
+            // $language->_(\'In a comment\');
+            /* $language->_(\'In a block comment\'); */
+        ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertEmpty($strings);
+    }
+
+    public function testDoesNotExtractWrongMethodName()
+    {
+        $code = '<?php $obj->translate(\'Not extracted\'); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertEmpty($strings);
+    }
+
+    public function testLineNumberIsCorrect()
+    {
+        $code = "<?php\n\n\n\$language->_('Line four');\n";
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('Line four', $strings);
+        $this->assertEquals(4, $strings['Line four'][0]['line']);
+    }
+
+    public function testEmptySourceProducesNoStrings()
+    {
+        $this->generator->extractFromSource('', 'empty.php');
+        $this->assertEmpty($this->generator->getStrings());
+    }
+
+    public function testNonPhpContentProducesNoStrings()
+    {
+        $code = '<html><body>Hello</body></html>';
+        $this->generator->extractFromSource($code, 'test.html');
+        $this->assertEmpty($this->generator->getStrings());
+    }
+
+    public function testReset()
+    {
+        $code = '<?php $language->_(\'string\'); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $this->assertNotEmpty($this->generator->getStrings());
+
+        $this->generator->reset();
+        $this->assertEmpty($this->generator->getStrings());
+    }
+
+    public function testGeneratePotFormat()
+    {
+        $code = '<?php $language->_(\'Test string\'); ?>';
+        $this->generator->extractFromSource($code, './test.php');
+
+        $pot = $this->generator->generatePot('testdomain');
+
+        // Check header
+        $this->assertStringContainsString('Project-Id-Version: testdomain', $pot);
+        $this->assertStringContainsString('Content-Type: text/plain; charset=UTF-8', $pot);
+        $this->assertStringContainsString('MIME-Version: 1.0', $pot);
+
+        // Check entry
+        $this->assertStringContainsString('#: ./test.php:', $pot);
+        $this->assertStringContainsString('msgid "Test string"', $pot);
+        $this->assertStringContainsString('msgstr ""', $pot);
+    }
+
+    public function testGeneratePotEscapesQuotes()
+    {
+        $code = '<?php $language->_("String with \\"quotes\\""); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+
+        $pot = $this->generator->generatePot('test');
+
+        $this->assertStringContainsString('msgid "String with \\"quotes\\""', $pot);
+    }
+
+    public function testGeneratePotEscapesNewlines()
+    {
+        $code = '<?php $language->_("Line one\nLine two"); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+
+        $pot = $this->generator->generatePot('test');
+
+        $this->assertStringContainsString('msgid "Line one\\nLine two"', $pot);
+    }
+
+    public function testGeneratePotWithoutHeader()
+    {
+        $code = '<?php $language->_(\'Simple\'); ?>';
+        $this->generator->extractFromSource($code, './test.php');
+
+        $pot = $this->generator->generatePotWithoutHeader();
+
+        $this->assertStringNotContainsString('Project-Id-Version', $pot);
+        $this->assertStringContainsString('#: ./test.php:', $pot);
+        $this->assertStringContainsString('msgid "Simple"', $pot);
+        $this->assertStringContainsString('msgstr ""', $pot);
+    }
+
+    public function testExtractFromFile()
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'pot_test_');
+        file_put_contents($tmpFile, '<?php $language->_(\'From file\'); ?>');
+
+        $this->generator->extractFromFile($tmpFile, dirname($tmpFile));
+        $strings = $this->generator->getStrings();
+
+        unlink($tmpFile);
+
+        $this->assertArrayHasKey('From file', $strings);
+    }
+
+    public function testExtractFromDirectory()
+    {
+        $tmpDir = sys_get_temp_dir() . '/pot_test_' . uniqid();
+        mkdir($tmpDir);
+        file_put_contents($tmpDir . '/one.php', '<?php $language->_(\'String one\'); ?>');
+        file_put_contents($tmpDir . '/two.php', '<?php $language->_(\'String two\'); ?>');
+        file_put_contents($tmpDir . '/readme.txt', 'Not a PHP file');
+
+        $this->generator->extractFromDirectory($tmpDir);
+        $strings = $this->generator->getStrings();
+
+        unlink($tmpDir . '/one.php');
+        unlink($tmpDir . '/two.php');
+        unlink($tmpDir . '/readme.txt');
+        rmdir($tmpDir);
+
+        $this->assertCount(2, $strings);
+        $this->assertArrayHasKey('String one', $strings);
+        $this->assertArrayHasKey('String two', $strings);
+    }
+
+    public function testExtractFromDirectoryRecursive()
+    {
+        $tmpDir = sys_get_temp_dir() . '/pot_test_' . uniqid();
+        mkdir($tmpDir);
+        mkdir($tmpDir . '/sub');
+        file_put_contents($tmpDir . '/top.php', '<?php $language->_(\'Top level\'); ?>');
+        file_put_contents($tmpDir . '/sub/nested.php', '<?php $language->_(\'Nested\'); ?>');
+
+        $this->generator->extractFromDirectory($tmpDir);
+        $strings = $this->generator->getStrings();
+
+        unlink($tmpDir . '/top.php');
+        unlink($tmpDir . '/sub/nested.php');
+        rmdir($tmpDir . '/sub');
+        rmdir($tmpDir);
+
+        $this->assertCount(2, $strings);
+        $this->assertArrayHasKey('Top level', $strings);
+        $this->assertArrayHasKey('Nested', $strings);
+    }
+
+    public function testRelativePathInFileReferences()
+    {
+        $tmpDir = sys_get_temp_dir() . '/pot_test_' . uniqid();
+        mkdir($tmpDir);
+        file_put_contents($tmpDir . '/test.php', '<?php $language->_(\'Relative\'); ?>');
+
+        $this->generator->extractFromFile($tmpDir . '/test.php', $tmpDir);
+        $strings = $this->generator->getStrings();
+
+        unlink($tmpDir . '/test.php');
+        rmdir($tmpDir);
+
+        $this->assertArrayHasKey('Relative', $strings);
+        $this->assertEquals('./test.php', $strings['Relative'][0]['file']);
+    }
+
+    public function testHandlesRealWorldPattern()
+    {
+        // Actual pattern from the Idno codebase
+        $code = '<?php
+            \Idno\Core\Idno::site()->session()->addErrorMessage(
+                \Idno\Core\Idno::site()->language()->_(
+                    "Something went wrong."
+                )
+            );
+        ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('Something went wrong.', $strings);
+    }
+
+    public function testHandlesSprintfPatternWithMultipleArgs()
+    {
+        $code = '<?php
+            \Idno\Core\Idno::site()->language()->_(
+                "Plugin %s doesn\'t have a version",
+                [get_class($this)]
+            );
+        ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey("Plugin %s doesn't have a version", $strings);
+    }
+
+    public function testHandlesTemplateContext()
+    {
+        // Pattern used in .tpl.php template files
+        $code = '<?php echo \Idno\Core\Idno::site()->language()->_(\'Skip to main content\'); ?>';
+        $this->generator->extractFromSource($code, 'template.tpl.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('Skip to main content', $strings);
+    }
+
+    public function testHandlesAdjacentCalls()
+    {
+        $code = '<?php
+            $a = $language->_(\'First\');
+            $b = $language->_(\'Second\');
+        ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertCount(2, $strings);
+    }
+
+    public function testStringWithBackslashes()
+    {
+        $code = '<?php $language->_(\'Path: C:\\\\Users\\\\test\'); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('Path: C:\\Users\\test', $strings);
+    }
+
+    public function testStringWithHtmlContent()
+    {
+        $code = '<?php $language->_(\'Click <a href="url">here</a>\'); ?>';
+        $this->generator->extractFromSource($code, 'test.php');
+        $strings = $this->generator->getStrings();
+
+        $this->assertArrayHasKey('Click <a href="url">here</a>', $strings);
+    }
+
+    public function testPotOutputIsDeterministic()
+    {
+        $code1 = '<?php $language->_(\'B string\'); ?>';
+        $code2 = '<?php $language->_(\'A string\'); ?>';
+
+        $this->generator->extractFromSource($code1, './b.php');
+        $this->generator->extractFromSource($code2, './a.php');
+
+        $pot1 = $this->generator->generatePot('test');
+
+        $this->generator->reset();
+
+        $this->generator->extractFromSource($code2, './a.php');
+        $this->generator->extractFromSource($code1, './b.php');
+
+        $pot2 = $this->generator->generatePot('test');
+
+        // Both should produce the same output regardless of insertion order
+        $this->assertEquals($pot1, $pot2);
+    }
+
+    public function testExtractFromMissingFile()
+    {
+        // Should not throw an exception
+        $this->generator->extractFromFile('/nonexistent/file.php');
+        $this->assertEmpty($this->generator->getStrings());
+    }
+
+    public function testExtractFromEmptyFile()
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'pot_test_');
+        file_put_contents($tmpFile, '');
+
+        $this->generator->extractFromFile($tmpFile);
+        unlink($tmpFile);
+
+        $this->assertEmpty($this->generator->getStrings());
+    }
+}

--- a/Themes/Black/Gruntfile.js
+++ b/Themes/Black/Gruntfile.js
@@ -66,14 +66,11 @@ module.exports = function (grunt) {
 
         const {execSync} = require('child_process');
 
-        var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
+        var name = grunt.config.get('pkg.name').toLowerCase();
 
-        console.log("Building language file as ./languages/" + pot);
+        console.log("Building language file for " + name);
 
-        execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-        execSync('rm ./languages/' + pot); // Remove existing
-
-        execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot);
+        execSync('php ../../idno.php build-lang theme:' + name, {stdio: 'inherit'});
 
     });
 

--- a/Themes/Black/composer.json
+++ b/Themes/Black/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/Themes/Cherwell/Gruntfile.js
+++ b/Themes/Cherwell/Gruntfile.js
@@ -64,18 +64,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang theme:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/Themes/Cherwell/composer.json
+++ b/Themes/Cherwell/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/Themes/Fauvists/Gruntfile.js
+++ b/Themes/Fauvists/Gruntfile.js
@@ -63,18 +63,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang theme:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/Themes/Fauvists/composer.json
+++ b/Themes/Fauvists/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/Themes/Green/Gruntfile.js
+++ b/Themes/Green/Gruntfile.js
@@ -63,18 +63,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang theme:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/Themes/Green/composer.json
+++ b/Themes/Green/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/Themes/Kandinsky/Gruntfile.js
+++ b/Themes/Kandinsky/Gruntfile.js
@@ -63,18 +63,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang theme:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/Themes/Kandinsky/composer.json
+++ b/Themes/Kandinsky/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/Themes/MarketStreet/Gruntfile.js
+++ b/Themes/MarketStreet/Gruntfile.js
@@ -63,18 +63,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang theme:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/Themes/MarketStreet/composer.json
+++ b/Themes/MarketStreet/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/Themes/Solo/Gruntfile.js
+++ b/Themes/Solo/Gruntfile.js
@@ -63,18 +63,15 @@ module.exports = function (grunt) {
 
     // Build your language file
     grunt.registerTask('build-lang', '', function(){
-	
+
 	const { execSync } = require('child_process');
-	
-	var pot = grunt.config.get('pkg.name').toLowerCase() + '.pot';
-	
-	console.log("Building language file as ./languages/" + pot);
-	
-	execSync('touch ./languages/' + pot); // Make sure it exists, if we're going to remove (for broken builds)
-	execSync('rm ./languages/' + pot); // Remove existing
-	
-	execSync('find . -type f -regex ".*\.php" | php vendor/mapkyca/known-language-tools/buildpot.php >> ./languages/' + pot); 
-	
+
+	var name = grunt.config.get('pkg.name').toLowerCase();
+
+	console.log("Building language file for " + name);
+
+	execSync('php ../../idno.php build-lang theme:' + name, {stdio: 'inherit'});
+
     });
 
 };

--- a/Themes/Solo/composer.json
+++ b/Themes/Solo/composer.json
@@ -7,7 +7,6 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/known-dev-scripts": "^1.0",
         "mapkyca/known-phpcs": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,6 @@
         }
     },
     "require-dev": {
-        "mapkyca/known-language-tools": "^1.0",
         "mapkyca/mapkyca-known-docker": "^1.0",
         "codeception/aspect-mock": "*",
         "squizlabs/php_codesniffer": "3.*",

--- a/docs/developers/languages/index.md
+++ b/docs/developers/languages/index.md
@@ -14,26 +14,34 @@ translations to your code.
 
 ### Creating .POT file
 
-The first step, after you've used ```\Idno\Core\Idno::site()->language()->_()``` to write your strings, is to generate a POT template 
-translation file. 
+The first step, after you've used ```\Idno\Core\Idno::site()->language()->_()``` to write your strings, is to generate a POT template
+translation file.
 
-To do this:
-
-* add the repository ``` mapkyca/known-language-tools ``` as a dev dependency in composer:
+From the Idno project root, run:
 
 ```bash
-composer require mapkyca/known-language-tools --dev
+# Extract strings for core Idno
+php idno.php build-lang core
+
+# Extract strings for a specific plugin
+php idno.php build-lang plugin:Status
+
+# Extract strings for a specific theme
+php idno.php build-lang theme:Cherwell
+
+# Extract strings for everything (core + all plugins + all themes)
+php idno.php build-lang all
 ```
 
-* Copy and rename the Sample.Gruntfile.js to your project's directory (where your Main.php is)
-* Create or modify your ```package.json``` to include your plugin's name (usually the namespace/directory of your Main.php
-* Create a ```languages``` directory
-* Execute ``` grunt build-lang ```
+This will parse all PHP files in the target and extract translatable strings into the appropriate ```.pot``` file.
 
-This will parse all your plugin's PHP files and extract translatable strings.
+The ```build-lang``` command uses PHP's built-in tokenizer to reliably find all ```->_()``` and ```->esc_()``` method calls.
 
 !!! note "Note"
-    If you have added a new translation string to Idno's core code or templates, you should use the Grunt ```build-lang``` task in Idno's project root to update the ```idno.pot``` file.
+    You can also run ```grunt build-lang``` from the project root or from any plugin/theme directory, which will invoke the same command.
+
+!!! note "Note"
+    If you have added a new translation string to Idno's core code or templates, run ```php idno.php build-lang core``` to update the ```idno.pot``` file.
 
 
 ### Creating your translation


### PR DESCRIPTION
## Here's what I fixed or added:

- **Added `PotGenerator` class** (`Idno/Core/PotGenerator.php`): A new built-in PHP class that extracts translatable strings from PHP source files and generates gettext `.pot` (Portable Object Template) files. Uses PHP's native `token_get_all()` for reliable parsing of `->_()` and `->esc_()` method calls.

- **Added `BuildLanguage` console plugin** (`ConsolePlugins/BuildLanguage/Main.php`): A new command-line tool that replaces the external `mapkyca/known-language-tools` dependency. Supports extracting strings from:
  - Core Idno (`php idno.php build-lang core`)
  - Individual plugins (`php idno.php build-lang plugin:Name`)
  - Individual themes (`php idno.php build-lang theme:Name`)
  - Everything at once (`php idno.php build-lang all`)

- **Added comprehensive test suite** (`Tests/Core/PotGeneratorTest.php`): 426 lines of unit tests covering string extraction, deduplication, POT file generation, file/directory scanning, and edge cases.

- **Enhanced `LanguageTest.php`**: Added additional test cases for translation fallback, substitution, HTML escaping, and language registration.

- **Updated documentation** (`docs/developers/languages/index.md`): Replaced external tool instructions with new built-in command usage.

- **Removed external dependency**: Removed `mapkyca/known-language-tools` from all `composer.json` files (core and all plugins/themes).

- **Updated Gruntfile.js files**: Simplified language build tasks across all plugins and themes to use the new console command.

- **Updated `.gitignore`**: Added `!ConsolePlugins/BuildLanguage` to track the new plugin.

## Here's why I did it:

The project previously relied on an external Composer package (`mapkyca/known-language-tools`) for extracting translatable strings and generating POT files. This created an unnecessary external dependency and made the build process less transparent.

By implementing `PotGenerator` as a core class and wrapping it in a console plugin, we:
- Eliminate the external dependency
- Provide full control over the extraction logic
- Make the tool available as a standard console command
- Improve maintainability and reduce friction in the development workflow
- Enable easier customization and future enhancements

## Checklist:

- [x] This pull request addresses a single issue
- [x] I've adhered to Idno's style guide
- [x] My code contains descriptive comments
- [x] I've added tests where applicable (426 lines of comprehensive unit tests)
- [x] Unit tests pass successfully

https://claude.ai/code/session_01CFz987PERjzcvTtY35FHgV