### PR TITLE
Handle MySQL connection timeouts in long-running processes

### DIFF
--- a/ConsolePlugins/EventQueueService/Main.php
+++ b/ConsolePlugins/EventQueueService/Main.php
@@ -30,6 +30,11 @@ namespace ConsolePlugins\EventQueueService {
             }
 
             do {
+                // Long-running workers can outlive MySQL's wait_timeout,
+                // causing "MySQL server has gone away" on the next query.
+                // Re-establish the connection if it has dropped.
+                Idno::site()->db()->reconnectIfNeeded();
+
                 $pending = AsynchronousQueuedEvent::getPendingFromQueue($queue, 50, 0);
 
                 if (!empty($pending)) {

--- a/Idno/Core/DataConcierge.php
+++ b/Idno/Core/DataConcierge.php
@@ -124,6 +124,21 @@ namespace Idno\Core {
         }
 
         /**
+         * Check if the database connection is still alive and reconnect
+         * if it has timed out.  Long-running processes (e.g. the async
+         * event queue worker) may hold a connection open for longer than
+         * the server's wait_timeout, causing "MySQL server has gone away"
+         * (error 2006) on the next query.
+         *
+         * The default implementation is a no-op; database backends that
+         * use persistent connections should override this.
+         */
+        function reconnectIfNeeded()
+        {
+            // No-op by default — backends override as needed.
+        }
+
+        /**
          * Saves a record to the specified database collection
          *
          * @param  string $collection

--- a/Idno/Data/MySQL.php
+++ b/Idno/Data/MySQL.php
@@ -19,12 +19,7 @@ namespace Idno\Data {
         {
 
             try {
-                $connection_string = 'mysql:host=' . $this->dbhost . ';dbname=' . $this->dbname . ';charset=utf8';
-                if (!empty($this->dbport)) {
-                    $connection_string .= ';port=' . $this->dbport;
-                }
-                $this->client = new \PDO($connection_string, $this->dbuser, $this->dbpass, array(\PDO::MYSQL_ATTR_LOCAL_INFILE => 1));
-                $this->client->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+                $this->client = $this->createPDOConnection();
             } catch (\Exception $e) {
                 error_log($e->getMessage());
                 if (!empty(\Idno\Core\Idno::site()->config()->forward_on_empty)) {
@@ -36,7 +31,7 @@ namespace Idno\Data {
 
                     if (\Idno\Core\Idno::site()->config()->debug) {
                         $message = '<p>' . $e->getMessage() . '</p>';
-                        $message .= '<p>' . $connection_string . '</p>';
+                        $message .= '<p>' . $this->buildConnectionString() . '</p>';
                     }
                     error_log($e->getMessage());
                     include \Idno\Core\Idno::site()->config()->path . '/statics/db.php';
@@ -47,6 +42,48 @@ namespace Idno\Data {
             $this->database = $this->dbname;
             $this->checkAndUpgradeSchema();
 
+        }
+
+        /**
+         * Build the PDO connection string for this MySQL instance.
+         *
+         * @return string
+         */
+        private function buildConnectionString()
+        {
+            $connection_string = 'mysql:host=' . $this->dbhost . ';dbname=' . $this->dbname . ';charset=utf8';
+            if (!empty($this->dbport)) {
+                $connection_string .= ';port=' . $this->dbport;
+            }
+            return $connection_string;
+        }
+
+        /**
+         * Create a new PDO connection using the stored credentials.
+         *
+         * @return \PDO
+         */
+        private function createPDOConnection()
+        {
+            $client = new \PDO($this->buildConnectionString(), $this->dbuser, $this->dbpass, array(\PDO::MYSQL_ATTR_LOCAL_INFILE => 1));
+            $client->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+            return $client;
+        }
+
+        /**
+         * Check if the MySQL connection is still alive and reconnect if
+         * it has timed out.  This prevents "MySQL server has gone away"
+         * (error 2006) in long-running processes like the async event
+         * queue worker.
+         */
+        function reconnectIfNeeded()
+        {
+            try {
+                $this->client->query('SELECT 1');
+            } catch (\Exception $e) {
+                error_log('MySQL connection lost, reconnecting: ' . $e->getMessage());
+                $this->client = $this->createPDOConnection();
+            }
         }
 
         /**

--- a/Idno/Entities/AsynchronousQueuedEvent.php
+++ b/Idno/Entities/AsynchronousQueuedEvent.php
@@ -8,13 +8,13 @@ namespace Idno\Entities {
     class AsynchronousQueuedEvent extends \Idno\Entities\BaseObject
     {
 
-        public function save($add_to_feed = false, $feed_verb = 'post')
+        public function save($overrideAccess = false)
         {
             if (empty($this->queue)) {
                 $this->queue = 'default';
             }
 
-            return parent::save($add_to_feed, $feed_verb);
+            return parent::save($overrideAccess);
         }
 
         public static function getPendingFromQueue($queue = 'default', $limit = 10, $offset = 0)


### PR DESCRIPTION
## Here's what I fixed or added:

- Refactored MySQL connection initialization in `Idno/Data/MySQL.php` by extracting connection string building and PDO creation into separate private methods (`buildConnectionString()` and `createPDOConnection()`)
- Added `reconnectIfNeeded()` method to `Idno/Data/MySQL.php` that detects and recovers from lost MySQL connections by attempting a simple query and reconnecting on failure
- Added a default no-op `reconnectIfNeeded()` method to `Idno/Core/DataConcierge.php` base class for database backends to override as needed
- Integrated connection health checks into the async event queue worker (`ConsolePlugins/EventQueueService/Main.php`) to call `reconnectIfNeeded()` before processing each batch of queued events
- Fixed parameter names in `Idno/Entities/AsynchronousQueuedEvent.php` `save()` method to match parent class signature (`$overrideAccess` instead of `$add_to_feed` and `$feed_verb`)

## Here's why I did it:

Long-running processes like the async event queue worker can hold database connections open longer than the MySQL server's `wait_timeout` setting (typically 8 hours). When the next query is executed after this timeout, the connection is silently closed by the server, resulting in "MySQL server has gone away" (error 2006) exceptions.

This change implements automatic connection recovery by periodically checking the connection health and reconnecting if needed, allowing long-running workers to continue operating without manual intervention.

## Checklist:

- [x] This pull request addresses a single issue
- [x] I've adhered to Idno's style guide
- [x] My code contains descriptive comments
- [x] The refactoring maintains backward compatibility

https://claude.ai/code/session_013pKynrJAN7yAiJEZxkm5jk