### PR TITLE
Fixing the "reply to" link and underlying webmentions

### DIFF
--- a/Themes/Twenty26/templates/modern/entity/annotations/replies.tpl.php
+++ b/Themes/Twenty26/templates/modern/entity/annotations/replies.tpl.php
@@ -7,13 +7,14 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
     );
     foreach ($vars['annotations'] as $locallink => $annotation) {
         $permalink = $annotation['permalink'] ? $annotation['permalink'] : $locallink;
-        // Extract annotation hash for anchor ID from the local link
-        $annotationHash = basename(parse_url($locallink, PHP_URL_PATH));
-        // For direct comments (permalink is a local annotation URL), use an anchor link
+        // Anchor ID for this annotation, derived from the local link hash
+        $anchorId = 'annotation-' . basename(parse_url($locallink, PHP_URL_PATH));
+        // For direct comments (permalink is a local annotation URL), link to the anchor;
+        // for webmentions, link to the source post
         $isLocalAnnotation = preg_match('#/annotations/[a-f0-9]+$#', $permalink);
-        $dateHref = $isLocalAnnotation ? '#annotation-' . $annotationHash : $permalink;
+        $dateHref = $isLocalAnnotation ? '#' . $anchorId : $permalink;
 ?>
-    <div class="idno-annotation h-cite" id="annotation-<?= htmlspecialchars($annotationHash) ?>">
+    <div class="idno-annotation h-cite" id="<?= htmlspecialchars($anchorId) ?>">
         <?php if (!empty($annotation['owner_image'])) { ?>
         <a href="<?= htmlspecialchars($annotation['owner_url']) ?>" class="u-url">
             <img class="idno-annotation-avatar u-photo"

--- a/Themes/Twenty26/templates/modern/entity/annotations/replies.tpl.php
+++ b/Themes/Twenty26/templates/modern/entity/annotations/replies.tpl.php
@@ -40,7 +40,7 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
                 <?= $this->autop($this->parseURLs(strip_tags($annotation['content']), 'rel="nofollow"')) ?>
             </div>
             <?php } ?>
-            <?php if (!empty($permalink)) { ?>
+            <?php if (!empty($permalink) && !$isLocalAnnotation) { ?>
             <div class="idno-annotation-source">
                 via <a href="<?= htmlspecialchars($permalink) ?>" class="u-url" rel="nofollow">
                     <?= parse_url($permalink, PHP_URL_HOST) ?>

--- a/Themes/Twenty26/templates/modern/entity/annotations/replies.tpl.php
+++ b/Themes/Twenty26/templates/modern/entity/annotations/replies.tpl.php
@@ -7,8 +7,13 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
     );
     foreach ($vars['annotations'] as $locallink => $annotation) {
         $permalink = $annotation['permalink'] ? $annotation['permalink'] : $locallink;
+        // Extract annotation hash for anchor ID from the local link
+        $annotationHash = basename(parse_url($locallink, PHP_URL_PATH));
+        // For direct comments (permalink is a local annotation URL), use an anchor link
+        $isLocalAnnotation = preg_match('#/annotations/[a-f0-9]+$#', $permalink);
+        $dateHref = $isLocalAnnotation ? '#annotation-' . $annotationHash : $permalink;
 ?>
-    <div class="idno-annotation h-cite">
+    <div class="idno-annotation h-cite" id="annotation-<?= htmlspecialchars($annotationHash) ?>">
         <?php if (!empty($annotation['owner_image'])) { ?>
         <a href="<?= htmlspecialchars($annotation['owner_url']) ?>" class="u-url">
             <img class="idno-annotation-avatar u-photo"
@@ -22,7 +27,7 @@ if (!empty($vars['annotations']) && is_array($vars['annotations'])) {
                     <?= htmlspecialchars($annotation['owner_name']) ?>
                 </a>
                 <span class="idno-entry-meta">
-                    <a href="<?= htmlspecialchars($permalink) ?>" rel="nofollow" class="u-url">
+                    <a href="<?= htmlspecialchars($dateHref) ?>" rel="nofollow" class="u-url">
                         <time class="dt-published" datetime="<?= date(DATE_ATOM, $annotation['time']) ?>">
                             <?= date('M j, Y', $annotation['time']) ?>
                         </time>

--- a/Themes/Twenty26/templates/modern/entity/shell.tpl.php
+++ b/Themes/Twenty26/templates/modern/entity/shell.tpl.php
@@ -38,9 +38,18 @@ if ($object) {
                             if ($replies > 0) {
                                 echo (sizeof($inreplyto) > 2 && $replies < sizeof($inreplyto) - 1) ? ', ' : ' and ';
                             }
+                            $linkText = parse_url($inreplytolink, PHP_URL_HOST);
+                            if (\Idno\Common\Entity::isLocalUUID($inreplytolink)) {
+                                if ($replyTarget = \Idno\Common\Entity::getByURL($inreplytolink)) {
+                                    $targetTitle = $replyTarget->getTitle();
+                                    if (!empty($targetTitle)) {
+                                        $linkText = $targetTitle;
+                                    }
+                                }
+                            }
                             ?>
-                            <a href="<?= $inreplytolink ?>" rel="in-reply-to" class="u-in-reply-to">
-                                <?= parse_url($inreplytolink, PHP_URL_HOST) ?>
+                            <a href="<?= htmlspecialchars($inreplytolink) ?>" rel="in-reply-to" class="u-in-reply-to">
+                                <?= htmlspecialchars($linkText) ?>
                             </a>
                             <?php
                             $replies++;


### PR DESCRIPTION
## Here's what I fixed or added:

External / webmention responses now have a well-styled "via" line, and the "reply to" line on updates that are in response to something else are well-styled and click well. And webmentions work again!

## Here's why I did it:

It looked ugly, and webmentions didn't work.

## Checklist: (`[x]` to check/tick the boxes)

- [ ] This pull request addresses a single issue
- [ ] If this code includes interface changes, I've included screenshots in this Pull Request thread
- [x] I've adhered to [Idno's style guide](https://docs.idno.co/en/latest/developers/standards/) ([these codesniffer rules](https://docs.idno.co/en/latest/developers/testing/#code-style-testing) might help!)
- [x] My git branch is named in a descriptive way - i.e., yourname-summary-of-issue
- [x] I've tested my code in-browser
- [x] My code contains descriptive comments
- [x] I've added tests where applicable, and...
- [x] I can run the [unit tests](https://docs.idno.co/en/latest/developers/testing/#unit-testing) successfully.
